### PR TITLE
feat: add list_links tool (read-only direct device links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ All configuration is via environment variables:
 
 ## Tools
 
-19 tools organized by what you'd actually want to do:
+20 tools organized by what you'd actually want to do:
 
 **Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `describe_device_type`
 
@@ -186,7 +186,7 @@ All configuration is via environment variables:
 
 **Change things** — `set_value`, `put_paramset`, `set_system_variable`, `execute_program`
 
-**Check health** — `get_service_messages`, `acknowledge_service_messages`, `get_system_info`
+**Check health** — `get_service_messages`, `acknowledge_service_messages`, `get_rssi`, `get_system_info`
 
 **Other** — `help` (context-aware), `run_script` (raw HomeMatic Script for bulk operations, renaming devices/channels, querying room membership, or anything not covered by the other tools)
 

--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ All configuration is via environment variables:
 
 ## Tools
 
-20 tools organized by what you'd actually want to do:
+21 tools organized by what you'd actually want to do:
 
-**Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `describe_device_type`
+**Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `list_links`, `describe_device_type`
 
 **Read state** — `get_value`, `get_values` (bulk), `get_paramset`
 

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
+import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
 import { toolResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
@@ -9,6 +10,13 @@ export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): v
   registerGetServiceMessages(server, deps);
   registerAcknowledgeServiceMessages(server, deps);
   registerGetSystemInfo(server, deps);
+  registerGetRssi(server, deps);
+}
+
+// rssiInfo reports 65536 (0x10000) when no measurement is available; real
+// values are already in dBm. Map the sentinel (and any non-number) to null.
+function normalizeRssi(v: unknown): number | null {
+  return typeof v === "number" && v !== 65536 ? v : null;
 }
 
 function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
@@ -267,6 +275,115 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
         return toolResult(results);
       } catch (err) {
         logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "error" });
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+    },
+  );
+}
+
+function registerGetRssi(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "get_rssi",
+    {
+      title: "Get RSSI / Radio Quality",
+      description:
+        "Report radio link quality (RSSI, in dBm) for every device, resolved to device names, " +
+        "plus BidCos interface health (duty cycle, connected state). Use to answer 'why is this " +
+        "sensor flaky?'. Higher (closer to 0) dBm is better; null means no measurement available.",
+      inputSchema: {
+        name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) => {
+      const { session, rateLimiter, logger } = deps;
+      const start = Date.now();
+
+      try {
+        // Device list → address→{name,interface}. Same call list_devices uses;
+        // also refresh the resolver so later interface lookups are warm.
+        await rateLimiter.acquire();
+        const devices = await withRetry(
+          () => session.call("Device.listAllDetail"),
+          "Device.listAllDetail",
+          logger,
+        ) as CcuDevice[];
+        deps.resolver.updateDeviceList(devices);
+        const nameByAddress = new Map<string, string>();
+        const ifaceByAddress = new Map<string, string>();
+        for (const d of devices) {
+          nameByAddress.set(d.address, d.name);
+          ifaceByAddress.set(d.address, d.interface);
+        }
+
+        // Enumerate interfaces and pull rssiInfo per interface. rssiInfo maps
+        // device1 → device2 → [rssiAtDevice1, rssiAtDevice2] (dBm; 65536 = none).
+        await rateLimiter.acquire();
+        const interfaces = await withRetry(
+          () => session.call("Interface.listInterfaces"),
+          "Interface.listInterfaces",
+          logger,
+        ) as Array<{ name: string }>;
+
+        const needle = args.name?.toLowerCase();
+        const deviceEntries: Array<Record<string, unknown>> = [];
+
+        for (const iface of interfaces) {
+          let info: Record<string, Record<string, unknown>> | null = null;
+          try {
+            await rateLimiter.acquire();
+            info = await withRetry(
+              () => session.call("Interface.rssiInfo", { interface: iface.name }),
+              "Interface.rssiInfo",
+              logger,
+            ) as Record<string, Record<string, unknown>>;
+          } catch {
+            // Interfaces without RF (e.g. VirtualDevices) don't support rssiInfo.
+            continue;
+          }
+          if (!info || typeof info !== "object") continue;
+
+          for (const [address, peers] of Object.entries(info)) {
+            if (!peers || typeof peers !== "object") continue;
+            const links = Object.entries(peers).map(([peer, pair]) => {
+              const [atDevice, atPeer] = Array.isArray(pair) ? pair : [];
+              return {
+                peer,
+                peerName: nameByAddress.get(peer) ?? "",
+                rssiDevice: normalizeRssi(atDevice), // dBm received by this device from peer
+                rssiPeer: normalizeRssi(atPeer),     // dBm received by the peer from this device
+              };
+            });
+            const entry = {
+              address,
+              name: nameByAddress.get(address) ?? "",
+              interface: ifaceByAddress.get(address) ?? iface.name,
+              links,
+            };
+            if (needle && !`${entry.address} ${entry.name}`.toLowerCase().includes(needle)) continue;
+            deviceEntries.push(entry);
+          }
+        }
+
+        // BidCos interface health (duty cycle, connected). Optional — not all
+        // setups expose it; tolerate failure rather than failing the whole call.
+        let bidcosInterfaces: unknown = [];
+        try {
+          await rateLimiter.acquire();
+          bidcosInterfaces = await withRetry(
+            () => session.call("Interface.listBidcosInterfaces"),
+            "Interface.listBidcosInterfaces",
+            logger,
+          );
+        } catch {
+          bidcosInterfaces = [];
+        }
+
+        logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "ok", devices: deviceEntries.length });
+        return toolResult({ devices: deviceEntries, interfaces: bidcosInterfaces });
+      } catch (err) {
+        logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
         throw err;
       }

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -14,6 +14,7 @@ export function registerDiscoveryTools(server: McpServer, deps: ServerDeps): voi
   registerListPrograms(server, deps);
   registerListSystemVariables(server, deps);
   registerDescribeDeviceType(server, deps);
+  registerListLinks(server, deps);
 }
 
 function registerListDevices(server: McpServer, deps: ServerDeps): void {
@@ -321,6 +322,95 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
         message: "Device type not in cache. Cache may still be warming. Try again shortly or call list_devices first.",
         availableTypes: Object.keys(deviceTypeCache.getAll()),
       });
