### PR TITLE
fix: avoid polynomial ReDoS in bearer-token parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { ResourcePoller } from "./resources/poller.js";
 import { resolveAuthToken } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
 import { createMcpServer } from "./server.js";
+import { extractBearerToken } from "./utils.js";
 
 async function main(): Promise<void> {
   const logger = createLogger();
@@ -105,11 +106,10 @@ async function main(): Promise<void> {
           return;
         }
 
-        // Auth check for MCP endpoints. The scheme is case-insensitive per
-        // RFC 7235; the token comparison is timing-safe (hash both sides so
-        // length differences don't create a timing side-channel).
-        const authHeader = req.headers.authorization ?? "";
-        const presented = authHeader.match(/^Bearer\s+(.+)$/i)?.[1] ?? "";
+        // Auth check for MCP endpoints. Token parsing tolerates the
+        // case-insensitive scheme (RFC 7235); the comparison is timing-safe
+        // (hash both sides so length differences don't leak via timing).
+        const presented = extractBearerToken(req.headers.authorization ?? "");
         const ha = createHash("sha256").update(presented).digest();
         const hb = createHash("sha256").update(authToken).digest();
         const headerValid = timingSafeEqual(ha, hb);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,21 @@ export function escapeHmScript(input: string): string {
     .replace(/\r/g, "\\r");
 }
 
+/**
+ * Extract the token from an `Authorization: Bearer <token>` header (scheme is
+ * case-insensitive per RFC 7235). Returns "" when absent or not a well-formed
+ * bearer header.
+ *
+ * The capture is anchored to a non-space first char (`\S.*`) so the whitespace
+ * and token patterns can't overlap — `\s+(.+)` overlapped on whitespace and
+ * backtracked polynomially on a caller-controlled header, which is reachable
+ * pre-auth (CodeQL js/polynomial-redos). Bearer tokens contain no spaces, so
+ * anchoring is behaviour-preserving for valid input.
+ */
+export function extractBearerToken(authHeader: string): string {
+  return authHeader.match(/^Bearer\s+(\S.*)$/i)?.[1] ?? "";
+}
+
 /** Format a tool result as MCP text content. */
 export function toolResult(data: unknown) {
   return { content: [{ type: "text" as const, text: typeof data === "string" ? data : JSON.stringify(data, null, 2) }] };

--- a/test/unit/bearer-token.test.ts
+++ b/test/unit/bearer-token.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { extractBearerToken } from "../../src/utils.js";
+
+describe("extractBearerToken", () => {
+  it("extracts a well-formed bearer token", () => {
+    expect(extractBearerToken("Bearer abc123")).toBe("abc123");
+  });
+
+  it("is case-insensitive on the scheme (RFC 7235)", () => {
+    expect(extractBearerToken("bearer abc123")).toBe("abc123");
+    expect(extractBearerToken("BEARER abc123")).toBe("abc123");
+  });
+
+  it("tolerates multiple spaces after the scheme", () => {
+    expect(extractBearerToken("Bearer    abc123")).toBe("abc123");
+  });
+
+  it("returns '' for a missing or non-bearer header", () => {
+    expect(extractBearerToken("")).toBe("");
+    expect(extractBearerToken("Basic abc123")).toBe("");
+    expect(extractBearerToken("Bearer")).toBe("");
+    expect(extractBearerToken("Bearer ")).toBe("");
+  });
+
+  it("does not backtrack polynomially on a whitespace-only tail (ReDoS guard)", () => {
+    // The old /^Bearer\s+(.+)$/ overlapped \s+ and .+ on whitespace; a long
+    // all-space tail was the polynomial-ReDoS input. Anchoring to \S makes
+    // this linear: it must complete near-instantly and yield no token.
+    const malicious = "Bearer" + " ".repeat(100_000);
+    const start = performance.now();
+    const token = extractBearerToken(malicious);
+    const elapsed = performance.now() - start;
+    expect(token).toBe("");
+    expect(elapsed).toBeLessThan(50);
+  });
+});


### PR DESCRIPTION
Closes #33 (CodeQL `js/polynomial-redos`, **high**).

## Problem
`src/index.ts` parsed the `Authorization` header with `/^Bearer\s+(.+)$/i`. `\s+` and `(.+)` overlap on whitespace, so a long all-space tail backtracks polynomially. The header is attacker-controlled and parsed **before** the bearer check — a pre-auth DoS vector on the HTTP transport.

## Fix
- Extract parsing into `extractBearerToken()` in `utils.ts`, anchoring the capture to a non-space first char: `/^Bearer\s+(\S.*)$/i`. No overlap → linear. Behaviour-preserving for valid tokens (no spaces).
- Unit tests in `test/unit/bearer-token.test.ts`, including a 100k-space **ReDoS guard** asserting it completes in <50ms and yields no token.

Lint clean; suite 224 passed.