### PR TITLE
Support browser clients via a configurable origin allowlist (default-deny)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ curl http://localhost:3000/health
 
 #### Browser-based clients (CORS)
 
-By default the HTTP server sends **no** CORS headers, so a random web page can't drive a local instance. To let a browser-based MCP client like [MCP Inspector](https://github.com/modelcontextprotocol/inspector) connect directly, set `MCP_CORS_ALLOW_ORIGIN` — `*` for local dev, or a single trusted origin (e.g. `https://inspector.example`). Authentication is always enforced regardless: every MCP request needs the bearer token.
+By default the HTTP server sends **no** CORS headers, so a random web page can't drive a local instance. To let browser-based MCP clients like [MCP Inspector](https://github.com/modelcontextprotocol/inspector) connect directly, set `MCP_ALLOWED_ORIGINS` to a comma-separated allowlist of trusted origins (e.g. `https://app.example,http://localhost:6274`). A request whose `Origin` is on the list gets that **exact** origin reflected in `Access-Control-Allow-Origin` — never the wildcard `*`, which would let any site drive a local instance that controls real CCU hardware. A request from any other origin gets no CORS headers (the browser blocks it) and is rejected server-side by DNS-rebinding protection. Authentication is always enforced regardless: every MCP request needs the bearer token.
 
 The HTTP transport also has **DNS-rebinding protection** on by default: it rejects requests whose `Host` header isn't `localhost`/`127.0.0.1` on the configured port. If you reach the server under another hostname (reverse proxy, container DNS name), list those hosts in `MCP_ALLOWED_HOSTS` or legitimate requests get a `403`.
 
@@ -170,7 +170,7 @@ All configuration is via environment variables:
 | `MCP_TRANSPORT` | `http` | `http` or `stdio` (the `--stdio` CLI flag overrides this) |
 | `MCP_PORT` | `3000` | HTTP server port (HTTP mode only) |
 | `MCP_AUTH_TOKEN` | auto-generated | Bearer token for HTTP mode; generated and saved to `$CACHE_DIR/.env` on first start |
-| `MCP_CORS_ALLOW_ORIGIN` | unset | CORS `Access-Control-Allow-Origin` for browser clients. Unset = no CORS (default-deny). Use `*` for dev/MCP Inspector, or one trusted origin |
+| `MCP_ALLOWED_ORIGINS` | unset | Comma-separated allowlist of browser origins. Unset = no cross-origin browser access (default-deny). An allowlisted origin is reflected exactly in `Access-Control-Allow-Origin` (never `*`); the list also drives DNS-rebinding origin checks |
 | `MCP_ALLOWED_HOSTS` | `localhost`/`127.0.0.1` | Extra `Host` values accepted by DNS-rebinding protection (comma-separated `host:port`); add your hostname when behind a proxy or container DNS name |
 | `CCU_RATE_LIMIT_BURST` | `20` | Max burst of requests sent to the CCU |
 | `CCU_RATE_LIMIT_RATE` | `10` | Sustained CCU requests per second |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # - MCP_TRANSPORT=http
       # - MCP_PORT=3000
       # - MCP_AUTH_TOKEN=           # auto-generated if unset
-      # - MCP_CORS_ALLOW_ORIGIN=*   # unset = no CORS (default-deny); '*' for dev/MCP Inspector, or one trusted origin
+      # - MCP_ALLOWED_ORIGINS=      # comma-separated browser origin allowlist; unset = no cross-origin browser access (default-deny). Exact origin reflected, never '*'
       # - MCP_ALLOWED_HOSTS=        # extra Host values for DNS-rebinding protection (comma-separated host:port)
 
       # === Cache (optional) ===

