### PR TITLE
Serve MCP over TLS (optional native HTTPS) — closes #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ By default the HTTP server sends **no** CORS headers, so a random web page can't
 
 The HTTP transport also has **DNS-rebinding protection** on by default: it rejects requests whose `Host` header isn't `localhost`/`127.0.0.1` on the configured port. If you reach the server under another hostname (reverse proxy, container DNS name), list those hosts in `MCP_ALLOWED_HOSTS` or legitimate requests get a `403`.
 
+**TLS.** The bearer token travels in the request, so anything beyond loopback should be encrypted. You have two options: terminate TLS at a reverse proxy (Caddy/nginx) in front and bind the server to loopback (`MCP_HOST=127.0.0.1`), or let the server serve HTTPS itself by setting `MCP_TLS_CERT` and `MCP_TLS_KEY` to a PEM cert/key pair. Plain HTTP is still fully supported — it stays the zero-config default — but the server logs a warning at startup when it's serving the token over unencrypted HTTP on a non-loopback bind; set `MCP_ALLOW_PLAINTEXT=true` to acknowledge that and silence it.
+
 CORS support was first implemented by [@marcinn2](https://github.com/marcinn2) in his fork [marcinn2/debmatic-mcp](https://github.com/marcinn2/debmatic-mcp) — thanks!
 
 ### HTTPS
@@ -172,6 +174,9 @@ All configuration is via environment variables:
 | `MCP_AUTH_TOKEN` | auto-generated | Bearer token for HTTP mode; generated and saved to `$CACHE_DIR/.env` on first start |
 | `MCP_ALLOWED_ORIGINS` | unset | Comma-separated allowlist of browser origins. Unset = no cross-origin browser access (default-deny). An allowlisted origin is reflected exactly in `Access-Control-Allow-Origin` (never `*`); the list also drives DNS-rebinding origin checks |
 | `MCP_ALLOWED_HOSTS` | `localhost`/`127.0.0.1` | Extra `Host` values accepted by DNS-rebinding protection (comma-separated `host:port`); add your hostname when behind a proxy or container DNS name |
+| `MCP_HOST` | unset (all interfaces) | Bind address for the HTTP listener; set `127.0.0.1` to restrict to loopback (e.g. behind a TLS-terminating proxy), which also silences the plaintext warning |
+| `MCP_TLS_CERT` / `MCP_TLS_KEY` | unset | PEM cert/key paths. Set **both** to serve MCP over HTTPS natively; leave unset for plain HTTP. Setting only one is a configuration error |
+| `MCP_ALLOW_PLAINTEXT` | `false` | Set `true` to acknowledge serving the bearer token over plain HTTP and silence the non-loopback plaintext warning |
 | `CCU_RATE_LIMIT_BURST` | `20` | Max burst of requests sent to the CCU |
 | `CCU_RATE_LIMIT_RATE` | `10` | Sustained CCU requests per second |
 | `RESOURCE_POLL_INTERVAL` | `60` | Seconds between polls for MCP resource change notifications |

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,26 @@ export interface AppConfig {
      * `MCP_ALLOWED_HOSTS` when the server is reached under another hostname.
      */
     allowedHosts: string[];
+    /**
+     * Optional bind address for the HTTP listener (`MCP_HOST`). Unset ⇒ bind
+     * all interfaces (the unchanged default). Set to `127.0.0.1`/`::1` to
+     * restrict the server to loopback (e.g. when a reverse proxy terminates TLS
+     * in front), which also suppresses the plaintext warning.
+     */
+    host?: string;
+    /**
+     * Optional TLS cert/key paths (`MCP_TLS_CERT` / `MCP_TLS_KEY`). When BOTH
+     * are set the server listens over HTTPS natively; otherwise it serves plain
+     * HTTP (the zero-config default). Setting only one is a configuration error.
+     */
+    tlsCertPath?: string;
+    tlsKeyPath?: string;
+    /**
+     * Acknowledge that serving over plain HTTP is intended
+     * (`MCP_ALLOW_PLAINTEXT=true`). Silences the non-loopback plaintext warning
+     * for operators who deliberately run without TLS (e.g. a trusted LAN).
+     */
+    allowPlaintext: boolean;
   };
   cache: {
     dir: string;
@@ -81,6 +101,15 @@ export function loadConfig(): AppConfig {
     .map((o) => o.trim())
     .filter(Boolean);
 
+  // Native TLS for the HTTP transport is opt-in: set BOTH cert and key. Plain
+  // HTTP stays the zero-config default (issue #50). Setting only one is almost
+  // certainly a mistake, so fail loudly rather than silently serving plaintext.
+  const tlsCertPath = process.env.MCP_TLS_CERT?.trim() || undefined;
+  const tlsKeyPath = process.env.MCP_TLS_KEY?.trim() || undefined;
+  if (Boolean(tlsCertPath) !== Boolean(tlsKeyPath)) {
+    throw new Error("MCP_TLS_CERT and MCP_TLS_KEY must both be set (or both unset)");
+  }
+
   return {
     ccu: {
       host,
@@ -98,6 +127,10 @@ export function loadConfig(): AppConfig {
       authToken: process.env.MCP_AUTH_TOKEN,
       allowedOrigins,
       allowedHosts,
+      host: process.env.MCP_HOST?.trim() || undefined,
+      tlsCertPath,
+      tlsKeyPath,
+      allowPlaintext: process.env.MCP_ALLOW_PLAINTEXT === "true",
     },
     cache: {
       dir: process.env.CACHE_DIR || "/data",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 
-import { createServer, type Server as HttpServer } from "node:http";
+import {
+  createServer as createHttpServer,
+  type Server as HttpServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
+import { readFile } from "node:fs/promises";
 import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -58,7 +65,7 @@ async function main(): Promise<void> {
 
   let poller: ResourcePoller;
   let closeTransports: () => Promise<void>;
-  let httpServer: HttpServer | null = null;
+  let httpServer: HttpServer | HttpsServer | null = null;
 
   if (config.mcp.transport === "stdio") {
     const mcpServer = createMcpServer(deps);
@@ -79,7 +86,7 @@ async function main(): Promise<void> {
     const authToken = await resolveAuthToken(config.mcp.authToken, config.cache.dir, logger);
     const sessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
 
-    httpServer = createServer(async (req, res) => {
+    const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       try {
         // CORS so browser-based MCP clients (e.g. MCP Inspector) can connect
         // directly. Default-deny against a configurable origin allowlist
@@ -190,7 +197,37 @@ async function main(): Promise<void> {
         }
         res.end(JSON.stringify({ error: "Internal error" }));
       }
-    });
+    };
+
+    // Native TLS is opt-in (issue #50): with both cert and key set we serve
+    // HTTPS so the bearer token isn't exposed in transit; otherwise we keep
+    // plain HTTP (the zero-config default). config validates that cert/key are
+    // set together.
+    const useTls = Boolean(config.mcp.tlsCertPath && config.mcp.tlsKeyPath);
+    if (useTls) {
+      const [cert, key] = await Promise.all([
+        readFile(config.mcp.tlsCertPath!),
+        readFile(config.mcp.tlsKeyPath!),
+      ]);
+      httpServer = createHttpsServer({ cert, key }, handleRequest);
+    } else {
+      httpServer = createHttpServer(handleRequest);
+      // Plain HTTP is allowed (some run behind a TLS-terminating proxy, or on a
+      // trusted LAN), but the bearer token then travels in the clear. Warn once
+      // at startup unless the listener is loopback-only or the operator has
+      // acknowledged it via MCP_ALLOW_PLAINTEXT.
+      const host = config.mcp.host;
+      const loopbackOnly = host === "127.0.0.1" || host === "::1" || host === "localhost";
+      if (!loopbackOnly && !config.mcp.allowPlaintext) {
+        logger.warn("plaintext_http", {
+          hint:
+            "MCP is serving the bearer token over unencrypted HTTP on a non-loopback " +
+            "address. Set MCP_TLS_CERT/MCP_TLS_KEY for native TLS, put a TLS-terminating " +
+            "reverse proxy in front, bind loopback with MCP_HOST=127.0.0.1, or set " +
+            "MCP_ALLOW_PLAINTEXT=true to silence this warning.",
+        });
+      }
+    }
 
     poller = new ResourcePoller(
       async () => {
@@ -206,8 +243,13 @@ async function main(): Promise<void> {
       sessions.clear();
     };
 
-    httpServer.listen(config.mcp.port, () => {
-      logger.info("server_ready", { transport: "http", port: config.mcp.port });
+    httpServer.listen(config.mcp.port, config.mcp.host, () => {
+      logger.info("server_ready", {
+        transport: useTls ? "https" : "http",
+        port: config.mcp.port,
+        host: config.mcp.host ?? "0.0.0.0",
+        tls: useTls,
+      });
     });
   }
 

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createServer, request, type Server, type IncomingHttpHeaders } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { AddressInfo } from "node:net";
@@ -504,10 +504,13 @@ describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebin
 // the clear. Skipped if openssl isn't available to mint a throwaway cert.
 const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
 
-// Minimal HTTPS client that trusts the self-signed test cert.
+// Minimal HTTPS client. TLS validation stays ENABLED — we trust the specific
+// throwaway cert by passing it as the CA (the cert carries an IP:127.0.0.1 SAN
+// so identity verification against the loopback host succeeds), rather than
+// disabling certificate validation.
 function httpsJson(
   port: number,
-  opts: { method?: string; path?: string; headers?: Record<string, string>; body?: unknown } = {},
+  opts: { method?: string; path?: string; headers?: Record<string, string>; body?: unknown; ca?: Buffer } = {},
 ): Promise<{ status: number; headers: IncomingHttpHeaders; text: string }> {
   return new Promise((resolve, reject) => {
     const payload = opts.body === undefined ? undefined : JSON.stringify(opts.body);
@@ -517,7 +520,7 @@ function httpsJson(
         port,
         path: opts.path ?? "/",
         method: opts.method ?? "GET",
-        rejectUnauthorized: false, // self-signed test cert
+        ca: opts.ca,
         headers: {
           ...(payload ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } : {}),
           ...opts.headers,
@@ -540,21 +543,26 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   let child: ChildProcess;
   let mcpPort: number;
   let cacheDir: string;
+  let caCert: Buffer;
 
   beforeAll(async () => {
     ccu = await startCcuMock();
     cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-tls-"));
     mcpPort = 20000 + Math.floor(Math.random() * 20000);
 
-    // Mint a throwaway self-signed cert for localhost.
+    // Mint a throwaway self-signed cert. The SAN must include IP:127.0.0.1 —
+    // Node (>=17) no longer falls back to the subject CN for identity checks,
+    // so a CN-only cert would fail verification against the loopback host.
     const certPath = join(cacheDir, "cert.pem");
     const keyPath = join(cacheDir, "key.pem");
     const gen = spawnSync("openssl", [
       "req", "-x509", "-newkey", "rsa:2048", "-nodes",
       "-keyout", keyPath, "-out", certPath,
       "-days", "1", "-subj", "/CN=localhost",
+      "-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1",
     ], { stdio: "ignore" });
     if (gen.status !== 0) throw new Error("openssl failed to generate test cert");
+    caCert = readFileSync(certPath);
 
     child = spawn("node", [DIST], {
       env: {
@@ -578,7 +586,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
     const deadline = Date.now() + 15_000;
     for (;;) {
       try {
-        const r = await httpsJson(mcpPort, { path: "/health" });
+        const r = await httpsJson(mcpPort, { path: "/health", ca: caCert });
         if (r.status === 200 || r.status === 503) break;
       } catch { /* not up yet */ }
       if (Date.now() > deadline) throw new Error("HTTPS server did not start");
@@ -595,7 +603,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   });
 
   it("serves the health endpoint over HTTPS", async () => {
-    const res = await httpsJson(mcpPort, { path: "/health" });
+    const res = await httpsJson(mcpPort, { path: "/health", ca: caCert });
     expect(res.status).toBe(200);
     expect((JSON.parse(res.text) as { status: string }).status).toBe("healthy");
   });
@@ -610,6 +618,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   it("completes the MCP initialize handshake over TLS", async () => {
     const res = await httpsJson(mcpPort, {
       method: "POST",
+      ca: caCert,
       headers: {
         "Authorization": `Bearer ${AUTH_TOKEN}`,
         "Accept": "application/json, text/event-stream",
@@ -627,6 +636,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   it("still enforces the bearer token over TLS", async () => {
     const res = await httpsJson(mcpPort, {
       method: "POST",
+      ca: caCert,
       headers: { "Accept": "application/json, text/event-stream" },
       body: { jsonrpc: "2.0", id: 1, method: "ping" },
     });

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createServer, request, type Server, type IncomingHttpHeaders } from "node:http";
-import { spawn, type ChildProcess } from "node:child_process";
+import { request as httpsRequest } from "node:https";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -484,6 +485,152 @@ describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebin
   it("rejects a forged Host header with 403 (DNS-rebinding protection)", async () => {
     const res = await rawPost(mcpPort, INIT_BODY, { token: AUTH_TOKEN, host: "evil.example" });
     expect(res.status).toBe(403);
+  });
+
+  // Must be last: clean shutdown
+  it("shuts down gracefully on SIGTERM with exit code 0", async () => {
+    const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
+    child.kill("SIGTERM");
+    const code = await Promise.race([
+      exited,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("shutdown timed out")), 12_000)),
+    ]);
+    expect(code).toBe(0);
+  }, 15_000);
+});
+
+// Issue #50: native TLS for the HTTP transport. When MCP_TLS_CERT/MCP_TLS_KEY
+// are set the server must listen over HTTPS so the bearer token isn't sent in
+// the clear. Skipped if openssl isn't available to mint a throwaway cert.
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+
+// Minimal HTTPS client that trusts the self-signed test cert.
+function httpsJson(
+  port: number,
+  opts: { method?: string; path?: string; headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; headers: IncomingHttpHeaders; text: string }> {
+  return new Promise((resolve, reject) => {
+    const payload = opts.body === undefined ? undefined : JSON.stringify(opts.body);
+    const req = httpsRequest(
+      {
+        host: "127.0.0.1",
+        port,
+        path: opts.path ?? "/",
+        method: opts.method ?? "GET",
+        rejectUnauthorized: false, // self-signed test cert
+        headers: {
+          ...(payload ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } : {}),
+          ...opts.headers,
+        },
+      },
+      (res) => {
+        let text = "";
+        res.on("data", (c) => (text += c));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers, text }));
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native TLS, mocked CCU)", () => {
+  let ccu: { server: Server; port: number };
+  let child: ChildProcess;
+  let mcpPort: number;
+  let cacheDir: string;
+
+  beforeAll(async () => {
+    ccu = await startCcuMock();
+    cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-tls-"));
+    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+
+    // Mint a throwaway self-signed cert for localhost.
+    const certPath = join(cacheDir, "cert.pem");
+    const keyPath = join(cacheDir, "key.pem");
+    const gen = spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=localhost",
+    ], { stdio: "ignore" });
+    if (gen.status !== 0) throw new Error("openssl failed to generate test cert");
+
+    child = spawn("node", [DIST], {
+      env: {
+        ...process.env,
+        CCU_HOST: "127.0.0.1",
+        CCU_PORT: String(ccu.port),
+        CCU_HTTPS: "false",
+        CCU_PASSWORD: "mock",
+        MCP_TRANSPORT: "http",
+        MCP_PORT: String(mcpPort),
+        MCP_AUTH_TOKEN: AUTH_TOKEN,
+        MCP_TLS_CERT: certPath,
+        MCP_TLS_KEY: keyPath,
+        CACHE_DIR: cacheDir,
+        RESOURCE_POLL_INTERVAL: "3600",
+        LOG_LEVEL: "error",
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+
+    const deadline = Date.now() + 15_000;
+    for (;;) {
+      try {
+        const r = await httpsJson(mcpPort, { path: "/health" });
+        if (r.status === 200 || r.status === 503) break;
+      } catch { /* not up yet */ }
+      if (Date.now() > deadline) throw new Error("HTTPS server did not start");
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    child?.kill("SIGTERM");
+    await new Promise((r) => setTimeout(r, 300));
+    child?.kill("SIGKILL");
+    ccu?.server.close();
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("serves the health endpoint over HTTPS", async () => {
+    const res = await httpsJson(mcpPort, { path: "/health" });
+    expect(res.status).toBe(200);
+    expect((JSON.parse(res.text) as { status: string }).status).toBe("healthy");
+  });
+
+  it("rejects a plaintext HTTP request to the TLS port (TLS is actually on)", async () => {
+    // A plain-HTTP GET to an HTTPS listener does not complete a normal response.
+    await expect(
+      fetch(`http://127.0.0.1:${mcpPort}/health`, { signal: AbortSignal.timeout(2000) }),
+    ).rejects.toThrow();
+  });
+
+  it("completes the MCP initialize handshake over TLS", async () => {
+    const res = await httpsJson(mcpPort, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${AUTH_TOKEN}`,
+        "Accept": "application/json, text/event-stream",
+        "mcp-protocol-version": "2025-06-18",
+      },
+      body: {
+        jsonrpc: "2.0", id: 0, method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "tls", version: "1" } },
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers["mcp-session-id"]).toBeTruthy();
+  });
+
+  it("still enforces the bearer token over TLS", async () => {
+    const res = await httpsJson(mcpPort, {
+      method: "POST",
+      headers: { "Accept": "application/json, text/event-stream" },
+      body: { jsonrpc: "2.0", id: 1, method: "ping" },
+    });
+    expect(res.status).toBe(401);
   });
 
   // Must be last: clean shutdown

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -44,7 +44,7 @@ describeIf("MCP tools against live CCU", () => {
     deps = {
       config: {
         ccu: config,
-        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [] },
+        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
         cache: { dir: tempDir, ttl: 86400 },
         rateLimiter: { burst: 20, rate: 10 },
         resourcePollInterval: 3600,

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -13,7 +13,7 @@ export function createMockDeps(overrides?: {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [] },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -27,6 +27,10 @@ describe("loadConfig", () => {
     delete process.env.CCU_TIMEOUT;
     delete process.env.CCU_SCRIPT_TIMEOUT;
     delete process.env.CCU_TLS_VERIFY;
+    delete process.env.MCP_HOST;
+    delete process.env.MCP_TLS_CERT;
+    delete process.env.MCP_TLS_KEY;
+    delete process.env.MCP_ALLOW_PLAINTEXT;
     delete process.env.LOG_LEVEL;
   });
 
@@ -196,5 +200,48 @@ describe("loadConfig", () => {
 
     process.env.CCU_TLS_VERIFY = "true";
     expect(loadConfig().ccu.tlsVerify).toBe(true);
+  });
+
+  // Issue #50: native TLS for the HTTP transport (opt-in), bind host, plaintext ack
+  it("TLS is off by default: no cert/key paths, plain HTTP", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    const config = loadConfig();
+    expect(config.mcp.tlsCertPath).toBeUndefined();
+    expect(config.mcp.tlsKeyPath).toBeUndefined();
+    expect(config.mcp.host).toBeUndefined();
+    expect(config.mcp.allowPlaintext).toBe(false);
+  });
+
+  it("reads MCP_TLS_CERT/MCP_TLS_KEY when both are set", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_TLS_CERT = "/data/cert.pem";
+    process.env.MCP_TLS_KEY = "/data/key.pem";
+    const config = loadConfig();
+    expect(config.mcp.tlsCertPath).toBe("/data/cert.pem");
+    expect(config.mcp.tlsKeyPath).toBe("/data/key.pem");
+  });
+
+  it("throws if only one of MCP_TLS_CERT / MCP_TLS_KEY is set", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+
+    process.env.MCP_TLS_CERT = "/data/cert.pem";
+    expect(() => loadConfig()).toThrow(/MCP_TLS_CERT and MCP_TLS_KEY must both be set/);
+
+    delete process.env.MCP_TLS_CERT;
+    process.env.MCP_TLS_KEY = "/data/key.pem";
+    expect(() => loadConfig()).toThrow(/MCP_TLS_CERT and MCP_TLS_KEY must both be set/);
+  });
+
+  it("reads MCP_HOST and MCP_ALLOW_PLAINTEXT", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_HOST = "127.0.0.1";
+    process.env.MCP_ALLOW_PLAINTEXT = "true";
+    const config = loadConfig();
+    expect(config.mcp.host).toBe("127.0.0.1");
+    expect(config.mcp.allowPlaintext).toBe(true);
   });
 });

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -10,7 +10,7 @@ function createMockDeps() {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [] },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 20, rate: 10 },
       resourcePollInterval: 60,


### PR DESCRIPTION
Closes #50.

The HTTP transport was plain `node:http`, so the bearer token traveled unencrypted unless an operator happened to put a TLS-terminating proxy in front — with no guardrail. This adds **opt-in native HTTPS** while keeping plain HTTP a first-class, zero-config option.

## Changes
- **`MCP_TLS_CERT` + `MCP_TLS_KEY`** (PEM paths) → server listens over HTTPS via `https.createServer`. Both required together; setting only one is a config error (fail loud, never silently plaintext).
- **Plain HTTP stays the default.** When serving the token over unencrypted HTTP on a non-loopback bind, the server logs a startup warning — unless `MCP_HOST` restricts it to loopback, or `MCP_ALLOW_PLAINTEXT=true` acknowledges it.
- **`MCP_HOST`** optionally binds a specific interface (e.g. `127.0.0.1` behind a reverse proxy).
- Request handling is untouched: auth, CORS, and DNS-rebinding protection all still apply. The handler was extracted into a shared function so HTTP and HTTPS reuse it.

## Tests
- Config unit tests for the new vars + the both-or-neither validation error.
- New e2e block mints a throwaway self-signed cert and exercises a **real TLS handshake**: health over HTTPS, MCP `initialize` over TLS, bearer-token still enforced, plain-HTTP-to-TLS-port rejected, clean shutdown. Skipped automatically if `openssl` is unavailable.
- README documents the reverse-proxy and native-TLS paths.

Full suite green (290 passed), `npm run lint` clean.