### PR TITLE
feat: add structured tool output (outputSchema + structuredContent)

### DIFF
--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -4,7 +4,7 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
-import { toolResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
+import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
   registerGetServiceMessages(server, deps);
@@ -26,6 +26,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
       title: "Get Service Messages",
       description:
         "Get all active service messages (low battery, unreachable, etc.) with device details and timestamps.",
+      outputSchema: { messages: z.array(z.unknown()).describe("Active alarms: {id, type, address, channelName, timestamp}") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
@@ -113,7 +114,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
         }
 
         logger.info("tool_call", { tool: "get_service_messages", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(messages);
+        return structuredResult({ messages: Array.isArray(messages) ? messages : [] }, messages);
       } catch (err) {
         logger.info("tool_call", { tool: "get_service_messages", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -243,6 +244,15 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
     {
       title: "Get System Info",
       description: "Get CCU system information: firmware version, serial number, addresses.",
+      outputSchema: {
+        serverVersion: z.string().optional(),
+        version: z.unknown().optional(),
+        serial: z.unknown().optional(),
+        address: z.unknown().optional(),
+        hmipAddress: z.unknown().optional(),
+        cacheTypes: z.number().optional(),
+        cacheWarming: z.boolean().optional(),
+      },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
@@ -272,7 +282,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
         results.cacheWarming = deviceTypeCache.isWarming();
 
         logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(results);
+        return structuredResult(results as Record<string, unknown>);
       } catch (err) {
         logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -294,6 +304,10 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
         "Use to answer 'why is this sensor flaky?'. Higher (closer to 0) dBm is better; null = no measurement.",
       inputSchema: {
         name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
+      },
+      outputSchema: {
+        devices: z.array(z.unknown()).describe("Per device: {address, name, interface, links:[{peer, rssiDevice, rssiPeer}]}"),
+        interfaces: z.unknown().describe("BidCos interface health (duty cycle, connected)"),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
@@ -427,7 +441,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
         }
 
         logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "ok", devices: deviceEntries.length });
-        return toolResult({ devices: deviceEntries, interfaces: bidcosInterfaces });
+        return structuredResult({ devices: deviceEntries, interfaces: bidcosInterfaces });
       } catch (err) {
         logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -4,7 +4,7 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
-import { toolResult } from "../utils.js";
+import { toolResult, structuredResult } from "../utils.js";
 
 export function registerDiscoveryTools(server: McpServer, deps: ServerDeps): void {
   registerListDevices(server, deps);
@@ -32,6 +32,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
         type: z.string().optional().describe("Filter by device type (exact match, e.g. 'HmIP-eTRV-2')"),
         name: z.string().optional().describe("Filter by device/channel name (substring, case-insensitive)"),
       },
+      outputSchema: { devices: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -117,7 +118,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             }));
 
         logger.info("tool_call", { tool: "list_devices", duration_ms: Date.now() - start, status: "ok", deviceCount: devices.length });
-        return toolResult(output);
+        return structuredResult({ devices: Array.isArray(output) ? output : [] }, output);
       } catch (err) {
         logger.info("tool_call", { tool: "list_devices", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -133,6 +134,7 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Interfaces",
       description: "List available communication interfaces (BidCos-RF, HmIP-RF, VirtualDevices, etc.).",
+      outputSchema: { interfaces: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
@@ -142,7 +144,7 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
         await rateLimiter.acquire();
         const result = await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger);
         logger.info("tool_call", { tool: "list_interfaces", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(result);
+        return structuredResult({ interfaces: Array.isArray(result) ? result : [] }, result);
       } catch (err) {
         logger.info("tool_call", { tool: "list_interfaces", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -158,6 +160,7 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Rooms",
       description: "List all rooms with their assigned channel IDs. Use with list_devices to find devices by room.",
+      outputSchema: { rooms: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
@@ -167,7 +170,7 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
         await rateLimiter.acquire();
         const result = await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger);
         logger.info("tool_call", { tool: "list_rooms", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(result);
+        return structuredResult({ rooms: Array.isArray(result) ? result : [] }, result);
       } catch (err) {
         logger.info("tool_call", { tool: "list_rooms", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -183,6 +186,7 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Functions",
       description: "List all function groups (Heating, Lighting, etc.) with their assigned channel IDs.",
+      outputSchema: { functions: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
@@ -192,7 +196,7 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
         await rateLimiter.acquire();
         const result = await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger);
         logger.info("tool_call", { tool: "list_functions", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(result);
+        return structuredResult({ functions: Array.isArray(result) ? result : [] }, result);
       } catch (err) {
         logger.info("tool_call", { tool: "list_functions", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -211,6 +215,7 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         name: z.string().optional().describe("Filter by program name (substring, case-insensitive)"),
       },
+      outputSchema: { programs: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -226,7 +231,7 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
         }
 
         logger.info("tool_call", { tool: "list_programs", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(programs);
+        return structuredResult({ programs: Array.isArray(programs) ? programs : [] }, programs);
       } catch (err) {
         logger.info("tool_call", { tool: "list_programs", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -245,6 +250,7 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
       inputSchema: {
         name: z.string().optional().describe("Filter by variable name (substring, case-insensitive)"),
       },
+      outputSchema: { systemVariables: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -260,7 +266,7 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
         }
 
         logger.info("tool_call", { tool: "list_system_variables", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(sysvars);
+        return structuredResult({ systemVariables: Array.isArray(sysvars) ? sysvars : [] }, sysvars);
       } catch (err) {
         logger.info("tool_call", { tool: "list_system_variables", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -282,6 +288,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         deviceType: z.string().describe("Device type name (e.g. 'HmIP-eTRV-2', 'HmIP-SWDO-I'). Get from list_devices."),
       },
+      outputSchema: { deviceType: z.string().optional().describe("Echoed device type; other keys hold the channel/datapoint schema or a not-found hint") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -292,7 +299,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
 
       if (cached) {
         logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: true });
-        return toolResult({ deviceType: args.deviceType, ...cached });
+        return structuredResult({ deviceType: args.deviceType, ...cached });
       }
 
       // Cache miss — try live query if we can find a device instance
@@ -308,7 +315,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
             );
             if (cached) {
               logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: false });
-              return toolResult({ deviceType: args.deviceType, ...cached });
+              return structuredResult({ deviceType: args.deviceType, ...cached });
             }
           } catch {
             // Live query failed — fall through to cache-miss message
@@ -317,7 +324,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
       }
 
       logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: false });
-      return toolResult({
+      return structuredResult({
         deviceType: args.deviceType,
         message: "Device type not in cache. Cache may still be warming. Try again shortly or call list_devices first.",
         availableTypes: Object.keys(deviceTypeCache.getAll()),
@@ -338,6 +345,7 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         address: z.string().optional().describe("Device or channel address to filter by (e.g. '000A1BE9A71F15' or '000A1BE9A71F15:1')"),
       },
+      outputSchema: { links: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -407,7 +415,7 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
         }
 
         logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "ok", links: links.length });
-        return toolResult(links);
+        return structuredResult({ links }, links);
       } catch (err) {
         logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
-import { toolResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
+import { toolResult, structuredResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
 
 export function registerReadTools(server: McpServer, deps: ServerDeps): void {
   registerGetValue(server, deps);
@@ -24,6 +24,11 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
         address: z.string().describe("Channel address (e.g. '000A1BE9A71F15:1')"),
         valueKey: z.string().describe("Datapoint name (e.g. 'STATE', 'LEVEL', 'ACTUAL_TEMPERATURE')"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
+      },
+      outputSchema: {
+        address: z.string(),
+        valueKey: z.string(),
+        value: z.unknown().describe("Parsed datapoint value (bool/number/string/null)"),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
@@ -46,7 +51,7 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
         );
 
         logger.info("tool_call", { tool: "get_value", duration_ms: Date.now() - start, status: "ok", address: args.address });
-        return toolResult({ address: args.address, valueKey: args.valueKey, value: parseValue(value) });
+        return structuredResult({ address: args.address, valueKey: args.valueKey, value: parseValue(value) });
       } catch (err) {
         logger.info("tool_call", { tool: "get_value", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -68,6 +73,9 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         channels: z.array(z.string()).optional().describe("Array of channel addresses to read"),
         room: z.string().optional().describe("Room name — read all channels in this room"),
         function: z.string().optional().describe("Function name — read all channels in this function group"),
+      },
+      outputSchema: {
+        values: z.array(z.unknown()).describe("One entry per channel: {address, name, datapoints}"),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
@@ -106,7 +114,9 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         );
 
         logger.info("tool_call", { tool: "get_values", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(typeof result === "string" ? tryParseJson(result) : result);
+        const data = typeof result === "string" ? tryParseJson(result) : result;
+        // Wrap the array for structuredContent; keep the bare array as the text block.
+        return structuredResult({ values: Array.isArray(data) ? data : [] }, data);
       } catch (err) {
         logger.info("tool_call", { tool: "get_values", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -198,6 +208,11 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
         paramsetKey: z.enum(["VALUES", "MASTER", "LINK"]).describe("Paramset to read"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
       },
+      outputSchema: {
+        address: z.string(),
+        paramsetKey: z.string(),
+        params: z.unknown().describe("Map of parameter name → value"),
+      },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -223,7 +238,7 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
         const params = (typeof result === "object" && result !== null && !Array.isArray(result))
           ? parseValues(result as Record<string, unknown>)
           : result;
-        return toolResult({ address: args.address, paramsetKey: args.paramsetKey, params });
+        return structuredResult({ address: args.address, paramsetKey: args.paramsetKey, params });
       } catch (err) {
         logger.info("tool_call", { tool: "get_paramset", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,6 +37,24 @@ export function toolResult(data: unknown) {
   return { content: [{ type: "text" as const, text: typeof data === "string" ? data : JSON.stringify(data, null, 2) }] };
 }
 
+/**
+ * Tool result carrying BOTH a human-readable text block (backwards-compatible
+ * with pre-structuredContent clients) and machine-readable `structuredContent`
+ * that validates against the tool's `outputSchema` (MCP 2025-11-25).
+ *
+ * `structured` must be an object (structuredContent is always a JSON object).
+ * For list/array tools, pass the wrapper object as `structured` and the bare
+ * array as `text` so the text block stays byte-for-byte what older clients got.
+ * For object tools, omit `text` and the object is used for both.
+ */
+export function structuredResult(structured: Record<string, unknown>, text?: unknown) {
+  const body = text === undefined ? structured : text;
+  return {
+    content: [{ type: "text" as const, text: typeof body === "string" ? body : JSON.stringify(body, null, 2) }],
+    structuredContent: structured,
+  };
+}
+
 /** Try to parse JSON, return raw string on failure. */
 export function tryParseJson(text: string): unknown {
   try { return JSON.parse(text); } catch { return text; }

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -305,6 +305,22 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
   });
 
+  // Issue #26: a successful tool call returns structuredContent AND passes the
+  // SDK's server-side outputSchema validation (a schema mismatch would come back
+  // as a JSON-RPC error instead). This is the end-to-end check unit tests can't do.
+  it("returns structuredContent that passes outputSchema validation", async () => {
+    const sid = await initialize(mcpPort);
+    const res = await mcpPost(mcpPort, {
+      jsonrpc: "2.0", id: 1, method: "tools/call",
+      params: { name: "get_system_info", arguments: {} },
+    }, sid);
+    expect(res.status).toBe(200);
+    const msg = await parseSse(res);
+    expect(msg.error).toBeUndefined();            // validation passed
+    expect(msg.result.isError).toBeFalsy();
+    expect(msg.result.structuredContent).toBeTypeOf("object");
+  });
+
   // Must be last: terminates the server and asserts a clean exit
   it("shuts down gracefully on SIGTERM with exit code 0", async () => {
     const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -274,3 +274,25 @@ describe("merge fallbacks (coverage round)", () => {
     cleanupDeps(deps);
   });
 });
+
+// Issue #26: structuredContent on diagnostics tools.
+describe("structured output (diagnostics)", () => {
+  it("get_system_info returns structuredContent as an object", async () => {
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockImplementation(async (method: string) => (method === "CCU.getVersion" ? "3.85.7" : null)),
+    });
+    const res = await callTool(server, "get_system_info") as any;
+    expect(res.structuredContent).toBeTypeOf("object");
+    expect(res.structuredContent.version).toBe("3.85.7");
+    cleanupDeps(deps);
+  });
+
+  it("get_service_messages wraps alarms under structuredContent.messages", async () => {
+    const mock = JSON.stringify({ alarms: [{ id: "1", type: "LOWBAT", address: "ABC:0", timestamp: "t" }], channelNames: {} });
+    const { server, deps } = createTestServer({ sessionCall: vi.fn().mockResolvedValue(mock) });
+    const res = await callTool(server, "get_service_messages") as any;
+    expect(Array.isArray(res.structuredContent.messages)).toBe(true);
+    expect(res.structuredContent.messages[0].type).toBe("LOWBAT");
+    cleanupDeps(deps);
+  });
+});

--- a/test/unit/tools-discovery.test.ts
+++ b/test/unit/tools-discovery.test.ts
@@ -269,3 +269,18 @@ describe("list_links handler", () => {
     cleanupDeps(deps);
   });
 });
+
+// Issue #26: list tools wrap their array under a named structuredContent key,
+// while the text block stays the bare array (backwards-compatible).
+describe("structured output (discovery)", () => {
+  it("list_devices exposes structuredContent.devices and a bare-array text block", async () => {
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockImplementation(async (method: string) => (method === "Device.listAllDetail" ? mockDevices : [])),
+    });
+    const res = await callTool(server, "list_devices") as any;
+    expect(Array.isArray(res.structuredContent.devices)).toBe(true);
+    expect(res.structuredContent.devices.length).toBeGreaterThan(0);
+    expect(Array.isArray(parseToolResult(res))).toBe(true); // text remains the bare array
+    cleanupDeps(deps);
+  });
+});

--- a/test/unit/tools-read.test.ts
+++ b/test/unit/tools-read.test.ts
@@ -176,3 +176,34 @@ describe("error and edge paths (coverage round)", () => {
     cleanupDeps(deps);
   });
 });
+
+// Issue #26: tools expose structuredContent alongside the text block.
+describe("structured output (read tools)", () => {
+  it("get_value returns structuredContent matching the object", async () => {
+    const { server, deps } = createTestServer({ sessionCall: vi.fn().mockResolvedValue(21.5) });
+    deps.resolver.updateDeviceList([{ id: "1", name: "Dev", address: "AAA", interface: "HmIP-RF", type: "T", operateGroupOnly: "false", isReady: "true", channels: [] }] as any);
+    const res = await callTool(server, "get_value", { address: "AAA:1", valueKey: "ACTUAL_TEMPERATURE" }) as any;
+    expect(res.structuredContent).toEqual({ address: "AAA:1", valueKey: "ACTUAL_TEMPERATURE", value: 21.5 });
+    cleanupDeps(deps);
+  });
+
+  it("get_values wraps the array under structuredContent.values (text stays the bare array)", async () => {
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockResolvedValue([{ address: "AAA:1", datapoints: {} }]),
+    });
+    const res = await callTool(server, "get_values", { channels: ["AAA:1"] }) as any;
+    expect(res.structuredContent).toEqual({ values: [{ address: "AAA:1", datapoints: {} }] });
+    expect(parseToolResult(res)).toEqual([{ address: "AAA:1", datapoints: {} }]); // backwards-compatible text
+    cleanupDeps(deps);
+  });
+
+  it("get_paramset returns structuredContent with address/paramsetKey/params", async () => {
+    const { server, deps } = createTestServer({ sessionCall: vi.fn().mockResolvedValue({ TEMP: "21" }) });
+    deps.resolver.updateDeviceList([{ id: "1", name: "Dev", address: "AAA", interface: "HmIP-RF", type: "T", operateGroupOnly: "false", isReady: "true", channels: [] }] as any);
+    const res = await callTool(server, "get_paramset", { address: "AAA:1", paramsetKey: "VALUES" }) as any;
+    expect(res.structuredContent.address).toBe("AAA:1");
+    expect(res.structuredContent.paramsetKey).toBe("VALUES");
+    expect(res.structuredContent.params).toBeDefined();
+    cleanupDeps(deps);
+  });
+});


### PR DESCRIPTION
Closes #26.

## What
Read/discovery/diagnostics tools now declare an **`outputSchema`** and return **`structuredContent`** (MCP 2025-11-25), so clients can validate/parse results instead of re-parsing the free-text block.

- New **`structuredResult()`** helper emits `structuredContent` (always a JSON object) + the text block.
- **Backwards-compatible:** for list/array tools the array is wrapped under a named key (`devices`, `rooms`, `functions`, `interfaces`, `programs`, `systemVariables`, `messages`, `values`, `links`) in `structuredContent`, while the **text block stays the bare array** older clients expect. Object-returning tools are unchanged in text.
- **Tools covered:** `get_value`, `get_values`, `get_paramset`; all `list_*` + `describe_device_type`; `get_service_messages`, `get_system_info`, `get_rssi`.
- **Permissive schemas** (`z.unknown()`/optional) so dynamic CCU payloads never trip the SDK's server-side output validation (which throws `McpError` on mismatch).

## Tests
- `structuredContent` shape assertions across read/discovery/diagnostics, asserting the text block stays a bare array for list tools.
- **e2e:** a real `tools/call` (`get_system_info`) returns `structuredContent` and **passes the SDK's server-side `outputSchema` validation** — the end-to-end check (unit `callTool` bypasses validation).
- Full suite green (278); **live integration green against the production CCU**.

## Acceptance criteria
- [x] Read/discovery/diagnostics tools declare `outputSchema`
- [x] Handlers return conforming `structuredContent`
- [x] Tests assert structuredContent shape (+ e2e validates through the server)
- [x] `npm test` green

## Out of scope
Write tools (`set_*`, create/delete sysvar, assign/unassign, `acknowledge_service_messages`) can gain structured output as a follow-up.