### PR TITLE
docs+ci: release runbook + version-sync gate/automatism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: CI only reads the repo (build + test).
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Version sync check
+        run: npm run check:versions
+
       - name: Audit dependencies
         run: npm audit --audit-level=high
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -57,6 +57,7 @@ Both publish targets have a dry-run that touches nothing remote. Run them on
 the release branch before tagging:
 
 ```sh
+npm run check:versions       # package.json <-> server.json versions agree
 npm publish --dry-run        # lists the tarball contents; no upload
 mcp-publisher validate       # validates server.json against the live schema
 ```
@@ -72,27 +73,26 @@ milestone — it's the source of the `Closes #N` list in the release PR.
 
 1. **Branch off `dev`:** `git checkout -b release/vX.Y.Z origin/dev`
 
-2. **Bump the version — three files must agree.** The MCP registry rejects a
-   publish where `server.json` and the npm package disagree, and the npm
-   version is immutable once published, so get this right before tagging:
-   - `package.json` `version` (and `package-lock.json`) — bump together with:
-     ```sh
-     npm version <patch|minor|major> --no-git-tag-version
-     ```
-     `--no-git-tag-version` is deliberate: it edits `package.json` +
-     `package-lock.json` only. The git tag is created later, on `main`
-     (step 7) — not here on the release branch.
-   - `server.json` — **two** spots: the root `version` and
-     `packages[0].version`. Both must equal the new `package.json` version.
-     (`packages[0].identifier` stays `debmatic-mcp`; the `$schema` date is a
-     schema version, not the release version — leave it.)
-
-   Verify they line up:
+2. **Bump the version — one command, three files.** The version lives in
+   `package.json`, `server.json` root `version`, and `server.json`
+   `packages[0].version`; the MCP registry rejects a publish where they
+   disagree and the npm version is immutable once published. A single command
+   keeps all three in sync:
    ```sh
-   node -e "const s=require('./server.json'),p=require('./package.json');
-   console.log(p.version, s.version, s.packages[0].version,
-   '->', p.version===s.version && p.version===s.packages[0].version)"
+   npm version <patch|minor|major> --no-git-tag-version
    ```
