### PR TITLE
feat: complete MCP tool annotation hints

### DIFF
--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -29,8 +29,9 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
         type: z.enum(["bool", "int", "double", "string"]).optional().describe("Value type override (auto-resolved if omitted)"),
       },
       annotations: {
-        title: "Set Value",
         destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
       },
     },
     async (args) => {
@@ -102,8 +103,9 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
         interface: z.string().optional().describe("Interface name override"),
       },
       annotations: {
-        title: "Put Paramset",
         destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
       },
     },
     async (args) => {
@@ -163,8 +165,9 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         value: z.union([z.string(), z.number(), z.boolean()]).describe("Value to set"),
       },
       annotations: {
-        title: "Set System Variable",
         destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
       },
     },
     async (args) => {
@@ -260,8 +263,8 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
         id: z.string().describe("Program ID. Get from list_programs."),
       },
       annotations: {
-        title: "Execute Program",
         destructiveHint: true,
+        openWorldHint: true,
       },
     },
     async (args) => {

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -16,6 +16,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
       title: "Get Service Messages",
       description:
         "Get all active service messages (low battery, unreachable, etc.) with device details and timestamps.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
       const { session, rateLimiter, logger } = deps;
@@ -118,6 +119,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
     {
       title: "Get System Info",
       description: "Get CCU system information: firmware version, serial number, addresses.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
       const { session, rateLimiter, logger, deviceTypeCache } = deps;

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -31,6 +31,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
         type: z.string().optional().describe("Filter by device type (exact match, e.g. 'HmIP-eTRV-2')"),
         name: z.string().optional().describe("Filter by device/channel name (substring, case-insensitive)"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
@@ -131,6 +132,7 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Interfaces",
       description: "List available communication interfaces (BidCos-RF, HmIP-RF, VirtualDevices, etc.).",
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
       const { session, rateLimiter, logger } = deps;
@@ -155,6 +157,7 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Rooms",
       description: "List all rooms with their assigned channel IDs. Use with list_devices to find devices by room.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
       const { session, rateLimiter, logger } = deps;
@@ -179,6 +182,7 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Functions",
       description: "List all function groups (Heating, Lighting, etc.) with their assigned channel IDs.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
       const { session, rateLimiter, logger } = deps;
@@ -206,6 +210,7 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         name: z.string().optional().describe("Filter by program name (substring, case-insensitive)"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
@@ -239,6 +244,7 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
       inputSchema: {
         name: z.string().optional().describe("Filter by variable name (substring, case-insensitive)"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
@@ -275,6 +281,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         deviceType: z.string().describe("Device type name (e.g. 'HmIP-eTRV-2', 'HmIP-SWDO-I'). Get from list_devices."),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger, deviceTypeCache } = deps;

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -146,6 +146,8 @@ function registerHelp(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         topic: z.string().optional().describe("Tool name, device type, or omit for general guide"),
       },
+      // Local-only: serves the static guide and the device-type cache; never reaches the CCU.
+      annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async (args) => {
       if (!args.topic) {
@@ -186,8 +188,8 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
         script: z.string().describe("HomeMatic Script to execute"),
       },
       annotations: {
-        title: "Run Script",
         destructiveHint: true,
+        openWorldHint: true,
       },
     },
     async (args) => {

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -25,6 +25,7 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
         valueKey: z.string().describe("Datapoint name (e.g. 'STATE', 'LEVEL', 'ACTUAL_TEMPERATURE')"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
@@ -68,6 +69,7 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         room: z.string().optional().describe("Room name — read all channels in this room"),
         function: z.string().optional().describe("Function name — read all channels in this function group"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
@@ -196,6 +198,7 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
         paramsetKey: z.enum(["VALUES", "MASTER", "LINK"]).describe("Paramset to read"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -113,3 +113,68 @@ describe("MCP Server Registration", () => {
     deps.rateLimiter.destroy();
   });
 });
+
+// Issue #27: tool annotation hints drive client UX (auto-approve safe reads,
+// reason about retries). These assert the invariants, not each tool by hand.
+describe("Tool annotations", () => {
+  const READ_TOOLS = [
+    "describe_device_type", "get_paramset", "get_service_messages", "get_system_info",
+    "get_value", "get_values", "help", "list_devices", "list_functions",
+    "list_interfaces", "list_programs", "list_rooms", "list_system_variables",
+  ];
+  const WRITE_TOOLS = ["execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
+  const IDEMPOTENT_WRITES = ["put_paramset", "set_system_variable", "set_value"];
+  const LOCAL_TOOLS = ["help"]; // everything else reaches the external CCU
+
+  type Ann = {
+    title?: string; readOnlyHint?: boolean; destructiveHint?: boolean;
+    idempotentHint?: boolean; openWorldHint?: boolean;
+  };
+  function annotationsByTool(): Record<string, Ann> {
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+    const tools = (server as any)._registeredTools as Record<string, { annotations?: Ann }>;
+    const out: Record<string, Ann> = {};
+    for (const [name, t] of Object.entries(tools)) out[name] = t.annotations ?? {};
+    deps.rateLimiter.destroy();
+    return out;
+  }
+
+  it("read tools set readOnlyHint and carry no write hints", () => {
+    const ann = annotationsByTool();
+    for (const name of READ_TOOLS) {
+      expect(ann[name].readOnlyHint, name).toBe(true);
+      expect(ann[name].destructiveHint, name).toBeUndefined();
+      expect(ann[name].idempotentHint, name).toBeUndefined();
+    }
+  });
+
+  it("write tools set destructiveHint and never readOnlyHint", () => {
+    const ann = annotationsByTool();
+    for (const name of WRITE_TOOLS) {
+      expect(ann[name].destructiveHint, name).toBe(true);
+      expect(ann[name].readOnlyHint, name).not.toBe(true);
+    }
+  });
+
+  it("idempotentHint marks only the idempotent writes", () => {
+    const ann = annotationsByTool();
+    for (const name of WRITE_TOOLS) {
+      expect(ann[name].idempotentHint ?? false, name).toBe(IDEMPOTENT_WRITES.includes(name));
+    }
+  });
+
+  it("openWorldHint is true for CCU-reaching tools, false for local help", () => {
+    const ann = annotationsByTool();
+    for (const [name, a] of Object.entries(ann)) {
+      expect(a.openWorldHint, name).toBe(!LOCAL_TOOLS.includes(name));
+    }
+  });
+
+  it("drops the redundant annotations.title (it duplicates the top-level title)", () => {
+    const ann = annotationsByTool();
+    for (const [name, a] of Object.entries(ann)) {
+      expect(a.title, name).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
Closes #27.

## Problem
Only `destructiveHint: true` was set, and only on the five write tools. No read tool carried `readOnlyHint`, so clients had no signal to auto-approve safe calls.

## Changes
- **`readOnlyHint: true`** on all 13 read/discovery/diagnostics tools (`get_value`, `get_values`, `get_paramset`, `list_*`, `describe_device_type`, `get_service_messages`, `get_system_info`, `help`).
- **`idempotentHint: true`** on `set_value`, `put_paramset`, `set_system_variable` (documented idempotent); deliberately **not** on `execute_program` / `run_script`.
- **`openWorldHint: true`** on every CCU-reaching tool; **`false`** on `help` (local-only — static guide + device-type cache).
- Dropped the redundant `annotations.title` (duplicated the top-level `title`).

## Tests
`test/unit/server-registration.test.ts` gains a `Tool annotations` block asserting the invariants across all 18 tools (read→readOnly + no write hints; write→destructive + never readOnly; idempotent set correctly; openWorld true except local help; no leftover `annotations.title`).

## Acceptance criteria
- [x] All read/discovery/diagnostics tools carry `readOnlyHint: true`
- [x] Idempotent writes carry `idempotentHint: true`; non-idempotent ones do not
- [x] `openWorldHint` set appropriately
- [x] Redundant `annotations.title` removed
- [x] `npm test` green (235 passed)