### PR TITLE
Move to Node 24 (clear Node 20 action deprecation warnings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -6,7 +6,7 @@ COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npx tsc
 
-FROM node:22-alpine
+FROM node:24-alpine
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepublishOnly": "npm run check:versions && npm run lint && npm test"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
GitHub deprecated the Node 20 action runtime, so CI emitted deprecation warnings. This moves the toolchain target to **Node 24** and bumps the CI actions to majors that run on the Node 24 runtime.

## Changes
- `actions/checkout@v4 → @v6`, `actions/setup-node@v4 → @v6` (both run on Node 24 — this is what clears the warnings)
- CI `node-version: "22" → "24"`
- `Dockerfile` base image `node:22-alpine → node:24-alpine` (builder + runtime stages)
- `package.json` `engines.node: ">=22" → ">=24"`

Build + full test suite pass (290 passed). Note: the Docker image base bump is not exercised by `ci.yml` (which only runs the npm build/test), but the npm toolchain is verified on Node 24 in CI.