+   `npm version` runs the `version` lifecycle hook (`scripts/sync-server-version.mjs`),
+   which copies the new version into both `server.json` spots and stages it —
+   so you never hand-edit `server.json`. `--no-git-tag-version` is deliberate:
+   it edits `package.json` + `package-lock.json` (+ syncs `server.json`) but
+   creates **no** commit/tag here; the tag is made later on `main` (step 7).
+
+   Confirm they agree (the same check CI runs):
+   ```sh
+   npm run check:versions     # exits non-zero on any drift
+   ```
+   This gate also runs in CI on every push and in `prepublishOnly`, so a
+   drifted manifest can't merge or publish even if the bump is done by hand.
    The README install snippets use unversioned `npx debmatic-mcp` /
    `claude mcp add` — there are **no pinned version strings to bump there**.
    Keep it that way; don't add versioned `npx debmatic-mcp@X.Y.Z` snippets to

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,222 @@
+# Release runbook
+
+How to publish a `vX.Y.Z` of `debmatic-mcp`. The release is **manual** —
+there is no release workflow (CI only builds and tests). The publish
+targets are **npm** (`npx debmatic-mcp`, the primary install path) and the
+**official MCP registry** (`registry.modelcontextprotocol.io`). The Docker
+image is build-your-own (`docker-compose` builds from source); nothing is
+pushed to a container registry, so there is no image-publish step.
+
+The goal: a release is a tag plus two `publish` commands, with version
+numbers that agree everywhere before any of it happens.
+
+## Branching context
+
+This repo runs the `main ⇄ dev` model (see the project brief). `dev` is the
+default/integration branch; `main` is protected and holds released code;
+each release is a tag `vX.Y.Z` on `main`. Branch off `dev`, never `main`.
+This runbook expands the release half of that model.
+
+## One-time prerequisites
+
+Per-account setup, **not** per-release. Done once when the publishing chain
+is first wired up.
+
+### npm — publish auth
+
+`debmatic-mcp` is published to npm under the unscoped name `debmatic-mcp`
+(`package.json` `name`). Publishing needs an authenticated npm session with
+publish rights on that package.
+
+1. `npm login` (or set `NPM_TOKEN` / `~/.npmrc` with an automation token).
+   Confirm with `npm whoami`.
+2. If the npm account has 2FA set to **auth-and-publish**, `npm publish`
+   prompts for a one-time code — pass it with `--otp=<code>` in
+   non-interactive shells. 2FA set to **auth-only** doesn't prompt on
+   publish.
+
+Symptom if missed: `npm publish` ends `ENEEDAUTH` (not logged in) or
+`EOTP` (OTP required). Neither mutates anything — fix auth and re-run.
+
+### MCP registry — publisher auth
+
+The registry listing is published from `server.json` with the
+`mcp-publisher` CLI. The server namespace is `io.github.claymore666/*`, which
+is authorized via GitHub login (OIDC) — the GitHub account must own the
+`claymore666` namespace.
+
+1. `mcp-publisher login github` (interactive; opens a device-code flow).
+2. Authorization persists locally; re-login only when the token expires.
+
+The `io.github.<user>/*` namespace maps to the GitHub user, so no DNS TXT
+record is needed (that path is only for custom-domain namespaces).
+
+### Pre-flight validation (do this every release, costs nothing)
+
+Both publish targets have a dry-run that touches nothing remote. Run them on
+the release branch before tagging:
+
+```sh
+npm publish --dry-run        # lists the tarball contents; no upload
+mcp-publisher validate       # validates server.json against the live schema
+```
+
+`npm publish --dry-run` is the cheap check that `files` in `package.json`
+ships what you expect (`dist`, `README.md`, `LICENSE`) and nothing secret.
+`mcp-publisher validate` must print `✅ server.json is valid`.
+
+## Per-release procedure
+
+Pre-flight: every issue/PR going into the release should be on the `vX.Y.Z`
+milestone — it's the source of the `Closes #N` list in the release PR.
+
+1. **Branch off `dev`:** `git checkout -b release/vX.Y.Z origin/dev`
+
+2. **Bump the version — three files must agree.** The MCP registry rejects a
+   publish where `server.json` and the npm package disagree, and the npm
+   version is immutable once published, so get this right before tagging:
+   - `package.json` `version` (and `package-lock.json`) — bump together with:
+     ```sh
+     npm version <patch|minor|major> --no-git-tag-version
+     ```
+     `--no-git-tag-version` is deliberate: it edits `package.json` +
+     `package-lock.json` only. The git tag is created later, on `main`
+     (step 7) — not here on the release branch.
+   - `server.json` — **two** spots: the root `version` and
+     `packages[0].version`. Both must equal the new `package.json` version.
+     (`packages[0].identifier` stays `debmatic-mcp`; the `$schema` date is a
+     schema version, not the release version — leave it.)
+
+   Verify they line up:
+   ```sh
+   node -e "const s=require('./server.json'),p=require('./package.json');
+   console.log(p.version, s.version, s.packages[0].version,
+   '->', p.version===s.version && p.version===s.packages[0].version)"
+   ```
+   The README install snippets use unversioned `npx debmatic-mcp` /
+   `claude mcp add` — there are **no pinned version strings to bump there**.
+   Keep it that way; don't add versioned `npx debmatic-mcp@X.Y.Z` snippets to
+   the README, or this list grows.
+
+3. **Documentation review — against the milestone, not from memory.** List
+   every PR on the `vX.Y.Z` milestone and reconcile each user-visible change
+   against the docs:
+   ```sh
+   gh pr list --state merged --limit 200 \
+     --json number,title,milestone \
+     --jq '.[] | select(.milestone.title=="vX.Y.Z") | "#\(.number) \(.title)"'
+   ```
+   For **each** merged PR: a new or changed tool lands in the README tool
+   list and in the `help` tool's `CONCEPTUAL_GUIDE` / `TOOL_HELP`
+   (`src/tools/meta.ts`) — these are user-facing surfaces that drift
+   silently. New env vars land in the README config table, `docker-compose.yml`
+   comments, and `server.json` `environmentVariables`. A milestone PR that
+   changed behaviour but carries no doc/help delta is the signal to look
+   harder, not to wave through. Then still read the README top-to-bottom for
+   anything the per-PR pass missed.
+
+4. **Write the release notes.** This repo has no `RELEASE_NOTES.md` /
+   `CHANGELOG.md`; the notes live in the **GitHub Release body** (step 8).
+   Draft them now while the change set is fresh — summarise in user-visible
+   terms and call out any compatibility notes (new required env var, changed
+   tool contract, dropped behaviour). If you'd rather have an in-repo
+   changelog, that's a separate decision — introduce it before, not during, a
+   release.
+
+5. **PR `release/vX.Y.Z` → `dev`.** Required check: `CI` (build + test +
+   `npm audit --audit-level=high`). Merge when green.
+
+6. **Open the release PR `dev` → `main`** titled `Release vX.Y.Z`, with a
+   `Closes #N` line for **every issue** in the milestone — that list is what
+   auto-closes them and lets the milestone close. `main` is protected, so
+   this PR is the only way in; merge it when CI is green.
+
+7. **Tag `vX.Y.Z` on `main`:**
+   ```sh
+   git checkout main && git pull --ff-only
+   git tag -s vX.Y.Z -m "vX.Y.Z — <one-liner>"   # -s = signed; shows Verified
+   git push origin vX.Y.Z
+   ```
+   `-s` signs the tag (shows **Verified** on GitHub) if a signing key is
+   configured; plain `git tag vX.Y.Z` is acceptable if not. Confirm with
+   `git tag -v vX.Y.Z` when signed.
+
+8. **Publish — npm, then the MCP registry, then the GitHub Release.** All
+   from the tagged `main` checkout, so the artifacts match the tag:
+   ```sh
+   npm publish                       # add --otp=<code> if 2FA prompts
+   mcp-publisher publish             # reads server.json
+   gh release create vX.Y.Z --title "vX.Y.Z" --notes "<step 4 notes>"
+   ```
+   `prepublishOnly` re-runs `npm run lint && npm test` before the upload, so a
+   broken build can't ship. Order matters only in that npm must succeed first
+   — the registry entry points consumers at the npm package.
+
+9. **Fast-forward `dev` to `main`** so the version bump and any release-branch
+   edits land on `dev` too:
+   ```sh
+   git checkout dev && git merge --ff-only main && git push origin dev
+   ```
+   Skipping this leaves the next feature branch starting from the previous
+   version's `package.json`/`server.json`, and the next release PR has to
+   re-bump them.
+
+10. **Prune merged branches.** If *Automatically delete head branches* is on,
+    PR heads go on merge. The `release/vX.Y.Z` branch was never a PR head into
+    `main` directly, so remove it and sweep for stragglers:
+    ```sh
+    git push origin --delete release/vX.Y.Z
+    git fetch --prune origin
+    git branch -r --merged origin/dev | grep -vE 'origin/(dev|main|HEAD)$'
+    ```
+    Delete what the sweep lists; leave open-PR and Dependabot branches alone.
+
+## Verifying
+
+After publishing:
+
+- `npm view debmatic-mcp version` returns `vX.Y.Z` (allow a minute for the
+  registry to update). `npx -y debmatic-mcp@X.Y.Z --help` from a clean
+  machine pulls and runs it.
+- The MCP registry shows the new version:
+  `curl -s 'https://registry.modelcontextprotocol.io/v0/servers?search=io.github.claymore666/debmatic-mcp' | jq '.servers[].version'`.
+- `gh release view vX.Y.Z` shows the notes body.
+- The milestone is closed:
+  `gh issue list --milestone vX.Y.Z --state open` — should be empty.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| `npm publish` ends `EOTP` | npm 2FA set to auth-and-publish | re-run with `--otp=<code>` |
+| `npm publish` ends `ENEEDAUTH` | not logged in / token expired | `npm login`, confirm `npm whoami`, re-run |
+| `npm publish` ends `403 cannot publish over previously published version` | version already on npm (npm is immutable) | bump to the next patch; never re-use a version |
+| `mcp-publisher publish` rejects the version | `server.json` version ≠ npm package version, or `mcpName` missing in `package.json` | align all three version spots (step 2); ensure `package.json` `mcpName` matches `server.json` `name` |
+| `mcp-publisher` 401 / auth error | publisher login expired | `mcp-publisher login github` again |
+| GitHub Release exists but npm/registry don't | published the release before the `publish` commands | run `npm publish` + `mcp-publisher publish` from the tagged checkout |
+
+## Backports between `dev` and `main`
+
+When a release-blocking hotfix must land on `main` without going through
+`dev`:
+
+1. Branch off `main`, fix, PR to `main`, merge. Don't push to `main`
+   directly — branch protection and the audit trail.
+2. Cherry-pick the same commit onto a branch off `dev`, PR to `dev`, so `dev`
+   doesn't regress on the next release PR.
+
+## Not applicable (deliberately omitted)
+
+These are in the docker-net-dhcp runbook but don't apply here, noted so their
+absence reads as a decision, not an oversight:
+
+- **Container registry publish (GHCR / Docker Hub), image signing (cosign),
+  SBOM, provenance** — no image is published; the Dockerfile is built locally
+  by `docker-compose`. If a published image is ever added, the GHCR-linking
+  and signing prerequisites from that runbook become relevant.
+- **Versioned docs site (mkdocs / GitHub Pages)** — docs are the README plus
+  this `docs/` folder; there's no published site to reconcile.
+- **rc dry-run via the release workflow / coverage ratchet** — there's no
+  release workflow to dry-run and no coverage gate. The pre-flight
+  `npm publish --dry-run` + `mcp-publisher validate` (above) are the
+  equivalent cheap checks.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit && tsc -p tsconfig.test.json",
-    "prepublishOnly": "npm run lint && npm test"
+    "check:versions": "node scripts/check-version-sync.mjs",
+    "version": "node scripts/sync-server-version.mjs && git add server.json",
+    "prepublishOnly": "npm run check:versions && npm run lint && npm test"
   },
   "engines": {
     "node": ">=22"

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -14,7 +14,7 @@
 //
 // Test seam: PKG_FILE / SERVER_FILE env vars point the check at synthetic
 // fixtures, so scripts gate logic is exercisable offline
-// (see test/check-version-sync.test.ts).
+// (see test/unit/version-sync.test.ts).
 import { readFileSync } from "node:fs";
 
 const PKG = process.env.PKG_FILE ?? "package.json";

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Failsafe gate: assert the release version is consistent across the three
+// places it lives, plus that the package identity matches. Exits non-zero
+// (with a remediation hint) on any drift, so CI and `prepublishOnly` block a
+// release whose npm package and MCP registry manifest disagree.
+//
+// Checks:
+//   1. package.json  version            == server.json  version
+//   2. package.json  version            == server.json  packages[].version
+//   3. package.json  mcpName            == server.json  name
+//
+// Usage:
+//   node scripts/check-version-sync.mjs      # exit 0 in sync, 1 on drift
+//
+// Test seam: PKG_FILE / SERVER_FILE env vars point the check at synthetic
+// fixtures, so scripts gate logic is exercisable offline
+// (see test/check-version-sync.test.ts).
+import { readFileSync } from "node:fs";
+
+const PKG = process.env.PKG_FILE ?? "package.json";
+const SERVER = process.env.SERVER_FILE ?? "server.json";
+
+const pkg = JSON.parse(readFileSync(PKG, "utf8"));
+const server = JSON.parse(readFileSync(SERVER, "utf8"));
+
+const problems = [];
+const rows = [];
+
+const pkgVersion = pkg.version;
+rows.push([`${PKG} version`, pkgVersion]);
+
+if (server.version !== pkgVersion) {
+  problems.push(`${SERVER} version "${server.version}" != ${PKG} version "${pkgVersion}"`);
+}
+rows.push([`${SERVER} version`, server.version]);
+
+const packages = Array.isArray(server.packages) ? server.packages : [];
+packages.forEach((p, i) => {
+  if (p.version !== pkgVersion) {
+    problems.push(`${SERVER} packages[${i}].version "${p.version}" != ${PKG} version "${pkgVersion}"`);
+  }
+  rows.push([`${SERVER} packages[${i}].version`, p.version]);
+});
+
+if (pkg.mcpName !== server.name) {
+  problems.push(`${PKG} mcpName "${pkg.mcpName}" != ${SERVER} name "${server.name}"`);
+}
+rows.push([`${PKG} mcpName`, pkg.mcpName]);
+rows.push([`${SERVER} name`, server.name]);
+
+const width = Math.max(...rows.map(([label]) => label.length));
+for (const [label, value] of rows) {
+  console.log(`  ${label.padEnd(width)}  ${value}`);
+}
+console.log();
+
+if (problems.length > 0) {
+  console.error("Version/identity drift:");
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error();
+  console.error("Fix: bump with `npm version <patch|minor|major>` (auto-syncs");
+  console.error("server.json), or run `node scripts/sync-server-version.mjs`.");
+  process.exit(1);
+}
+
+console.log("Versions in sync.");

--- a/scripts/sync-server-version.mjs
+++ b/scripts/sync-server-version.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Automatism: copy package.json's version into server.json's two version
+// fields (root `version` and `packages[0].version`), so the MCP registry
+// manifest always matches the npm package.
+//
+// Runs automatically from the `version` npm lifecycle hook (see
+// package.json "scripts.version"), so `npm version <patch|minor|major>`
+// bumps all three spots in one command. Also runnable by hand:
+//   node scripts/sync-server-version.mjs
+//
+// Idempotent: a no-op (and prints so) when already in sync. Preserves the
+// file's 2-space indentation and trailing newline.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const PKG = process.env.PKG_FILE ?? "package.json";
+const SERVER = process.env.SERVER_FILE ?? "server.json";
+
+const pkg = JSON.parse(readFileSync(PKG, "utf8"));
+const raw = readFileSync(SERVER, "utf8");
+const server = JSON.parse(raw);
+
+const version = pkg.version;
+if (!version) {
+  console.error(`sync-server-version: no "version" in ${PKG}`);
+  process.exit(1);
+}
+
+let changed = false;
+if (server.version !== version) {
+  server.version = version;
+  changed = true;
+}
+if (Array.isArray(server.packages)) {
+  for (const p of server.packages) {
+    if (p.version !== version) {
+      p.version = version;
+      changed = true;
+    }
+  }
+}
+
+if (!changed) {
+  console.log(`sync-server-version: ${SERVER} already at ${version} — no change`);
+  process.exit(0);
+}
+
+writeFileSync(SERVER, JSON.stringify(server, null, 2) + "\n");
+console.log(`sync-server-version: set ${SERVER} version → ${version}`);

--- a/test/unit/version-sync.test.ts
+++ b/test/unit/version-sync.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+const CHECK = join(root, "scripts/check-version-sync.mjs");
+const SYNC = join(root, "scripts/sync-server-version.mjs");
+
+const PKG = (version: string, mcpName = "io.github.x/y") =>
+  JSON.stringify({ name: "y", version, mcpName });
+
+const SERVER = (version: string, pkgVersion = version, name = "io.github.x/y") =>
+  JSON.stringify({
+    $schema: "https://example/server.schema.json",
+    name,
+    version,
+    packages: [{ registryType: "npm", identifier: "y", version: pkgVersion }],
+  });
+
+describe("check-version-sync gate", () => {
+  let dir: string;
+  let pkgFile: string;
+  let serverFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vsync-"));
+    pkgFile = join(dir, "package.json");
+    serverFile = join(dir, "server.json");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const run = (script: string) =>
+    execFileSync("node", [script], {
+      env: { ...process.env, PKG_FILE: pkgFile, SERVER_FILE: serverFile },
+      encoding: "utf8",
+    });
+
+  const runCheck = (): { code: number; out: string } => {
+    try {
+      return { code: 0, out: run(CHECK) };
+    } catch (e: any) {
+      return { code: e.status ?? 1, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+    }
+  };
+
+  it("passes (exit 0) when all three versions and identity agree", () => {
+    writeFileSync(pkgFile, PKG("1.3.0"));
+    writeFileSync(serverFile, SERVER("1.3.0"));
+    const { code, out } = runCheck();
+    expect(code).toBe(0);
+    expect(out).toContain("Versions in sync.");
+  });
+
+  it("fails (exit 1) when server.json root version drifts", () => {
+    writeFileSync(pkgFile, PKG("1.3.0"));
+    writeFileSync(serverFile, SERVER("1.2.0", "1.3.0"));
+    const { code, out } = runCheck();
+    expect(code).toBe(1);
+    expect(out).toContain("drift");
+  });
+
+  it("fails (exit 1) when packages[].version drifts", () => {
+    writeFileSync(pkgFile, PKG("1.3.0"));
+    writeFileSync(serverFile, SERVER("1.3.0", "1.2.0"));
+    const { code } = runCheck();
+    expect(code).toBe(1);
+  });
+
+  it("fails (exit 1) when mcpName != server name", () => {
+    writeFileSync(pkgFile, PKG("1.3.0", "io.github.x/wrong"));
+    writeFileSync(serverFile, SERVER("1.3.0"));
+    const { code } = runCheck();
+    expect(code).toBe(1);
+  });
+
+  it("sync-server-version brings a drifted server.json back into sync", () => {
+    writeFileSync(pkgFile, PKG("1.3.0"));
+    writeFileSync(serverFile, SERVER("1.2.0", "1.2.0"));
+    run(SYNC);
+    const synced = JSON.parse(readFileSync(serverFile, "utf8"));
+    expect(synced.version).toBe("1.3.0");
+    expect(synced.packages[0].version).toBe("1.3.0");
+    expect(runCheck().code).toBe(0);
+  });
+});
+
+describe("live repo manifest", () => {
+  it("package.json and server.json are in sync (the gate, live)", () => {
+    // Belt-and-suspenders: `npm test` itself goes red if the real files drift,
+    // not just the dedicated CI step.
+    const code = (() => {
+      try {
+        execFileSync("node", [CHECK], { cwd: root, encoding: "utf8" });
+        return 0;
+      } catch (e: any) {
+        return e.status ?? 1;
+      }
+    })();
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
Adds `docs/release-runbook.md`, adapting the docker-net-dhcp runbook to debmatic-mcp's real publish chain.

## What carries over
- One-time auth setup (npm publish auth/OTP, `mcp-publisher login github`)
- Per-release procedure: branch off `dev` → version bump (with the gotcha that **three** spots must agree: `package.json` + the two `server.json` versions) → milestone-driven doc/help review → release PR `dev → main` → signed tag on `main` → `npm publish` + `mcp-publisher publish` + GitHub Release → ff `dev → main` → prune
- Pre-flight dry-runs that touch nothing remote (`npm publish --dry-run`, `mcp-publisher validate`)
- Verification, troubleshooting table, and `dev ⇄ main` backports

## What was dropped (and why, documented in a "Not applicable" section)
- GHCR/Docker Hub publish, cosign/SBOM/provenance — no image is published (Dockerfile is build-your-own via compose)
- mkdocs/GitHub Pages site — docs are README + `docs/`
- rc-via-workflow and coverage ratchet — no release workflow exists; the dry-runs are the equivalent cheap gate

Suite green before commit (219 passed).