### PR TITLE
fix: send WWW-Authenticate challenge on 401

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,17 @@ async function main(): Promise<void> {
         const hb = createHash("sha256").update(authToken).digest();
         const headerValid = timingSafeEqual(ha, hb);
         if (!headerValid) {
-          res.writeHead(401, { "Content-Type": "application/json" });
+          // Challenge header so clients can discover the scheme (RFC 6750 /
+          // MCP auth spec). Add error=invalid_token only when a (bad) token was
+          // actually presented; RFC 6750 §3 omits the error param when no
+          // credentials were sent.
+          const challenge = presented
+            ? 'Bearer realm="debmatic-mcp", error="invalid_token"'
+            : 'Bearer realm="debmatic-mcp"';
+          res.writeHead(401, {
+            "Content-Type": "application/json",
+            "WWW-Authenticate": challenge,
+          });
           res.end(JSON.stringify({ error: "Unauthorized" }));
           return;
         }

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -213,6 +213,34 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
     expect(res.status).toBe(401);
   });
 
+  // Issue #29: 401 carries a WWW-Authenticate challenge (RFC 6750 / MCP auth spec)
+  it("challenges with WWW-Authenticate: Bearer and no error when no token is sent", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Accept": "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    expect(res.status).toBe(401);
+    const challenge = res.headers.get("www-authenticate") ?? "";
+    expect(challenge).toContain("Bearer");
+    expect(challenge).toContain('realm="debmatic-mcp"');
+    expect(challenge).not.toContain("error="); // no credentials presented
+  });
+
+  it("adds error=invalid_token to the challenge when a bad token is sent", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer wrong-token",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate") ?? "").toContain('error="invalid_token"');
+  });
+
   // Regression #17: with a reused stateless transport, request 2+ returned 500
   it("handles many sequential requests on one session", async () => {
     const sid = await initialize(mcpPort);


### PR DESCRIPTION
Closes #29.

## Problem
The HTTP transport returned `401 {"error":"Unauthorized"}` with no `WWW-Authenticate` header, so clients had no machine-readable signal for how to authenticate (RFC 6750 / MCP auth spec).

## Fix
- Add `WWW-Authenticate: Bearer realm="debmatic-mcp"` to the 401 response.
- Include `error="invalid_token"` **only** when a (bad) token was actually presented; per RFC 6750 §3 the `error` param is omitted when no credentials were sent.

The server keeps its static-bearer-token model — this is the low-risk spec-alignment slice only, not the full OAuth 2.1 resource-server flow (explicitly out of scope per the issue).

## Tests
e2e (`test/e2e/http-transport.test.ts`): challenge present with `realm` and no `error=` on the no-token path; `error="invalid_token"` present on the bad-token path.

## Acceptance criteria
- [x] 401 responses include a `WWW-Authenticate: Bearer` header
- [x] `npm test` green (244 passed)