+    },
+  );
+}
+
+function registerListLinks(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "list_links",
+    {
+      title: "List Direct Device Links",
+      description:
+        "List direct device links (Direktverknüpfungen) — sender→receiver channel pairings that operate " +
+        "independently of the CCU (e.g. a wall switch directly driving a lamp, or thermostats linked to a " +
+        "FALMOT). Read-only. Optionally filter to links involving a specific device or channel address.",
+      inputSchema: {
+        address: z.string().optional().describe("Device or channel address to filter by (e.g. '000A1BE9A71F15' or '000A1BE9A71F15:1')"),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) => {
+      const { session, rateLimiter, logger } = deps;
+      const start = Date.now();
+
+      try {
+        // Channel address → name map; SENDER/RECEIVER from getLinks are channel addresses.
+        await rateLimiter.acquire();
+        const devices = await withRetry(
+          () => session.call("Device.listAllDetail"),
+          "Device.listAllDetail",
+          logger,
+        ) as CcuDevice[];
+        deps.resolver.updateDeviceList(devices);
+        const channelName = new Map<string, string>();
+        for (const d of devices) for (const ch of d.channels) channelName.set(ch.address, ch.name);
+
+        // Auto-iterate all interfaces (BidCos-RF, HmIP-RF, …) like the cache warmer.
+        await rateLimiter.acquire();
+        const interfaces = await withRetry(
+          () => session.call("Interface.listInterfaces"),
+          "Interface.listInterfaces",
+          logger,
+        ) as Array<{ name: string }>;
+
+        // Match a channel address against the filter: exact channel, or any
+        // channel of the given device address (so a device-level filter works).
+        const matchesAddr = (chAddr: string): boolean => {
+          if (!args.address) return true;
+          return chAddr === args.address || chAddr.split(":")[0] === args.address;
+        };
+
+        const links: Array<Record<string, unknown>> = [];
+        for (const iface of interfaces) {
+          let raw: unknown;
+          try {
+            await rateLimiter.acquire();
+            raw = await withRetry(
+              () => session.call("Interface.getLinks", { interface: iface.name, address: args.address ?? "", flags: 0 }),
+              "Interface.getLinks",
+              logger,
+            );
+          } catch {
+            continue; // interface doesn't expose getLinks
+          }
+          if (!Array.isArray(raw)) continue;
+
+          for (const l of raw as Array<Record<string, unknown>>) {
+            const sender = String(l.SENDER ?? "");
+            const receiver = String(l.RECEIVER ?? "");
+            // Re-filter client-side in case the interface ignores the address arg.
+            if (!matchesAddr(sender) && !matchesAddr(receiver)) continue;
+            links.push({
+              sender,
+              senderName: channelName.get(sender) ?? "",
+              receiver,
+              receiverName: channelName.get(receiver) ?? "",
+              name: l.NAME ?? "",
+              description: l.DESCRIPTION ?? "",
+              flags: l.FLAGS ?? 0,
+              interface: iface.name,
+            });
+          }
+        }
+
+        logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "ok", links: links.length });
+        return toolResult(links);
+      } catch (err) {
+        logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "error" });
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
     },
   );
 }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -45,7 +45,7 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 - \`run_script\` executes arbitrary HomeMatic Script for anything tools don't cover
 
 ## Available Tools
-**Discovery:** list_devices, list_interfaces, list_rooms, list_functions, list_programs, list_system_variables, describe_device_type
+**Discovery:** list_devices, list_interfaces, list_rooms, list_functions, list_programs, list_system_variables, list_links, describe_device_type
 **Read:** get_value, get_values, get_paramset
 **Control:** set_value, put_paramset, set_system_variable, execute_program
 **Diagnostics:** get_service_messages, acknowledge_service_messages, get_rssi, get_system_info
@@ -82,6 +82,11 @@ Returns: Array of variables with id, name, value, type, min, max`,
   describe_device_type: `Get channel/datapoint schema for a device type (from cache).
 Args: deviceType (string, e.g. "HmIP-eTRV-2")
 Returns: Channels with paramsets, datapoint types, ranges, operations`,
