### PR TITLE
fix: enable DNS-rebinding protection and make wildcard CORS opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ curl http://localhost:3000/health
 
 #### Browser-based clients (CORS)
 
-The HTTP server sends permissive CORS headers and answers `OPTIONS` preflight requests, so browser-based MCP clients like [MCP Inspector](https://github.com/modelcontextprotocol/inspector) can connect directly — no proxy needed. Authentication is still enforced: browsers can read the endpoint, but every MCP request needs the bearer token.
+By default the HTTP server sends **no** CORS headers, so a random web page can't drive a local instance. To let a browser-based MCP client like [MCP Inspector](https://github.com/modelcontextprotocol/inspector) connect directly, set `MCP_CORS_ALLOW_ORIGIN` — `*` for local dev, or a single trusted origin (e.g. `https://inspector.example`). Authentication is always enforced regardless: every MCP request needs the bearer token.
+
+The HTTP transport also has **DNS-rebinding protection** on by default: it rejects requests whose `Host` header isn't `localhost`/`127.0.0.1` on the configured port. If you reach the server under another hostname (reverse proxy, container DNS name), list those hosts in `MCP_ALLOWED_HOSTS` or legitimate requests get a `403`.
 
 CORS support was first implemented by [@marcinn2](https://github.com/marcinn2) in his fork [marcinn2/debmatic-mcp](https://github.com/marcinn2/debmatic-mcp) — thanks!
 
@@ -168,6 +170,8 @@ All configuration is via environment variables:
 | `MCP_TRANSPORT` | `http` | `http` or `stdio` (the `--stdio` CLI flag overrides this) |
 | `MCP_PORT` | `3000` | HTTP server port (HTTP mode only) |
 | `MCP_AUTH_TOKEN` | auto-generated | Bearer token for HTTP mode; generated and saved to `$CACHE_DIR/.env` on first start |
+| `MCP_CORS_ALLOW_ORIGIN` | unset | CORS `Access-Control-Allow-Origin` for browser clients. Unset = no CORS (default-deny). Use `*` for dev/MCP Inspector, or one trusted origin |
+| `MCP_ALLOWED_HOSTS` | `localhost`/`127.0.0.1` | Extra `Host` values accepted by DNS-rebinding protection (comma-separated `host:port`); add your hostname when behind a proxy or container DNS name |
 | `CCU_RATE_LIMIT_BURST` | `20` | Max burst of requests sent to the CCU |
 | `CCU_RATE_LIMIT_RATE` | `10` | Sustained CCU requests per second |
 | `RESOURCE_POLL_INTERVAL` | `60` | Seconds between polls for MCP resource change notifications |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       # - MCP_TRANSPORT=http
       # - MCP_PORT=3000
       # - MCP_AUTH_TOKEN=           # auto-generated if unset
+      # - MCP_CORS_ALLOW_ORIGIN=*   # unset = no CORS (default-deny); '*' for dev/MCP Inspector, or one trusted origin
+      # - MCP_ALLOWED_HOSTS=        # extra Host values for DNS-rebinding protection (comma-separated host:port)
 
       # === Cache (optional) ===
       # - CACHE_DIR=/data

--- a/server.json
+++ b/server.json
@@ -59,6 +59,16 @@
           "description": "Directory for the device type cache and session persistence",
           "default": "/data",
           "format": "string"
+        },
+        {
+          "name": "MCP_CORS_ALLOW_ORIGIN",
+          "description": "CORS Access-Control-Allow-Origin for browser clients. Unset = no CORS (default-deny); use '*' for dev/MCP Inspector or a single trusted origin",
+          "format": "string"
+        },
+        {
+          "name": "MCP_ALLOWED_HOSTS",
+          "description": "Extra Host header values accepted by DNS-rebinding protection (comma-separated host:port); add your hostname when behind a proxy or container DNS name",
+          "format": "string"
         }
       ]
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,18 @@ export interface AppConfig {
     transport: "http" | "stdio";
     port: number;
     authToken?: string;
+    /**
+     * Value echoed in `Access-Control-Allow-Origin`. Unset ⇒ no CORS header is
+     * sent (browsers are blocked by default). Set `MCP_CORS_ALLOW_ORIGIN=*` for
+     * local dev / MCP Inspector, or a single trusted origin.
+     */
+    corsAllowOrigin?: string;
+    /**
+     * Host-header allowlist for the StreamableHTTP transport's DNS-rebinding
+     * protection. Defaults to localhost/127.0.0.1 on the MCP port; extend via
+     * `MCP_ALLOWED_HOSTS` when the server is reached under another hostname.
+     */
+    allowedHosts: string[];
   };
   cache: {
     dir: string;
@@ -43,6 +55,20 @@ export function loadConfig(): AppConfig {
     return val;
   };
 
+  const mcpPort = parseIntEnv("MCP_PORT", "3000");
+  // DNS-rebinding defense: the transport rejects any Host header not on this
+  // list. localhost/127.0.0.1 on the bound port covers local use; deployments
+  // reached under another hostname (reverse proxy, container DNS name) add it
+  // via MCP_ALLOWED_HOSTS (comma-separated, "host:port").
+  const allowedHosts = [
+    `127.0.0.1:${mcpPort}`,
+    `localhost:${mcpPort}`,
+    ...(process.env.MCP_ALLOWED_HOSTS || "")
+      .split(",")
+      .map((h) => h.trim())
+      .filter(Boolean),
+  ];
+
   return {
     ccu: {
       host,
@@ -56,8 +82,10 @@ export function loadConfig(): AppConfig {
     },
     mcp: {
       transport,
-      port: parseIntEnv("MCP_PORT", "3000"),
+      port: mcpPort,
       authToken: process.env.MCP_AUTH_TOKEN,
+      corsAllowOrigin: process.env.MCP_CORS_ALLOW_ORIGIN || undefined,
+      allowedHosts,
     },
     cache: {
       dir: process.env.CACHE_DIR || "/data",

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,17 +82,27 @@ async function main(): Promise<void> {
     httpServer = createServer(async (req, res) => {
       try {
         // CORS so browser-based MCP clients (e.g. MCP Inspector) can connect
-        // directly. Auth is still enforced via the bearer token below.
-        // Mcp-Session-Id must be exposed or browsers can't reuse the session.
-        // Credit: @marcinn2 (marcinn2/debmatic-mcp@d33a0cb)
-        res.setHeader("Access-Control-Allow-Origin", "*");
-        res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-        res.setHeader(
-          "Access-Control-Allow-Headers",
-          "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID",
-        );
-        res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
-        res.setHeader("Access-Control-Max-Age", "86400");
+        // directly. Opt-in only: a cross-origin browser is allowed solely when
+        // MCP_CORS_ALLOW_ORIGIN is configured (`*` for dev, or one trusted
+        // origin). Default is no CORS header at all, so a random web page can't
+        // reach a local instance. DNS-rebinding protection on the transport
+        // (allowedHosts, below) is the matching Host-header defense. Auth is
+        // still enforced via the bearer token regardless.
+        // CORS first implemented by @marcinn2 (marcinn2/debmatic-mcp@d33a0cb).
+        const corsOrigin = config.mcp.corsAllowOrigin;
+        if (corsOrigin) {
+          res.setHeader("Access-Control-Allow-Origin", corsOrigin);
+          res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+          res.setHeader(
+            "Access-Control-Allow-Headers",
+            "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID",
+          );
+          res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
+          res.setHeader("Access-Control-Max-Age", "86400");
+          // A specific origin makes the response vary by Origin; mark it so
+          // shared caches don't serve it to a different origin.
+          if (corsOrigin !== "*") res.setHeader("Vary", "Origin");
+        }
 
         if (req.method === "OPTIONS") {
           res.writeHead(204);
@@ -130,6 +140,11 @@ async function main(): Promise<void> {
         // transport itself rejects non-initialize requests without a session.
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
+          // Defense-in-depth against DNS rebinding: reject requests whose Host
+          // header isn't an expected one (a browser tricked into hitting a
+          // local instance carries the attacker's host, not localhost:port).
+          enableDnsRebindingProtection: true,
+          allowedHosts: config.mcp.allowedHosts,
           onsessioninitialized: (sid) => {
             sessions.set(sid, { server: sessionServer, transport });
             logger.info("mcp_session_started", { sessions: sessions.size });

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { createServer, type Server } from "node:http";
+import { createServer, request, type Server, type IncomingHttpHeaders } from "node:http";
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
@@ -166,6 +166,10 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
         MCP_TRANSPORT: "http",
         MCP_PORT: String(mcpPort),
         MCP_AUTH_TOKEN: AUTH_TOKEN,
+        // This block exercises the dev/MCP-Inspector configuration: wildcard
+        // CORS is opt-in (issue #28). The secure-defaults block below covers
+        // the unset (default-deny) behavior.
+        MCP_CORS_ALLOW_ORIGIN: "*",
         CACHE_DIR: cacheDir,
         RESOURCE_POLL_INTERVAL: "3600",
         LOG_LEVEL: "error",
@@ -274,6 +278,128 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
   });
 
   // Must be last: terminates the server and asserts a clean exit
+  it("shuts down gracefully on SIGTERM with exit code 0", async () => {
+    const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
+    child.kill("SIGTERM");
+    const code = await Promise.race([
+      exited,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("shutdown timed out")), 12_000)),
+    ]);
+    expect(code).toBe(0);
+  }, 15_000);
+});
+
+// Issue #28: secure HTTP defaults — no CORS env set, DNS-rebinding protection on.
+// `request` is used (not fetch) because undici forbids overriding the Host header,
+// and a forged Host is exactly the DNS-rebinding vector we need to exercise.
+function rawPost(
+  port: number,
+  body: unknown,
+  opts: { host?: string; token?: string } = {},
+): Promise<{ status: number; headers: IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const req = request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json, text/event-stream",
+          "mcp-protocol-version": "2025-06-18",
+          ...(opts.token ? { Authorization: `Bearer ${opts.token}` } : {}),
+          ...(opts.host ? { Host: opts.host } : {}),
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        res.on("data", () => {}); // drain
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers }));
+      },
+    );
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+const INIT_BODY = {
+  jsonrpc: "2.0", id: 0, method: "initialize",
+  params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "secure", version: "1" } },
+};
+
+describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebinding on)", () => {
+  let ccu: { server: Server; port: number };
+  let child: ChildProcess;
+  let mcpPort: number;
+  let cacheDir: string;
+
+  beforeAll(async () => {
+    ccu = await startCcuMock();
+    cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-secure-"));
+    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+
+    child = spawn("node", [DIST], {
+      env: {
+        ...process.env,
+        CCU_HOST: "127.0.0.1",
+        CCU_PORT: String(ccu.port),
+        CCU_HTTPS: "false",
+        CCU_PASSWORD: "mock",
+        MCP_TRANSPORT: "http",
+        MCP_PORT: String(mcpPort),
+        MCP_AUTH_TOKEN: AUTH_TOKEN,
+        // MCP_CORS_ALLOW_ORIGIN deliberately unset → default-deny CORS.
+        CACHE_DIR: cacheDir,
+        RESOURCE_POLL_INTERVAL: "3600",
+        LOG_LEVEL: "error",
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+
+    const deadline = Date.now() + 15_000;
+    for (;;) {
+      try {
+        const r = await fetch(`http://127.0.0.1:${mcpPort}/health`);
+        if (r.status === 200 || r.status === 503) break;
+      } catch { /* not up yet */ }
+      if (Date.now() > deadline) throw new Error("server did not start");
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    child?.kill("SIGTERM");
+    await new Promise((r) => setTimeout(r, 300));
+    child?.kill("SIGKILL");
+    ccu?.server.close();
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("does not emit Access-Control-Allow-Origin when CORS is unconfigured (default-deny)", async () => {
+    const preflight = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "OPTIONS",
+      headers: { "Origin": "http://evil.example", "Access-Control-Request-Method": "POST" },
+    });
+    expect(preflight.headers.get("access-control-allow-origin")).toBeNull();
+
+    const init = await initialize(mcpPort);
+    expect(init).toBeTruthy(); // a non-browser client still works fine
+  });
+
+  it("accepts a request whose Host header is on the allowlist", async () => {
+    const res = await rawPost(mcpPort, INIT_BODY, { token: AUTH_TOKEN, host: `127.0.0.1:${mcpPort}` });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a forged Host header with 403 (DNS-rebinding protection)", async () => {
+    const res = await rawPost(mcpPort, INIT_BODY, { token: AUTH_TOKEN, host: "evil.example" });
+    expect(res.status).toBe(403);
+  });
+
+  // Must be last: clean shutdown
   it("shuts down gracefully on SIGTERM with exit code 0", async () => {
     const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
     child.kill("SIGTERM");

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -44,7 +44,7 @@ describeIf("MCP tools against live CCU", () => {
     deps = {
       config: {
         ccu: config,
-        mcp: { transport: "stdio", port: 3000 },
+        mcp: { transport: "stdio", port: 3000, allowedHosts: [] },
         cache: { dir: tempDir, ttl: 86400 },
         rateLimiter: { burst: 20, rate: 10 },
         resourcePollInterval: 3600,

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -13,7 +13,7 @@ export function createMockDeps(overrides?: {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000 },
+      mcp: { transport: "stdio" as const, port: 3000, allowedHosts: [] },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -17,6 +17,8 @@ describe("loadConfig", () => {
     delete process.env.MCP_TRANSPORT;
     delete process.env.MCP_PORT;
     delete process.env.MCP_AUTH_TOKEN;
+    delete process.env.MCP_CORS_ALLOW_ORIGIN;
+    delete process.env.MCP_ALLOWED_HOSTS;
     delete process.env.CACHE_DIR;
     delete process.env.CACHE_TTL;
     delete process.env.CCU_RATE_LIMIT_BURST;
@@ -148,6 +150,39 @@ describe("loadConfig", () => {
 
     process.env.RESOURCE_POLL_INTERVAL = "-60";
     expect(() => loadConfig()).toThrow(/RESOURCE_POLL_INTERVAL must be a positive number/);
+  });
+
+  // Issue #28: HTTP transport hardening
+  it("CORS is default-deny: corsAllowOrigin is undefined unless configured", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    expect(loadConfig().mcp.corsAllowOrigin).toBeUndefined();
+
+    process.env.MCP_CORS_ALLOW_ORIGIN = "*";
+    expect(loadConfig().mcp.corsAllowOrigin).toBe("*");
+
+    process.env.MCP_CORS_ALLOW_ORIGIN = "https://app.example";
+    expect(loadConfig().mcp.corsAllowOrigin).toBe("https://app.example");
+  });
+
+  it("allowedHosts defaults to localhost/127.0.0.1 on the MCP port", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_PORT = "4567";
+    expect(loadConfig().mcp.allowedHosts).toEqual(["127.0.0.1:4567", "localhost:4567"]);
+  });
+
+  it("MCP_ALLOWED_HOSTS extends the default host allowlist (trimmed, no blanks)", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_PORT = "3000";
+    process.env.MCP_ALLOWED_HOSTS = "mcp.lan:3000, , proxy.example ";
+    expect(loadConfig().mcp.allowedHosts).toEqual([
+      "127.0.0.1:3000",
+      "localhost:3000",
+      "mcp.lan:3000",
+      "proxy.example",
+    ]);
   });
 
   it("parses CCU_TLS_VERIFY (default off)", () => {

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -10,7 +10,7 @@ function createMockDeps() {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000 },
+      mcp: { transport: "stdio" as const, port: 3000, allowedHosts: [] },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 20, rate: 10 },
       resourcePollInterval: 60,


### PR DESCRIPTION
Closes #28.

## Problem
The HTTP transport set `Access-Control-Allow-Origin: *` unconditionally and never enabled `StreamableHTTPServerTransport`'s DNS-rebinding protection. A browser page could POST to a local instance; the bearer token was the only line of defense.

## Fix (scoped per #28; multi-origin allowlist deferred to #37)
- **DNS-rebinding protection on by default** — `enableDnsRebindingProtection: true` + `allowedHosts` (default `127.0.0.1:<port>` / `localhost:<port>`, extend via `MCP_ALLOWED_HOSTS`). A forged `Host` header now gets a `403`. Non-browser clients (no `Origin`, correct `Host`) are unaffected.
- **Wildcard CORS is opt-in** — `MCP_CORS_ALLOW_ORIGIN`. Unset ⇒ no CORS header at all (default-deny); `*` for dev/MCP Inspector, or a single trusted origin (which also emits `Vary: Origin`).
- **Docs** — README config table + CORS section, `docker-compose.yml`, `server.json` `environmentVariables`.

## Tests
- e2e (`test/e2e/http-transport.test.ts`): existing CORS block now runs under `MCP_CORS_ALLOW_ORIGIN=*` (the dev config); new **secure-defaults** block asserts no `Access-Control-Allow-Origin` when unset, an allowlisted `Host` is accepted, and a forged `Host` → `403`.
- unit (`test/unit/config.test.ts`): default-deny `corsAllowOrigin`, `allowedHosts` default, `MCP_ALLOWED_HOSTS` parsing.

## Acceptance criteria
- [x] DNS-rebinding protection enabled on the StreamableHTTP transport
- [x] Wildcard CORS is opt-in via config, not the default
- [x] Tests cover rejected vs allowed Host/Origin
- [x] `npm test` green (237 passed)

## Notes
- Default `allowedHosts` covers localhost only — deployments behind a reverse proxy or container DNS name must set `MCP_ALLOWED_HOSTS`, else legitimate requests get `403`. Documented in the README.