### PR TITLE
fix+feat: correct CCU response handling (get_rssi, list_links, create_system_variable) + HmIP RSSI

### DIFF
--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -316,32 +316,33 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
         }
 
         // Create via ReGa (no SysVar.createString exists, and this keeps all four
-        // types on one code path). Modeled exactly on the CCU's own JSON-RPC
-        // method scripts (occu WebUI/www/api/methods/sysvar/create*.tcl): set
-        // ValueType + type-specifics, then oSysVars.Add(sv.ID()) LAST. We add
-        // ValueUnit (float) and DPInfo (description), which those methods don't
-        // expose as parameters. There is no createString method, hence ReGa.
+        // types on one code path). Ordering matters and was verified live: set
+        // ValueType + Name + type-specifics, Add(sv.ID()), and only THEN set
+        // ValueUnit/DPInfo — setting those *before* Add makes the CCU store the
+        // variable under a deduplicated " N" name (silent rename). The script
+        // returns the actual stored name so we never report a name we didn't get.
         const name = escapeHmScript(args.name);
         const info = escapeHmScript(args.description ?? "");
+        const unit = escapeHmScript(args.unit ?? "");
         let typeSetup: string;
         switch (args.type) {
           case "bool":
             typeSetup =
               'sv.ValueType(ivtBinary);\n' +
               'sv.ValueSubType(istBool);\n' +
+              `sv.Name("${name}");\n` +
               'sv.ValueName0("false");\n' +
               'sv.ValueName1("true");\n' +
               'sv.State(false);';
             break;
           case "float": {
-            const unit = escapeHmScript(args.unit ?? "");
             const min = Number.isFinite(args.min) ? args.min : 0;
             const max = Number.isFinite(args.max) ? args.max : 100;
             typeSetup =
               'sv.ValueType(ivtFloat);\n' +
+              `sv.Name("${name}");\n` +
               `sv.ValueMin(${min});\n` +
               `sv.ValueMax(${max});\n` +
-              `sv.ValueUnit("${unit}");\n` +
               'sv.State(0);';
             break;
           }
@@ -350,6 +351,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
             typeSetup =
               'sv.ValueType(ivtInteger);\n' +
               'sv.ValueSubType(istEnum);\n' +
+              `sv.Name("${name}");\n` +
               `sv.ValueList("${list}");\n` +
               'sv.State(0);';
             break;
@@ -358,29 +360,58 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
           default:
             typeSetup =
               'sv.ValueType(ivtString);\n' +
+              `sv.Name("${name}");\n` +
               'sv.State("");';
             break;
         }
 
+        // ValueUnit applies to float only; DPInfo (description) to all. Both go
+        // AFTER Add (see comment above).
+        const postAdd =
+          (args.type === "float" ? `sv.ValueUnit("${unit}");\n` : "") +
+          `sv.DPInfo("${info}");`;
+
         const script =
           `object oSysVars = dom.GetObject(ID_SYSTEM_VARIABLES);\n` +
           `object sv = dom.CreateObject(OT_VARDP);\n` +
-          `sv.Name("${name}");\n` +
           `${typeSetup}\n` +
-          `sv.DPInfo("${info}");\n` +
           `sv.Internal(false);\n` +
-          `oSysVars.Add(sv.ID());`;
+          `oSysVars.Add(sv.ID());\n` +
+          `${postAdd}\n` +
+          `dom.RTUpdate(false);\n` +
+          `WriteLine(sv.Name());`;
 
         await rateLimiter.acquire();
-        await withRetry(
+        const createResult = await withRetry(
           () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
 
+        // The script echoes the ACTUAL stored name. The CCU silently dedups a
+        // requested name against existing similar names (e.g. "X" becomes "X 1"
+        // when an "X 2" already exists), which the exact-match pre-check above
+        // can't see. If we didn't get the name we asked for, undo it and report
+        // the collision rather than leaving a surprise variable behind.
+        const actualName = typeof createResult === "string" && createResult.trim()
+          ? createResult.trim()
+          : args.name;
+        if (actualName !== args.name) {
+          try {
+            await rateLimiter.acquire();
+            await session.call("SysVar.deleteSysVarByName", { name: actualName });
+          } catch { /* best-effort cleanup of the unintended object */ }
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: `System variable name unavailable: "${args.name}" (the CCU would store it as "${actualName}")`,
+            hint: "Pick a different name — the CCU deduplicates against existing similar names.",
+          });
+        }
+
         typeCacheHolder.entry = null; // new variable must be visible to the next set
         logger.info("tool_call", { tool: "create_system_variable", duration_ms: Date.now() - start, status: "ok", type: args.type });