--- a/server.json
+++ b/server.json
@@ -61,8 +61,8 @@
           "format": "string"
         },
         {
-          "name": "MCP_CORS_ALLOW_ORIGIN",
-          "description": "CORS Access-Control-Allow-Origin for browser clients. Unset = no CORS (default-deny); use '*' for dev/MCP Inspector or a single trusted origin",
+          "name": "MCP_ALLOWED_ORIGINS",
+          "description": "Comma-separated allowlist of browser origins. Unset = no cross-origin browser access (default-deny). An allowlisted origin is reflected exactly in Access-Control-Allow-Origin (never '*'); the list also drives DNS-rebinding origin checks",
           "format": "string"
         },
         {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,11 +7,15 @@ export interface AppConfig {
     port: number;
     authToken?: string;
     /**
-     * Value echoed in `Access-Control-Allow-Origin`. Unset ⇒ no CORS header is
-     * sent (browsers are blocked by default). Set `MCP_CORS_ALLOW_ORIGIN=*` for
-     * local dev / MCP Inspector, or a single trusted origin.
+     * Default-deny origin allowlist for browser-based MCP clients. Empty ⇒ no
+     * cross-origin browser access (the secure default). A request whose `Origin`
+     * is on this list gets that exact origin reflected in
+     * `Access-Control-Allow-Origin` (never `*`); the same list drives the
+     * transport's DNS-rebinding `allowedOrigins` so CORS and rebinding
+     * protection can't drift apart. Set via `MCP_ALLOWED_ORIGINS`
+     * (comma-separated, e.g. `https://app.example,http://localhost:6274`).
      */
-    corsAllowOrigin?: string;
+    allowedOrigins: string[];
     /**
      * Host-header allowlist for the StreamableHTTP transport's DNS-rebinding
      * protection. Defaults to localhost/127.0.0.1 on the MCP port; extend via
@@ -69,6 +73,14 @@ export function loadConfig(): AppConfig {
       .filter(Boolean),
   ];
 
+  // Default-deny browser origin allowlist. Empty unless MCP_ALLOWED_ORIGINS is
+  // set; it feeds both the reflective CORS headers and the transport's
+  // DNS-rebinding Origin check (single source of truth).
+  const allowedOrigins = (process.env.MCP_ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
   return {
     ccu: {
       host,
@@ -84,7 +96,7 @@ export function loadConfig(): AppConfig {
       transport,
       port: mcpPort,
       authToken: process.env.MCP_AUTH_TOKEN,
-      corsAllowOrigin: process.env.MCP_CORS_ALLOW_ORIGIN || undefined,
+      allowedOrigins,
       allowedHosts,
     },
     cache: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,16 +82,24 @@ async function main(): Promise<void> {
     httpServer = createServer(async (req, res) => {
       try {
         // CORS so browser-based MCP clients (e.g. MCP Inspector) can connect
-        // directly. Opt-in only: a cross-origin browser is allowed solely when
-        // MCP_CORS_ALLOW_ORIGIN is configured (`*` for dev, or one trusted
-        // origin). Default is no CORS header at all, so a random web page can't
-        // reach a local instance. DNS-rebinding protection on the transport
-        // (allowedHosts, below) is the matching Host-header defense. Auth is
-        // still enforced via the bearer token regardless.
+        // directly. Default-deny against a configurable origin allowlist
+        // (MCP_ALLOWED_ORIGINS): a cross-origin browser is allowed solely when
+        // its Origin is on the list, and we reflect that exact origin back —
+        // never `*`, which would let any web page drive a local instance that
+        // controls real CCU hardware (the DNS-rebinding vector). With the list
+        // empty (the default) no CORS headers are sent at all. The same list
+        // also feeds the transport's DNS-rebinding `allowedOrigins` (below), so
+        // a disallowed origin is rejected server-side too. Auth is still
+        // enforced via the bearer token regardless.
         // CORS first implemented by @marcinn2 (marcinn2/debmatic-mcp@d33a0cb).
-        const corsOrigin = config.mcp.corsAllowOrigin;
-        if (corsOrigin) {
-          res.setHeader("Access-Control-Allow-Origin", corsOrigin);
+        const requestOrigin = req.headers.origin;
+        const originAllowed =
+          typeof requestOrigin === "string" && config.mcp.allowedOrigins.includes(requestOrigin);
+        if (originAllowed) {
+          // Reflect the exact origin (never `*`); Vary so shared caches don't
+          // serve this response to a different origin.
+          res.setHeader("Access-Control-Allow-Origin", requestOrigin);
+          res.setHeader("Vary", "Origin");
           res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
           res.setHeader(
             "Access-Control-Allow-Headers",
@@ -99,13 +107,13 @@ async function main(): Promise<void> {
           );
           res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
           res.setHeader("Access-Control-Max-Age", "86400");
-          // A specific origin makes the response vary by Origin; mark it so
-          // shared caches don't serve it to a different origin.
-          if (corsOrigin !== "*") res.setHeader("Vary", "Origin");
         }
 
         if (req.method === "OPTIONS") {
-          res.writeHead(204);
+          // Preflight succeeds (204, with the CORS headers above) only for an
+          // allowed origin; anything else gets 403 and no allow headers, so the
+          // browser blocks the actual request.
+          res.writeHead(originAllowed ? 204 : 403);
           res.end();
           return;
         }
@@ -153,8 +161,14 @@ async function main(): Promise<void> {
           // Defense-in-depth against DNS rebinding: reject requests whose Host
           // header isn't an expected one (a browser tricked into hitting a
           // local instance carries the attacker's host, not localhost:port).
+          // allowedOrigins mirrors the CORS allowlist so a browser request with
+          // a disallowed Origin is also rejected server-side; an empty list
+          // disables the Origin check (the SDK only enforces it when non-empty,
+          // and only when an Origin header is present — non-browser clients that
+          // send no Origin are unaffected).
           enableDnsRebindingProtection: true,
           allowedHosts: config.mcp.allowedHosts,
+          allowedOrigins: config.mcp.allowedOrigins,
           onsessioninitialized: (sid) => {
             sessions.set(sid, { server: sessionServer, transport });
             logger.info("mcp_session_started", { sessions: sessions.size });

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -13,6 +13,8 @@ import { AddressInfo } from "node:net";
 
 const DIST = join(__dirname, "../../dist/index.js");
 const AUTH_TOKEN = "e2e-test-token";
+// Origin on the allowlist for the CORS-enabled describe block below.
+const ALLOWED_ORIGIN = "http://localhost:6274";
 
 function startCcuMock(): Promise<{ server: Server; port: number }> {
   const server = createServer((req, res) => {
@@ -166,10 +168,10 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
         MCP_TRANSPORT: "http",
         MCP_PORT: String(mcpPort),
         MCP_AUTH_TOKEN: AUTH_TOKEN,
-        // This block exercises the dev/MCP-Inspector configuration: wildcard
-        // CORS is opt-in (issue #28). The secure-defaults block below covers
-        // the unset (default-deny) behavior.
-        MCP_CORS_ALLOW_ORIGIN: "*",
+        // This block exercises the browser-client configuration (issue #37):
+        // a single trusted origin is allowlisted. The secure-defaults block
+        // below covers the unset (default-deny) behavior.
+        MCP_ALLOWED_ORIGINS: ALLOWED_ORIGIN,
         CACHE_DIR: cacheDir,
         RESOURCE_POLL_INTERVAL: "3600",
         LOG_LEVEL: "error",
@@ -268,41 +270,82 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
     expect(res.status).toBeGreaterThanOrEqual(400);
   });
 
-  // CORS (issue #19, credit @marcinn2): browser clients need preflight + exposed session header
-  it("answers OPTIONS preflight with 204 and CORS headers, without auth", async () => {
+  // CORS (issue #37, building on #19/@marcinn2): an allowlisted browser origin
+  // gets preflight + the exact origin reflected back — never `*`.
+  it("answers OPTIONS preflight from an allowed origin with 204 and reflects the exact origin", async () => {
     const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
       method: "OPTIONS",
       headers: {
-        "Origin": "http://localhost:6274",
+        "Origin": ALLOWED_ORIGIN,
         "Access-Control-Request-Method": "POST",
         "Access-Control-Request-Headers": "content-type, authorization, mcp-session-id",
       },
     });
     expect(res.status).toBe(204);
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
+    expect(res.headers.get("vary")).toContain("Origin");
     expect(res.headers.get("access-control-allow-methods")).toContain("POST");
     expect(res.headers.get("access-control-allow-headers")?.toLowerCase()).toContain("mcp-session-id");
   });
 
-  it("sets CORS headers on MCP responses and exposes Mcp-Session-Id", async () => {
-    const res = await mcpPost(mcpPort, {
-      jsonrpc: "2.0", id: 0, method: "initialize",
-      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "cors", version: "1" } },
+  it("rejects an OPTIONS preflight from a disallowed origin (403, no CORS headers)", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "OPTIONS",
+      headers: {
+        "Origin": "http://evil.example",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+    expect(res.status).toBe(403);
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("reflects the allowed origin on MCP responses and exposes Mcp-Session-Id", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "POST",
+      headers: {
+        "Origin": ALLOWED_ORIGIN,
+        "Authorization": `Bearer ${AUTH_TOKEN}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "mcp-protocol-version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 0, method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "cors", version: "1" } },
+      }),
     });
     expect(res.status).toBe(200);
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
     expect(res.headers.get("access-control-expose-headers")?.toLowerCase()).toContain("mcp-session-id");
     await res.text();
   });
 
-  it("sets CORS headers on 401 responses too", async () => {
+  it("omits CORS headers for a disallowed origin even when another is allowlisted", async () => {
     const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "Accept": "application/json, text/event-stream" },
+      headers: {
+        "Origin": "http://evil.example",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("reflects the allowed origin on 401 responses too", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "POST",
+      headers: {
+        "Origin": ALLOWED_ORIGIN,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+      },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
     });
     expect(res.status).toBe(401);
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
   });
 
   // Must be last: terminates the server and asserts a clean exit
@@ -379,7 +422,7 @@ describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebin
         MCP_TRANSPORT: "http",
         MCP_PORT: String(mcpPort),
         MCP_AUTH_TOKEN: AUTH_TOKEN,
-        // MCP_CORS_ALLOW_ORIGIN deliberately unset → default-deny CORS.
+        // MCP_ALLOWED_ORIGINS deliberately unset → default-deny CORS.
         CACHE_DIR: cacheDir,
         RESOURCE_POLL_INTERVAL: "3600",
         LOG_LEVEL: "error",

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -44,7 +44,7 @@ describeIf("MCP tools against live CCU", () => {
     deps = {
       config: {
         ccu: config,
-        mcp: { transport: "stdio", port: 3000, allowedHosts: [] },
+        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [] },
         cache: { dir: tempDir, ttl: 86400 },
         rateLimiter: { burst: 20, rate: 10 },
         resourcePollInterval: 3600,

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -13,7 +13,7 @@ export function createMockDeps(overrides?: {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedHosts: [] },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [] },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -17,7 +17,7 @@ describe("loadConfig", () => {
     delete process.env.MCP_TRANSPORT;
     delete process.env.MCP_PORT;
     delete process.env.MCP_AUTH_TOKEN;
-    delete process.env.MCP_CORS_ALLOW_ORIGIN;
+    delete process.env.MCP_ALLOWED_ORIGINS;
     delete process.env.MCP_ALLOWED_HOSTS;
     delete process.env.CACHE_DIR;
     delete process.env.CACHE_TTL;
@@ -152,17 +152,21 @@ describe("loadConfig", () => {
     expect(() => loadConfig()).toThrow(/RESOURCE_POLL_INTERVAL must be a positive number/);
   });
 
-  // Issue #28: HTTP transport hardening
-  it("CORS is default-deny: corsAllowOrigin is undefined unless configured", () => {
+  // Issue #28 / #37: HTTP transport hardening
+  it("origin allowlist is default-deny: allowedOrigins is empty unless configured", () => {
     process.env.CCU_HOST = "test";
     process.env.CCU_PASSWORD = "pw";
-    expect(loadConfig().mcp.corsAllowOrigin).toBeUndefined();
+    expect(loadConfig().mcp.allowedOrigins).toEqual([]);
+  });
 
-    process.env.MCP_CORS_ALLOW_ORIGIN = "*";
-    expect(loadConfig().mcp.corsAllowOrigin).toBe("*");
-
-    process.env.MCP_CORS_ALLOW_ORIGIN = "https://app.example";
-    expect(loadConfig().mcp.corsAllowOrigin).toBe("https://app.example");
+  it("MCP_ALLOWED_ORIGINS parses a comma-separated allowlist (trimmed, no blanks)", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_ALLOWED_ORIGINS = "https://app.example, , http://localhost:6274 ";
+    expect(loadConfig().mcp.allowedOrigins).toEqual([
+      "https://app.example",
+      "http://localhost:6274",
+    ]);
   });
 
   it("allowedHosts defaults to localhost/127.0.0.1 on the MCP port", () => {

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -10,7 +10,7 @@ function createMockDeps() {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedHosts: [] },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [] },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 20, rate: 10 },
       resourcePollInterval: 60,


### PR DESCRIPTION
Closes #37. Builds on #28 (DNS-rebinding/CORS hardening).

## What

Replaces the unreleased, wildcard-capable `MCP_CORS_ALLOW_ORIGIN` with **`MCP_ALLOWED_ORIGINS`** — a comma-separated, default-deny origin allowlist that drives **both** the CORS response headers and the transport's DNS-rebinding origin check from a single source of truth.

## Behaviour

- **Default (unset):** no cross-origin browser access; DNS-rebinding protection on — matches #28.
- **Allowlisted origin:** the exact `Origin` is reflected in `Access-Control-Allow-Origin` (never `*`), with `Vary: Origin`, the MCP method/header allowances, and `Mcp-Session-Id` exposed. `OPTIONS` preflight returns `204` only for allowed origins.
- **Disallowed origin:** no CORS allow headers (browser blocks it); preflight gets `403`; the request is also rejected server-side via the transport's `allowedOrigins`.
- **Non-browser clients** (stdio, server-to-server) send no `Origin` and are unaffected — the SDK only enforces the origin check when an `Origin` header is present.

## Docs

README config table + browser-clients section, `docker-compose.yml` comments, and `server.json` `environmentVariables` all updated for the new var.

## Tests

`npm test` green (273 passed). New/updated e2e coverage: allowed origin reflected on preflight/MCP/401 responses, disallowed origin rejected (403 preflight + no headers) even when another origin is allowlisted, and default-deny. Unit tests for `MCP_ALLOWED_ORIGINS` parsing (trim/blank-strip) and default-empty.