### PR TITLE
feat: add acknowledge_service_messages tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ All configuration is via environment variables:
 
 ## Tools
 
-18 tools organized by what you'd actually want to do:
+19 tools organized by what you'd actually want to do:
 
 **Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `describe_device_type`
 
@@ -186,7 +186,7 @@ All configuration is via environment variables:
 
 **Change things** — `set_value`, `put_paramset`, `set_system_variable`, `execute_program`
 
-**Check health** — `get_service_messages`, `get_system_info`
+**Check health** — `get_service_messages`, `acknowledge_service_messages`, `get_system_info`
 
 **Other** — `help` (context-aware), `run_script` (raw HomeMatic Script for bulk operations, renaming devices/channels, querying room membership, or anything not covered by the other tools)
 

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -1,11 +1,13 @@
+import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
-import { toolResult, tryParseJson, VERSION } from "../utils.js";
+import { toolResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
   registerGetServiceMessages(server, deps);
+  registerAcknowledgeServiceMessages(server, deps);
   registerGetSystemInfo(server, deps);
 }
 
@@ -106,6 +108,120 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
         return toolResult(messages);
       } catch (err) {
         logger.info("tool_call", { tool: "get_service_messages", duration_ms: Date.now() - start, status: "error" });
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+    },
+  );
+}
+
+function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "acknowledge_service_messages",
+    {
+      title: "Acknowledge Service Messages",
+      description:
+        "Confirm/dismiss active service messages (e.g. clear a low-battery or unreachable warning). " +
+        "Provide an alarm id (from get_service_messages) to confirm one message, or a channel address " +
+        "to confirm all active messages on that channel. A warning reappears if its condition persists.",
+      inputSchema: {
+        id: z.string().optional().describe("Alarm id from get_service_messages (confirm a single message)"),
+        address: z.string().optional().describe("Channel address — confirm all active messages on this channel (e.g. '000A1BE9A71F15:0')"),
+      },
+      annotations: {
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      const { session, rateLimiter, logger } = deps;
+      const start = Date.now();
+
+      try {
+        if (!args.id && !args.address) {
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: "Provide either an alarm id or a channel address to acknowledge.",
+            hint: "Call get_service_messages to see active alarms with their ids and addresses.",
+          });
+        }
+
+        // Enumerate active alarms (same OT_ALARMDP objects get_service_messages
+        // lists), AlConfirm() the ones matching the requested id/address, and
+        // report what was confirmed. Confirming in ReGa avoids a second round
+        // trip and means we only ever confirm currently-active alarms.
+        const wantId = escapeHmScript(args.id ?? "");
+        const wantAddr = escapeHmScript(args.address ?? "");
+        const script = `
+          string wantId = "${wantId}";
+          string wantAddr = "${wantAddr}";
+          object svcs = dom.GetObject(ID_SERVICES);
+          boolean first = true;
+          Write('{"confirmed":[');
+          if (svcs) {
+            string sId;
+            foreach(sId, svcs.EnumIDs()) {
+              object svc = dom.GetObject(sId);
+              if (svc && svc.IsTypeOf(OT_ALARMDP) && svc.AlState() == asOncoming) {
+                string alName = svc.Name();
+                string chAddr = "";
+                string dpName = "";
+                integer alPos = alName.Find("AL-");
+                if (alPos >= 0) {
+                  string rest = alName.Substr(3, alName.Length());
+                  integer dotPos = rest.Find(".");
+                  if (dotPos > 0) {
+                    chAddr = rest.Substr(0, dotPos);
+                    dpName = rest.Substr(dotPos + 1, rest.Length());
+                  }
+                }
+                boolean match = false;
+                if (wantId != "" && sId == wantId) { match = true; }
+                if (wantAddr != "" && chAddr == wantAddr) { match = true; }
+                if (match) {
+                  svc.AlConfirm();
+                  if (!first) { Write(","); } first = false;
+                  ! JSON-escape user-controlled names (backslash first, then quote)
+                  dpName = dpName.Replace("\\\\", "\\\\\\\\");
+                  dpName = dpName.Replace("\\"", "\\\\\\"");
+                  Write('{"id":"' # sId # '","type":"' # dpName # '","address":"' # chAddr # '"}');
+                }
+              }
+            }
+          }
+          Write(']}');
+        `;
+
+        await rateLimiter.acquire();
+        const result = await withRetry(
+          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          "ReGa.runScript",
+          logger,
+        );
+
+        const parsed = typeof result === "string" ? tryParseJson(result) : result;
+        const confirmed = (parsed && typeof parsed === "object" && !Array.isArray(parsed)
+          && Array.isArray((parsed as Record<string, unknown>).confirmed))
+          ? (parsed as Record<string, unknown>).confirmed as Array<Record<string, unknown>>
+          : [];
+
+        if (confirmed.length === 0) {
+          throw new CcuError({
+            error: "NOT_FOUND",
+            code: 0,
+            message: args.id
+              ? `No active service message with id: ${args.id}`
+              : `No active service messages on channel: ${args.address}`,
+            hint: "Call get_service_messages to see currently active alarms.",
+          });
+        }
+
+        logger.info("tool_call", { tool: "acknowledge_service_messages", duration_ms: Date.now() - start, status: "ok", count: confirmed.length });
+        return toolResult({ confirmed, count: confirmed.length });
+      } catch (err) {
+        logger.info("tool_call", { tool: "acknowledge_service_messages", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
         throw err;
       }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -48,7 +48,7 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 **Discovery:** list_devices, list_interfaces, list_rooms, list_functions, list_programs, list_system_variables, describe_device_type
 **Read:** get_value, get_values, get_paramset
 **Control:** set_value, put_paramset, set_system_variable, execute_program
-**Diagnostics:** get_service_messages, get_system_info
+**Diagnostics:** get_service_messages, acknowledge_service_messages, get_system_info
 **Meta:** help, run_script
 `;
 
@@ -121,6 +121,11 @@ Returns: {id, executed}`,
   get_service_messages: `Get active service messages (low battery, unreachable, etc.).
 Args: none
 Returns: Array of {id, name, address, channelName, timestamp}`,
+
+  acknowledge_service_messages: `Confirm/dismiss active service messages (e.g. clear a low-battery warning).
+Args: id (single alarm id from get_service_messages) OR address (all active messages on a channel) — at least one required
+Returns: {confirmed: Array of {id, type, address}, count}
+NOT_FOUND if no active message matches; the warning reappears if its condition persists.`,
 
   get_system_info: `Get CCU system info: firmware, serial, addresses, cache status.
 Args: none

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -130,7 +130,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, sid);
     expect(res.status).toBe(200);
     const msg = await parseSse(res);
-    expect(msg.result.tools.length).toBe(18);
+    expect(msg.result.tools.length).toBe(19);
   });
 
   it("returns a structured tool error (not a crash) when a tool needs the CCU", async () => {
@@ -220,7 +220,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
       const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: i, method: "tools/list", params: {} }, sid);
       expect(res.status).toBe(200);
       const msg = await parseSse(res);
-      expect(msg.result.tools.length).toBe(18);
+      expect(msg.result.tools.length).toBe(19);
     }
   });
 

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -109,4 +109,20 @@ describeIf("MCP tools against live CCU", () => {
     expect(result.isError).toBe(true);
     expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
   }, 30_000);
+
+  // Exercises the real ReGa enumeration + AlConfirm path without mutating the
+  // user's CCU: a bogus id matches no active alarm → empty confirmed → NOT_FOUND.
+  // We deliberately do NOT auto-confirm a real active alarm (it would silently
+  // dismiss the user's warnings during a test run).
+  it("acknowledge_service_messages returns NOT_FOUND for an unknown id (live ReGa)", async () => {
+    const result: any = await callTool(server, "acknowledge_service_messages", { id: "999999999" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
+  }, 30_000);
+
+  it("acknowledge_service_messages rejects an empty request with INVALID_INPUT", async () => {
+    const result: any = await callTool(server, "acknowledge_service_messages", {});
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+  }, 30_000);
 });

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -47,6 +47,7 @@ describe("MCP Server Registration", () => {
     const toolNames = Object.keys(tools).sort();
 
     expect(toolNames).toEqual([
+      "acknowledge_service_messages",
       "describe_device_type",
       "execute_program",
       "get_paramset",
@@ -67,7 +68,7 @@ describe("MCP Server Registration", () => {
       "set_value",
     ]);
 
-    expect(Object.keys(tools).length).toBe(18);
+    expect(Object.keys(tools).length).toBe(19);
     deps.rateLimiter.destroy();
   });
 
@@ -122,8 +123,8 @@ describe("Tool annotations", () => {
     "get_value", "get_values", "help", "list_devices", "list_functions",
     "list_interfaces", "list_programs", "list_rooms", "list_system_variables",
   ];
-  const WRITE_TOOLS = ["execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
-  const IDEMPOTENT_WRITES = ["put_paramset", "set_system_variable", "set_value"];
+  const WRITE_TOOLS = ["acknowledge_service_messages", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
+  const IDEMPOTENT_WRITES = ["acknowledge_service_messages", "put_paramset", "set_system_variable", "set_value"];
   const LOCAL_TOOLS = ["help"]; // everything else reaches the external CCU
 
   type Ann = {

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -58,6 +58,68 @@ describe("get_service_messages handler", () => {
   });
 });
 
+describe("acknowledge_service_messages handler", () => {
+  it("confirms a single alarm by id and reports what was confirmed", async () => {
+    const mock = JSON.stringify({ confirmed: [{ id: "4711", type: "LOWBAT", address: "ABC:0" }] });
+    const sessionCall = vi.fn().mockResolvedValue(mock);
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result = parseToolResult(await callTool(server, "acknowledge_service_messages", { id: "4711" })) as any;
+    expect(result.count).toBe(1);
+    expect(result.confirmed[0].id).toBe("4711");
+    cleanupDeps(deps);
+  });
+
+  it("confirms all active messages on a channel address", async () => {
+    const mock = JSON.stringify({
+      confirmed: [
+        { id: "1", type: "LOWBAT", address: "ABC:0" },
+        { id: "2", type: "UNREACH", address: "ABC:0" },
+      ],
+    });
+    const { server, deps } = createTestServer({ sessionCall: vi.fn().mockResolvedValue(mock) });
+
+    const result = parseToolResult(await callTool(server, "acknowledge_service_messages", { address: "ABC:0" })) as any;
+    expect(result.count).toBe(2);
+    cleanupDeps(deps);
+  });
+
+  it("returns INVALID_INPUT when neither id nor address is given", async () => {
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result: any = await callTool(server, "acknowledge_service_messages", {});
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    expect(sessionCall).not.toHaveBeenCalled(); // validated before touching the CCU
+    cleanupDeps(deps);
+  });
+
+  it("returns NOT_FOUND when nothing matched (no active alarm for that id/address)", async () => {
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockResolvedValue(JSON.stringify({ confirmed: [] })),
+    });
+
+    const result: any = await callTool(server, "acknowledge_service_messages", { id: "9999" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
+    cleanupDeps(deps);
+  });
+
+  it("generates a script that confirms (AlConfirm) and escapes the requested id/address", async () => {
+    const sessionCall = vi.fn().mockResolvedValue(JSON.stringify({ confirmed: [{ id: "1", type: "x", address: 'A":0' }] }));
+    const { server, deps } = createTestServer({ sessionCall });
+
+    await callTool(server, "acknowledge_service_messages", { address: 'A":0' });
+    const script = sessionCall.mock.calls[0][1].script as string;
+    expect(script).toContain("AlConfirm()");
+    expect(script).toContain("OT_ALARMDP");
+    // the embedded address literal is escaped (quote -> \")
+    expect(script).toContain('string wantAddr = "A\\":0";');
+    cleanupDeps(deps);
+  });
+});
+
 describe("get_system_info handler", () => {
   it("returns all system info fields", async () => {
     const { server, deps } = createTestServer({


### PR DESCRIPTION
Closes #21.

## What
New `acknowledge_service_messages` tool to confirm/dismiss active service messages (e.g. clear a low-battery or unreachable warning) — previously only possible via a hand-written `run_script`.

- **By id** (from `get_service_messages`) → confirm one message; **by address** → confirm all active messages on a channel.
- ReGa `AlConfirm()` on the same `OT_ALARMDP` objects `get_service_messages` enumerates; confirms in a single script pass and reports what it confirmed.
- `INVALID_INPUT` when neither id nor address is given; structured **NOT_FOUND** when nothing matches (same pattern as `execute_program`, #18).
- A warning reappears if its underlying condition persists (documented in help text).

## Tests
- Unit: single-id confirm, by-address confirm, INVALID_INPUT (no CCU call), NOT_FOUND (empty match), and script-generation/escaping assertion (`AlConfirm()` present, user input escaped).
- Live integration: NOT_FOUND for a bogus id (exercises real ReGa enumeration) + INVALID_INPUT. Deliberately does **not** auto-confirm a real active alarm — that would silently dismiss the user's warnings during a test run.
- Help text (`TOOL_HELP` + conceptual guide), README tool list (18→19), registration/annotation tests updated.

Full suite green (247 passed); lint clean.