+
+  list_links: `List direct device links (Direktverknüpfungen) — sender→receiver channel pairings that work without the CCU.
+Args: address? (device or channel address filter, e.g. "000A1BE9A71F15" or "000A1BE9A71F15:1")
+Returns: Array of {sender, senderName, receiver, receiverName, name, description, flags, interface}
+Read-only; answers "what directly controls this?". Link creation/removal is out of scope.`,
 
   get_value: `Read a single datapoint value.
 Args: address (string), valueKey (string), interface? (auto-resolved)

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -48,7 +48,7 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 **Discovery:** list_devices, list_interfaces, list_rooms, list_functions, list_programs, list_system_variables, describe_device_type
 **Read:** get_value, get_values, get_paramset
 **Control:** set_value, put_paramset, set_system_variable, execute_program
-**Diagnostics:** get_service_messages, acknowledge_service_messages, get_system_info
+**Diagnostics:** get_service_messages, acknowledge_service_messages, get_rssi, get_system_info
 **Meta:** help, run_script
 `;
 
@@ -130,6 +130,11 @@ NOT_FOUND if no active message matches; the warning reappears if its condition p
   get_system_info: `Get CCU system info: firmware, serial, addresses, cache status.
 Args: none
 Returns: {version, serial, address, hmipAddress, cacheTypes, cacheWarming}`,