-        return toolResult({ name: args.name, type: args.type, created: true });
+        return toolResult({ name: actualName, type: args.type, created: true });
       } catch (err) {
         logger.info("tool_call", { tool: "create_system_variable", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -288,11 +288,10 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
     {
       title: "Get RSSI / Radio Quality",
       description:
-        "Report radio link quality (RSSI, in dBm) from Interface.rssiInfo, resolved to device names, " +
-        "plus BidCos interface health (duty cycle, connected state). Use to answer 'why is this " +
-        "sensor flaky?'. Higher (closer to 0) dBm is better; null means no measurement available. " +
-        "Note: rssiInfo covers BidCos-RF; HmIP-RF does not expose it, so pure-HmIP setups return no " +
-        "rssiInfo data (HmIP RSSI lives in per-device RSSI_DEVICE/RSSI_PEER datapoints — not yet read here).",
+        "Report radio link quality (RSSI, in dBm) for every device, resolved to device names, plus " +
+        "BidCos interface health (duty cycle, connected state). Covers both transports: BidCos-RF via " +
+        "Interface.rssiInfo, and HmIP-RF via each device's RSSI_DEVICE/RSSI_PEER maintenance datapoints. " +
+        "Use to answer 'why is this sensor flaky?'. Higher (closer to 0) dBm is better; null = no measurement.",
       inputSchema: {
         name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
       },
@@ -371,6 +370,45 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
             };
             if (needle && !`${entry.address} ${entry.name}`.toLowerCase().includes(needle)) continue;
             deviceEntries.push(entry);
+          }
+        }
+
+        // HmIP devices don't expose rssiInfo; their RSSI lives in the :0
+        // maintenance channel's RSSI_DEVICE / RSSI_PEER datapoints (dBm, negative).
+        // Read the :0 VALUES paramset per HmIP device (one call each — there's no
+        // bulk equivalent) and merge into the same output shape: rssiDevice =
+        // measured by the device, rssiPeer = measured by the peer (AP/CCU), where
+        // present. Values are already dBm; a non-negative reading means "no value".
+        // Interface.getParamset returns raw string values; coerce, and treat
+        // only a negative dBm as a real reading (0/positive/non-numeric = none).
+        const dbm = (v: unknown): number | null => {
+          const n = typeof v === "string" ? Number(v) : v;
+          return typeof n === "number" && Number.isFinite(n) && n < 0 ? n : null;
+        };
+        for (const d of devices) {
+          if (!/hmip/i.test(d.interface)) continue;
+          const maint = d.channels.find((c) => c.address.endsWith(":0"));
+          if (!maint) continue;
+          if (needle && !`${d.address} ${d.name}`.toLowerCase().includes(needle)) continue;
+          try {
+            await rateLimiter.acquire();
+            const vals = await withRetry(
+              () => session.call("Interface.getParamset", { interface: d.interface, address: maint.address, paramsetKey: "VALUES" }),
+              "Interface.getParamset",
+              logger,
+            ) as Record<string, unknown>;
+            const rssiDevice = dbm(vals?.RSSI_DEVICE);
+            const rssiPeer = dbm(vals?.RSSI_PEER);
+            if (rssiDevice === null && rssiPeer === null) continue; // no usable RSSI
+            deviceEntries.push({
+              address: d.address,
+              name: d.name,
+              interface: d.interface,
+              links: [{ peer: d.interface, peerName: "", rssiDevice, rssiPeer }],
+            });
+          } catch {
+            // device unreachable / paramset unreadable — skip, don't fail the call
+            continue;
           }
         }
 

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -288,9 +288,11 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
     {
       title: "Get RSSI / Radio Quality",
       description:
-        "Report radio link quality (RSSI, in dBm) for every device, resolved to device names, " +
+        "Report radio link quality (RSSI, in dBm) from Interface.rssiInfo, resolved to device names, " +
         "plus BidCos interface health (duty cycle, connected state). Use to answer 'why is this " +
-        "sensor flaky?'. Higher (closer to 0) dBm is better; null means no measurement available.",
+        "sensor flaky?'. Higher (closer to 0) dBm is better; null means no measurement available. " +
+        "Note: rssiInfo covers BidCos-RF; HmIP-RF does not expose it, so pure-HmIP setups return no " +
+        "rssiInfo data (HmIP RSSI lives in per-device RSSI_DEVICE/RSSI_PEER datapoints — not yet read here).",
       inputSchema: {
         name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
       },
@@ -317,8 +319,12 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
           ifaceByAddress.set(d.address, d.interface);
         }
 
-        // Enumerate interfaces and pull rssiInfo per interface. rssiInfo maps
-        // device1 → device2 → [rssiAtDevice1, rssiAtDevice2] (dBm; 65536 = none).
+        // Enumerate interfaces and pull rssiInfo per interface. The JSON-RPC
+        // Interface.rssiInfo returns an ARRAY (see occu .../interface/rssiinfo.tcl):
+        //   [{ name: <deviceAddress>, partner: [{ name: <peerAddress>, rssiData: [a, b] }] }]
+        // The `name` fields are device/peer addresses; rssiData values are dBm
+        // (65536 = no measurement). atDevice = received by this device from peer,
+        // atPeer = received by the peer from this device.
         await rateLimiter.acquire();
         const interfaces = await withRetry(
           () => session.call("Interface.listInterfaces"),
@@ -329,30 +335,32 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
         const needle = args.name?.toLowerCase();
         const deviceEntries: Array<Record<string, unknown>> = [];
 
+        type RssiEntry = { name: string; partner?: Array<{ name: string; rssiData?: unknown }> };
         for (const iface of interfaces) {
-          let info: Record<string, Record<string, unknown>> | null = null;
+          let info: RssiEntry[] | null = null;
           try {
             await rateLimiter.acquire();
             info = await withRetry(
               () => session.call("Interface.rssiInfo", { interface: iface.name }),
               "Interface.rssiInfo",
               logger,
-            ) as Record<string, Record<string, unknown>>;
+            ) as RssiEntry[];
           } catch {
             // Interfaces without RF (e.g. VirtualDevices) don't support rssiInfo.
             continue;
           }
-          if (!info || typeof info !== "object") continue;
+          if (!Array.isArray(info)) continue;
 
-          for (const [address, peers] of Object.entries(info)) {
-            if (!peers || typeof peers !== "object") continue;
-            const links = Object.entries(peers).map(([peer, pair]) => {
-              const [atDevice, atPeer] = Array.isArray(pair) ? pair : [];
+          for (const dev of info) {
+            const address = dev?.name ?? "";
+            if (!address) continue;
+            const links = (Array.isArray(dev.partner) ? dev.partner : []).map((p) => {
+              const pair = Array.isArray(p?.rssiData) ? p.rssiData : [];
               return {
-                peer,
-                peerName: nameByAddress.get(peer) ?? "",
-                rssiDevice: normalizeRssi(atDevice), // dBm received by this device from peer
-                rssiPeer: normalizeRssi(atPeer),     // dBm received by the peer from this device
+                peer: p?.name ?? "",
+                peerName: nameByAddress.get(p?.name ?? "") ?? "",
+                rssiDevice: normalizeRssi(pair[0]), // dBm received by this device from peer
+                rssiPeer: normalizeRssi(pair[1]),   // dBm received by the peer from this device
               };
             });
             const entry = {

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -387,8 +387,10 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
           if (!Array.isArray(raw)) continue;
 
           for (const l of raw as Array<Record<string, unknown>>) {
-            const sender = String(l.SENDER ?? "");
-            const receiver = String(l.RECEIVER ?? "");
+            // JSON-RPC getLinks returns lowercase fields (see occu
+            // .../interface/getlinks.tcl): sender, receiver, name, description, flags.
+            const sender = String(l.sender ?? "");
+            const receiver = String(l.receiver ?? "");
             // Re-filter client-side in case the interface ignores the address arg.
             if (!matchesAddr(sender) && !matchesAddr(receiver)) continue;
             links.push({
@@ -396,9 +398,9 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
               senderName: channelName.get(sender) ?? "",
               receiver,
               receiverName: channelName.get(receiver) ?? "",
-              name: l.NAME ?? "",
-              description: l.DESCRIPTION ?? "",
-              flags: l.FLAGS ?? 0,
+              name: l.name ?? "",
+              description: l.description ?? "",
+              flags: l.flags ?? 0,
               interface: iface.name,
             });
           }

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -172,10 +172,14 @@ describeIf("MCP tools against live CCU", () => {
   // Full lifecycle against real ReGa: create → set → read back → delete. Uses a
   // throwaway name and always deletes, so the CCU is left as it was found.
   it("system variable lifecycle: create → set → read → delete (live)", async () => {
-    const name = "debmatic_mcp_test_var";
+    // Unique per run: the CCU keeps hidden VARDP objects for a name even after
+    // deletion, so reusing a fixed name eventually makes create dedup it to
+    // "<name> N". A fresh name each run sidesteps that and keeps the test clean.
+    const name = `debmatic_mcp_test_${Date.now()}`;
     try {
       const created = parseToolResult(await callTool(server, "create_system_variable", { name, type: "float", unit: "°C", min: 0, max: 50 })) as any;
       expect(created.created).toBe(true);
+      expect(created.name).toBe(name); // got the exact requested name, not a deduped one
 
       // Duplicate create is rejected.
       const dup: any = await callTool(server, "create_system_variable", { name, type: "float" });
@@ -203,9 +207,12 @@ describeIf("MCP tools against live CCU", () => {
   // CCU as found. Skips gracefully if the CCU has no rooms/channels to work with.
   it("assign_channel → verify via list_rooms → unassign (live)", async () => {
     const rooms = parseToolResult(await callTool(server, "list_rooms")) as Array<{ id: string; name: string; channelIds: string[] }>;
-    const devices = parseToolResult(await callTool(server, "list_devices")) as Array<{ channels: Array<{ id: string; address: string }> }>;
-    const channel = devices.flatMap((d) => d.channels)[0];
     expect(rooms.length).toBeGreaterThan(0);
+    // Filtered list_devices returns FULL channel objects (with `id`); the
+    // unfiltered/compact form omits `id`, which we need to check room membership.
+    const populated = rooms.find((r) => r.channelIds.length > 0) ?? rooms[0]!;
+    const devices = parseToolResult(await callTool(server, "list_devices", { room: populated.name })) as Array<{ channels: Array<{ id: string; address: string }> }>;
+    const channel = devices.flatMap((d) => d.channels).find((c) => c.id && c.address);
     expect(channel).toBeDefined();
 
     // Pick a room the channel is NOT already in, so the revert is a true revert.

--- a/test/unit/tools-control.test.ts
+++ b/test/unit/tools-control.test.ts
@@ -199,6 +199,27 @@ describe("create_system_variable handler", () => {
     expect(script).toContain("ivtBinary");
     expect(script).toContain("istBool");
     expect(script).toContain('sv.Name("Urlaub")');
+    // ValueUnit/DPInfo (and the verifying WriteLine) come AFTER oSysVars.Add — a
+    // CCU naming quirk renames the variable if they're set before Add.
+    expect(script.indexOf("oSysVars.Add")).toBeLessThan(script.indexOf("WriteLine(sv.Name())"));
+    cleanupDeps(deps);
+  });
+
+  it("rejects a CCU name-dedup (script echoes a suffixed name) and cleans it up", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [];        // exact name looks free…
+      if (method === "ReGa.runScript") return "Urlaub 1"; // …but the CCU deduped it
+      return null;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result: any = await callTool(server, "create_system_variable", { name: "Urlaub", type: "bool" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    // the unintended, dedup'd variable is removed
+    expect(sessionCall.mock.calls.some(
+      (c: unknown[]) => c[0] === "SysVar.deleteSysVarByName" && (c[1] as any)?.name === "Urlaub 1",
+    )).toBe(true);
     cleanupDeps(deps);
   });
 

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -126,17 +126,22 @@ describe("get_rssi handler", () => {
       switch (method) {
         case "Device.listAllDetail":
           return [
-            { id: "1", name: "Thermostat Büro", address: "ABC123", interface: "HmIP-RF", type: "HmIP-eTRV", channels: [] },
+            { id: "1", name: "Thermostat Büro", address: "ABC123", interface: "HmIP-RF", type: "HmIP-eTRV",
+              channels: [{ id: "10", name: "M", address: "ABC123:0", deviceId: "1", index: 0 }] },
             { id: "2", name: "Fenster Küche", address: "DEF456", interface: "BidCos-RF", type: "HM-SWDO", channels: [] },
           ];
         case "Interface.listInterfaces":
           return [{ name: "HmIP-RF" }, { name: "BidCos-RF" }, { name: "VirtualDevices" }];
         case "Interface.rssiInfo":
-          // Real JSON-RPC shape: array of {name: <addr>, partner: [{name: <addr>, rssiData: [a,b]}]}
-          if (params?.interface === "VirtualDevices") throw new Error("rssiInfo not supported");
-          if (params?.interface === "HmIP-RF") return [{ name: "ABC123", partner: [{ name: "HmIP-RF", rssiData: [-65, -70] }] }];
+          // Real JSON-RPC shape: array of {name: <addr>, partner: [{name: <addr>, rssiData: [a,b]}]}.
+          // HmIP-RF and VirtualDevices don't implement rssiInfo on a real CCU → throw.
           if (params?.interface === "BidCos-RF") return [{ name: "DEF456", partner: [{ name: "BidCoS-RF", rssiData: [65536, -80] }] }];
-          return [];
+          throw new Error("rssiInfo not supported");
+        case "Interface.getParamset":
+          // HmIP :0 maintenance channel exposes RSSI_DEVICE (dBm, negative).
+          // Raw getParamset returns STRING values (the tool coerces them).
+          if (params?.address === "ABC123:0") return { RSSI_DEVICE: "-72", UNREACH: "0" };
+          return {};
         case "Interface.listBidcosInterfaces":
           return [{ ADDRESS: "OEQ0123456", DUTY_CYCLE: 12, CONNECTED: true }];
         default:
@@ -144,17 +149,18 @@ describe("get_rssi handler", () => {
       }
     });
 
-  it("reports per-device RSSI (dBm) resolved to names, normalizing 65536 → null", async () => {
+  it("reports BidCos RSSI via rssiInfo (65536 → null) and HmIP RSSI via maintenance datapoints", async () => {
     const { server, deps } = createTestServer({ sessionCall: rssiMock() });
     const result = parseToolResult(await callTool(server, "get_rssi")) as any;
 
     const byAddr = Object.fromEntries(result.devices.map((d: any) => [d.address, d]));
-    expect(byAddr.ABC123.name).toBe("Thermostat Büro");
-    expect(byAddr.ABC123.links[0].rssiDevice).toBe(-65);
-    expect(byAddr.ABC123.links[0].rssiPeer).toBe(-70);
-    // 65536 sentinel normalized to null; the other direction kept
+    // BidCos via rssiInfo: 65536 sentinel → null, other direction kept
     expect(byAddr.DEF456.links[0].rssiDevice).toBeNull();
     expect(byAddr.DEF456.links[0].rssiPeer).toBe(-80);
+    // HmIP via RSSI_DEVICE datapoint (rssiInfo threw for HmIP-RF)
+    expect(byAddr.ABC123.name).toBe("Thermostat Büro");
+    expect(byAddr.ABC123.links[0].rssiDevice).toBe(-72);
+    expect(byAddr.ABC123.links[0].rssiPeer).toBeNull(); // no RSSI_PEER datapoint
     cleanupDeps(deps);
   });
 

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -132,10 +132,11 @@ describe("get_rssi handler", () => {
         case "Interface.listInterfaces":
           return [{ name: "HmIP-RF" }, { name: "BidCos-RF" }, { name: "VirtualDevices" }];
         case "Interface.rssiInfo":
+          // Real JSON-RPC shape: array of {name: <addr>, partner: [{name: <addr>, rssiData: [a,b]}]}
           if (params?.interface === "VirtualDevices") throw new Error("rssiInfo not supported");
-          if (params?.interface === "HmIP-RF") return { ABC123: { "HmIP-RF": [-65, -70] } };
-          if (params?.interface === "BidCos-RF") return { DEF456: { "BidCoS-RF": [65536, -80] } };
-          return {};
+          if (params?.interface === "HmIP-RF") return [{ name: "ABC123", partner: [{ name: "HmIP-RF", rssiData: [-65, -70] }] }];
+          if (params?.interface === "BidCos-RF") return [{ name: "DEF456", partner: [{ name: "BidCoS-RF", rssiData: [65536, -80] }] }];
+          return [];
         case "Interface.listBidcosInterfaces":
           return [{ ADDRESS: "OEQ0123456", DUTY_CYCLE: 12, CONNECTED: true }];
         default:

--- a/test/unit/tools-discovery.test.ts
+++ b/test/unit/tools-discovery.test.ts
@@ -230,8 +230,9 @@ describe("list_links handler", () => {
         case "Interface.listInterfaces":
           return [{ name: "HmIP-RF" }, { name: "VirtualDevices" }];
         case "Interface.getLinks":
+          // Real JSON-RPC shape: lowercase fields (occu .../interface/getlinks.tcl)
           if (params?.interface === "VirtualDevices") throw new Error("getLinks not supported");
-          return [{ SENDER: "AAA:1", RECEIVER: "BBB:3", NAME: "Taster→Licht", DESCRIPTION: "", FLAGS: 0 }];
+          return [{ sender: "AAA:1", receiver: "BBB:3", name: "Taster→Licht", description: "", flags: 0 }];
         default:
           return null;
       }


### PR DESCRIPTION
Bugs found by **live-testing the merged 1.3 tools against the production CCU**, all verified against the OCCU method TCL and confirmed live (**11/11 integration tests pass against prod**). Plus an enhancement that makes `get_rssi` actually useful on an HmIP CCU.

## get_rssi (#22) — fix + HmIP support
- **Fix:** `Interface.rssiInfo` returns an **array** `[{name, partner:[{name, rssiData:[a,b]}]}]` (occu `rssiinfo.tcl`), not the address-map the code parsed → always empty. Reworked the parse.
- **`rssiInfo` only covers BidCos-RF** — HmIP-RF errors on it, so a pure-HmIP CCU got nothing. **Now also reads HmIP RSSI** from each device's `:0` maintenance channel (`RSSI_DEVICE`/`RSSI_PEER` via `Interface.getParamset`) and merges into the same output. Raw values are strings → coerced; only a negative dBm counts. **Live: 22 devices now (was 0).**

## list_links (#23)
`getLinks` returns **lowercase** fields `sender`/`receiver`/`name`/`description`/`flags` (occu `getlinks.tcl`) — code read uppercase → 30 links, all blank. Fixed.

## create_system_variable (#24)
- **`ValueUnit`/`DPInfo` must be set AFTER `oSysVars.Add()`** — before it, the CCU stores the var under a deduplicated name.
- The CCU **silently dedups** a requested name against lingering (even hidden) objects (`X`→`X 1`), invisible to the exact-match pre-check. The script now echoes the **actual** stored name; on mismatch we delete the stray var and return `INVALID_INPUT` instead of leaving a surprise behind.

## Tests
- Unit-test mocks corrected to the **real** response shapes (HmIP `rssiInfo` throws; `getParamset` returns strings; `getLinks` lowercase), plus dedup-rejection and HmIP-RSSI tests.
- Live integration: filtered `list_devices` for channel ids; unique per-run sysvar name. **All 11 pass against prod.**