+
+  get_rssi: `Radio link quality (RSSI, dBm) per device, plus BidCos interface health.
+Args: name (optional substring filter on device name/address)
+Returns: {devices: [{address, name, interface, links: [{peer, peerName, rssiDevice, rssiPeer}]}], interfaces}
+rssiDevice/rssiPeer are dBm (higher = better); null means no measurement. Use to diagnose flaky devices.`,
 
   run_script: `Execute arbitrary HomeMatic Script. NOT idempotent — never auto-retried.
 Args: script (string)

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -130,7 +130,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, sid);
     expect(res.status).toBe(200);
     const msg = await parseSse(res);
-    expect(msg.result.tools.length).toBe(20);
+    expect(msg.result.tools.length).toBe(21);
   });
 
   it("returns a structured tool error (not a crash) when a tool needs the CCU", async () => {
@@ -220,7 +220,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
       const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: i, method: "tools/list", params: {} }, sid);
       expect(res.status).toBe(200);
       const msg = await parseSse(res);
-      expect(msg.result.tools.length).toBe(20);
+      expect(msg.result.tools.length).toBe(21);
     }
   });
 

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -130,7 +130,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, sid);
     expect(res.status).toBe(200);
     const msg = await parseSse(res);
-    expect(msg.result.tools.length).toBe(19);
+    expect(msg.result.tools.length).toBe(20);
   });
 
   it("returns a structured tool error (not a crash) when a tool needs the CCU", async () => {
@@ -220,7 +220,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
       const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: i, method: "tools/list", params: {} }, sid);
       expect(res.status).toBe(200);
       const msg = await parseSse(res);
-      expect(msg.result.tools.length).toBe(19);
+      expect(msg.result.tools.length).toBe(20);
     }
   });
 

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -125,4 +125,26 @@ describeIf("MCP tools against live CCU", () => {
     expect(result.isError).toBe(true);
     expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
   }, 30_000);
+
+  it("get_rssi returns devices with plausible dBm RSSI values (live)", async () => {
+    const result = parseToolResult(await callTool(server, "get_rssi")) as {
+      devices: Array<{ address: string; links: Array<{ rssiDevice: number | null; rssiPeer: number | null }> }>;
+      interfaces: unknown;
+    };
+    expect(Array.isArray(result.devices)).toBe(true);
+
+    for (const d of result.devices) {
+      expect(typeof d.address).toBe("string");
+      for (const link of d.links) {
+        for (const v of [link.rssiDevice, link.rssiPeer]) {
+          if (v !== null) {
+            // dBm: never the 65536 sentinel, within a physically plausible range
+            expect(v).not.toBe(65536);
+            expect(v).toBeGreaterThan(-130);
+            expect(v).toBeLessThan(0);
+          }
+        }
+      }
+    }
+  }, 60_000);
 });

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -147,4 +147,25 @@ describeIf("MCP tools against live CCU", () => {
       }
     }
   }, 60_000);
+
+  it("list_links returns well-formed links (live; production CCU has thermostat↔FALMOT links)", async () => {
+    const links = parseToolResult(await callTool(server, "list_links")) as Array<{
+      sender: string; receiver: string; senderName: string; receiverName: string; interface: string;
+    }>;
+    expect(Array.isArray(links)).toBe(true);
+    for (const l of links) {
+      expect(typeof l.sender).toBe("string");
+      expect(typeof l.receiver).toBe("string");
+      expect(l.sender).not.toBe("");
+      expect(l.receiver).not.toBe("");
+    }
+    // Filtering by a sender's device returns a subset that all involve that device.
+    if (links.length > 0) {
+      const dev = links[0]!.sender.split(":")[0]!;
+      const filtered = parseToolResult(await callTool(server, "list_links", { address: dev })) as Array<{ sender: string; receiver: string }>;
+      for (const l of filtered) {
+        expect(l.sender.split(":")[0] === dev || l.receiver.split(":")[0] === dev).toBe(true);
+      }
+    }
+  }, 60_000);
 });

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -60,6 +60,7 @@ describe("MCP Server Registration", () => {
       "list_devices",
       "list_functions",
       "list_interfaces",
+      "list_links",
       "list_programs",
       "list_rooms",
       "list_system_variables",
@@ -69,7 +70,7 @@ describe("MCP Server Registration", () => {
       "set_value",
     ]);
 
-    expect(Object.keys(tools).length).toBe(20);
+    expect(Object.keys(tools).length).toBe(21);
     deps.rateLimiter.destroy();
   });
 
@@ -122,7 +123,7 @@ describe("Tool annotations", () => {
   const READ_TOOLS = [
     "describe_device_type", "get_paramset", "get_service_messages", "get_system_info",
     "get_rssi", "get_value", "get_values", "help", "list_devices", "list_functions",
-    "list_interfaces", "list_programs", "list_rooms", "list_system_variables",
+    "list_interfaces", "list_links", "list_programs", "list_rooms", "list_system_variables",
   ];
   const WRITE_TOOLS = ["acknowledge_service_messages", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
   const IDEMPOTENT_WRITES = ["acknowledge_service_messages", "put_paramset", "set_system_variable", "set_value"];

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -51,6 +51,7 @@ describe("MCP Server Registration", () => {
       "describe_device_type",
       "execute_program",
       "get_paramset",
+      "get_rssi",
       "get_service_messages",
       "get_system_info",
       "get_value",
@@ -68,7 +69,7 @@ describe("MCP Server Registration", () => {
       "set_value",
     ]);
 
-    expect(Object.keys(tools).length).toBe(19);
+    expect(Object.keys(tools).length).toBe(20);
     deps.rateLimiter.destroy();
   });
 
@@ -120,7 +121,7 @@ describe("MCP Server Registration", () => {
 describe("Tool annotations", () => {
   const READ_TOOLS = [
     "describe_device_type", "get_paramset", "get_service_messages", "get_system_info",
-    "get_value", "get_values", "help", "list_devices", "list_functions",
+    "get_rssi", "get_value", "get_values", "help", "list_devices", "list_functions",
     "list_interfaces", "list_programs", "list_rooms", "list_system_variables",
   ];
   const WRITE_TOOLS = ["acknowledge_service_messages", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -120,6 +120,79 @@ describe("acknowledge_service_messages handler", () => {
   });
 });
 
+describe("get_rssi handler", () => {
+  const rssiMock = () =>
+    vi.fn().mockImplementation(async (method: string, params?: any) => {
+      switch (method) {
+        case "Device.listAllDetail":
+          return [
+            { id: "1", name: "Thermostat Büro", address: "ABC123", interface: "HmIP-RF", type: "HmIP-eTRV", channels: [] },
+            { id: "2", name: "Fenster Küche", address: "DEF456", interface: "BidCos-RF", type: "HM-SWDO", channels: [] },
+          ];
+        case "Interface.listInterfaces":
+          return [{ name: "HmIP-RF" }, { name: "BidCos-RF" }, { name: "VirtualDevices" }];
+        case "Interface.rssiInfo":
+          if (params?.interface === "VirtualDevices") throw new Error("rssiInfo not supported");
+          if (params?.interface === "HmIP-RF") return { ABC123: { "HmIP-RF": [-65, -70] } };
+          if (params?.interface === "BidCos-RF") return { DEF456: { "BidCoS-RF": [65536, -80] } };
+          return {};
+        case "Interface.listBidcosInterfaces":
+          return [{ ADDRESS: "OEQ0123456", DUTY_CYCLE: 12, CONNECTED: true }];
+        default:
+          return null;
+      }
+    });
+
+  it("reports per-device RSSI (dBm) resolved to names, normalizing 65536 → null", async () => {
+    const { server, deps } = createTestServer({ sessionCall: rssiMock() });
+    const result = parseToolResult(await callTool(server, "get_rssi")) as any;
+
+    const byAddr = Object.fromEntries(result.devices.map((d: any) => [d.address, d]));
+    expect(byAddr.ABC123.name).toBe("Thermostat Büro");
+    expect(byAddr.ABC123.links[0].rssiDevice).toBe(-65);
+    expect(byAddr.ABC123.links[0].rssiPeer).toBe(-70);
+    // 65536 sentinel normalized to null; the other direction kept
+    expect(byAddr.DEF456.links[0].rssiDevice).toBeNull();
+    expect(byAddr.DEF456.links[0].rssiPeer).toBe(-80);
+    cleanupDeps(deps);
+  });
+
+  it("includes BidCos interface health (duty cycle, connected)", async () => {
+    const { server, deps } = createTestServer({ sessionCall: rssiMock() });
+    const result = parseToolResult(await callTool(server, "get_rssi")) as any;
+    expect(result.interfaces[0].DUTY_CYCLE).toBe(12);
+    expect(result.interfaces[0].CONNECTED).toBe(true);
+    cleanupDeps(deps);
+  });
+
+  it("filters by device name/address substring", async () => {
+    const { server, deps } = createTestServer({ sessionCall: rssiMock() });
+    const result = parseToolResult(await callTool(server, "get_rssi", { name: "küche" })) as any;
+    expect(result.devices).toHaveLength(1);
+    expect(result.devices[0].address).toBe("DEF456");
+    cleanupDeps(deps);
+  });
+
+  it("tolerates interfaces that don't support rssiInfo (e.g. VirtualDevices)", async () => {
+    const { server, deps } = createTestServer({ sessionCall: rssiMock() });
+    const result = parseToolResult(await callTool(server, "get_rssi")) as any;
+    expect(result.devices).toHaveLength(2); // both RF devices present despite VirtualDevices throwing
+    cleanupDeps(deps);
+  });
+
+  it("tolerates listBidcosInterfaces failure (returns empty interfaces)", async () => {
+    const base = rssiMock().getMockImplementation()!;
+    const sessionCall = vi.fn().mockImplementation(async (method: string, params?: any) => {
+      if (method === "Interface.listBidcosInterfaces") throw new Error("unsupported");
+      return base(method, params);
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const result = parseToolResult(await callTool(server, "get_rssi")) as any;
+    expect(result.interfaces).toEqual([]);
+    cleanupDeps(deps);
+  });
+});
+
 describe("get_system_info handler", () => {
   it("returns all system info fields", async () => {
     const { server, deps } = createTestServer({

--- a/test/unit/tools-discovery.test.ts
+++ b/test/unit/tools-discovery.test.ts
@@ -215,3 +215,56 @@ describe("list_devices error path (coverage round)", () => {
     cleanupDeps(deps);
   });
 });
+
+describe("list_links handler", () => {
+  const linksMock = () =>
+    vi.fn().mockImplementation(async (method: string, params?: any) => {
+      switch (method) {
+        case "Device.listAllDetail":
+          return [
+            { id: "1", name: "Wandtaster", address: "AAA", interface: "HmIP-RF", type: "x", operateGroupOnly: "false", isReady: "true",
+              channels: [{ id: "11", name: "Taste Oben", address: "AAA:1", deviceId: "1", index: 1 }] },
+            { id: "2", name: "Deckenlampe", address: "BBB", interface: "HmIP-RF", type: "y", operateGroupOnly: "false", isReady: "true",
+              channels: [{ id: "21", name: "Licht", address: "BBB:3", deviceId: "2", index: 3 }] },
+          ];
+        case "Interface.listInterfaces":
+          return [{ name: "HmIP-RF" }, { name: "VirtualDevices" }];
+        case "Interface.getLinks":
+          if (params?.interface === "VirtualDevices") throw new Error("getLinks not supported");
+          return [{ SENDER: "AAA:1", RECEIVER: "BBB:3", NAME: "Taster→Licht", DESCRIPTION: "", FLAGS: 0 }];
+        default:
+          return null;
+      }
+    });
+
+  it("lists links with sender/receiver channel names resolved", async () => {
+    const { server, deps } = createTestServer({ sessionCall: linksMock() });
+    const result = parseToolResult(await callTool(server, "list_links")) as any[];
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sender).toBe("AAA:1");
+    expect(result[0].senderName).toBe("Taste Oben");
+    expect(result[0].receiver).toBe("BBB:3");
+    expect(result[0].receiverName).toBe("Licht");
+    expect(result[0].interface).toBe("HmIP-RF");
+    cleanupDeps(deps);
+  });
+
+  it("filters by device address (matches either endpoint)", async () => {
+    const { server, deps } = createTestServer({ sessionCall: linksMock() });
+    const hit = parseToolResult(await callTool(server, "list_links", { address: "BBB" })) as any[];
+    expect(hit).toHaveLength(1);
+
+    const miss = parseToolResult(await callTool(server, "list_links", { address: "ZZZ" })) as any[];
+    expect(miss).toHaveLength(0);
+    cleanupDeps(deps);
+  });
+
+  it("tolerates interfaces that don't support getLinks", async () => {
+    const { server, deps } = createTestServer({ sessionCall: linksMock() });
+    // VirtualDevices.getLinks throws; the HmIP-RF link still comes back
+    const result = parseToolResult(await callTool(server, "list_links")) as any[];
+    expect(result).toHaveLength(1);
+    cleanupDeps(deps);
+  });
+});


### PR DESCRIPTION
Closes #23. **Stacked on #42** (base = `feature/rssi-diagnostics`); retargets to `dev` as the stack merges.

## What
New read-only `list_links` tool exposing direct device links (Direktverknüpfungen) — sender→receiver channel pairings that operate without the CCU (wall switch → lamp, thermostats → FALMOT). Previously invisible (not reachable via `run_script`/ReGa).

- Auto-iterates **all interfaces** (`Interface.listInterfaces` → `Interface.getLinks` per interface), like the cache warmer.
- Resolves `SENDER`/`RECEIVER` channel addresses to **names** from the device list.
- Optional `address` filter — device- or channel-level, matching either endpoint.
- Read-only by design; `addLink`/`removeLink` explicitly out of scope.
- `getLinks` already returns `NAME`/`DESCRIPTION`, so `getLinkInfo`/`getLinkPeers` enrichment wasn't needed.

## Tests
- Unit: name resolution across endpoints, address filter (hit + miss), and tolerance for an interface that doesn't support `getLinks`.
- Live: asserts well-formed links and that filtering by a device returns only links involving it (the production CCU has real links).
- Help text, README tool list (20→21), registration/annotation tests updated.

Full suite green (255 passed); lint clean.