### PR TITLE
Verify the CCU's TLS certificate — closes #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,16 @@ CCU_HTTPS=true
 CCU_PORT=443
 ```
 
-The server accepts self-signed certificates automatically — certificate verification is **off by default** because CCUs ship with self-signed certs. If your CCU has a proper certificate, enable verification with `CCU_TLS_VERIFY=true`.
+The server accepts self-signed certificates automatically — certificate verification is **off by default** because CCUs ship with self-signed certs (the server logs a warning when running unverified). To actually verify the connection and close the MITM gap, you have three options:
+
+- **Pin the fingerprint** (simplest for a self-signed appliance cert): set `CCU_TLS_FINGERPRINT` to the cert's SHA-256 (hex, with or without colons). The connection is rejected unless the CCU presents exactly that certificate. Read it with:
+  ```bash
+  echo | openssl s_client -connect "$CCU_HOST:443" 2>/dev/null | openssl x509 -noout -fingerprint -sha256
+  ```
+- **Trust a CA/self-signed PEM**: point `CCU_CA_CERT` at the certificate file for standard chain validation.
+- **System trust store**: if your CCU has a publicly-trusted certificate, set `CCU_TLS_VERIFY=true`.
+
+`CCU_TLS_FINGERPRINT` takes precedence over `CCU_CA_CERT`, which takes precedence over `CCU_TLS_VERIFY`.
 
 ## Configuration
 
@@ -163,7 +172,9 @@ All configuration is via environment variables:
 | `CCU_USER` | `Admin` | CCU username |
 | `CCU_PORT` | `80` | API port (`443` when using HTTPS) |
 | `CCU_HTTPS` | `false` | Connect via HTTPS (self-signed certs supported) |
-| `CCU_TLS_VERIFY` | `false` | Verify the CCU's TLS certificate (enable if you have a proper cert) |
+| `CCU_TLS_VERIFY` | `false` | Verify the CCU's TLS certificate against the system trust store (for a publicly-trusted cert) |
+| `CCU_TLS_FINGERPRINT` | unset | Pin the CCU's self-signed leaf cert by its SHA-256 fingerprint (hex, colons optional). Takes precedence over the other TLS options |
+| `CCU_CA_CERT` | unset | Path to the CCU's CA/self-signed PEM for chain validation |
 | `CCU_TIMEOUT` | `10000` | CCU request timeout in milliseconds |
 | `CCU_SCRIPT_TIMEOUT` | `30000` | HM Script execution timeout in milliseconds |
 | `LOG_LEVEL` | `info` | `error`, `warn`, `info`, or `debug` |

--- a/src/ccu/client.ts
+++ b/src/ccu/client.ts
@@ -1,7 +1,13 @@
-import { Agent, fetch as undiciFetch } from "undici";
+import { Agent, buildConnector, fetch as undiciFetch } from "undici";
+import type { TLSSocket } from "node:tls";
 import type { CcuConfig, CcuRpcRequest, CcuRpcResponse } from "./types.js";
 import { CcuError, mapCcuError, mapNetworkError } from "../middleware/error-mapper.js";
 import type { Logger } from "../logger.js";
+
+/** Normalize a SHA-256 fingerprint for comparison: drop colons, lowercase. */
+function normalizeFingerprint(fp: string): string {
+  return fp.replace(/:/g, "").toLowerCase();
+}
 
 export class CcuClient {
   private readonly baseUrl: string;
@@ -18,11 +24,64 @@ export class CcuClient {
 
     if (config.https) {
       this.dispatcher = new Agent({
-        connect: { rejectUnauthorized: config.tlsVerify },
+        connect: this.buildConnect(config, logger),
         pipelining: 0,
         keepAliveTimeout: 1000,
       });
     }
+  }
+
+  /**
+   * Decide how the CCU's TLS certificate is verified (issue #51), most specific
+   * first:
+   *  1. CCU_TLS_FINGERPRINT — pin the exact self-signed leaf cert. Strongest
+   *     for an appliance; we complete the handshake without chain validation
+   *     (a self-signed cert has no chain) and reject unless the presented
+   *     cert's SHA-256 matches.
+   *  2. CCU_CA_CERT — trust a provided CA/self-signed PEM and do standard
+   *     chain validation.
+   *  3. CCU_TLS_VERIFY — verify against the system trust store (public CA).
+   *  4. Default — unverified, with a loud warning (a CCU ships a self-signed
+   *     cert, so this is the zero-config fallback, but it's MITM-exposed).
+   */
+  private buildConnect(config: CcuConfig, logger: Logger) {
+    if (config.tlsFingerprint) {
+      const expected = normalizeFingerprint(config.tlsFingerprint);
+      // rejectUnauthorized:false lets the self-signed handshake complete; the
+      // fingerprint check below is what actually authenticates the peer.
+      const connector = buildConnector({ rejectUnauthorized: false });
+      return (opts: buildConnector.Options, cb: buildConnector.Callback): void => {
+        connector(opts, (err, socket) => {
+          if (err || !socket) return cb(err ?? new Error("CCU TLS connect failed"), null);
+          const cert = (socket as TLSSocket).getPeerCertificate?.();
+          const actual = cert?.fingerprint256 ? normalizeFingerprint(cert.fingerprint256) : "";
+          if (!actual || actual !== expected) {
+            socket.destroy();
+            return cb(
+              new Error(
+                `CCU TLS certificate fingerprint mismatch (expected ${expected}, got ${actual || "none"})`,
+              ),
+              null,
+            );
+          }
+          cb(null, socket);
+        });
+      };
+    }
+
+    if (config.caCert) {
+      return { ca: config.caCert, rejectUnauthorized: true };
+    }
+
+    if (!config.tlsVerify) {
+      logger.warn("ccu_tls_unverified", {
+        hint:
+          "CCU TLS certificate is NOT verified (MITM-exposed). Pin it with " +
+          "CCU_TLS_FINGERPRINT, trust it with CCU_CA_CERT, or set CCU_TLS_VERIFY=true " +
+          "if the CCU presents a publicly-trusted certificate.",
+      });
+    }
+    return { rejectUnauthorized: config.tlsVerify };
   }
 
   async call(method: string, params: Record<string, unknown>, timeout?: number): Promise<unknown> {

--- a/src/ccu/types.ts
+++ b/src/ccu/types.ts
@@ -149,6 +149,19 @@ export interface CcuConfig {
   https: boolean;
   /** Verify the CCU's TLS certificate. Off by default: CCUs ship self-signed certs. */
   tlsVerify: boolean;
+  /**
+   * Pin the CCU's self-signed leaf certificate by its SHA-256 fingerprint
+   * (`CCU_TLS_FINGERPRINT`, hex, with or without colons). When set, the
+   * connection is rejected unless the presented cert matches — the simplest way
+   * to verify a self-signed appliance cert. Takes precedence over `caCert`.
+   */
+  tlsFingerprint?: string;
+  /**
+   * PEM contents of the CCU's CA / self-signed certificate (`CCU_CA_CERT`
+   * points at the file). When set, the connection is validated against this CA
+   * with standard chain verification.
+   */
+  caCert?: string;
   user: string;
   password: string;
   timeout: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import type { CcuConfig } from "./ccu/types.js";
 
 export interface AppConfig {
@@ -110,12 +111,28 @@ export function loadConfig(): AppConfig {
     throw new Error("MCP_TLS_CERT and MCP_TLS_KEY must both be set (or both unset)");
   }
 
+  // CCU TLS verification (issue #51). A CCU ships a self-signed cert, so verify
+  // it either by pinning the leaf fingerprint (CCU_TLS_FINGERPRINT) or by
+  // trusting a CA/self-signed PEM (CCU_CA_CERT). Fingerprint takes precedence.
+  const tlsFingerprint = process.env.CCU_TLS_FINGERPRINT?.trim() || undefined;
+  const caCertPath = process.env.CCU_CA_CERT?.trim() || undefined;
+  let caCert: string | undefined;
+  if (caCertPath) {
+    try {
+      caCert = readFileSync(caCertPath, "utf-8");
+    } catch (err) {
+      throw new Error(`CCU_CA_CERT could not be read at "${caCertPath}": ${(err as Error).message}`);
+    }
+  }
+
   return {
     ccu: {
       host,
       port: parseIntEnv("CCU_PORT", process.env.CCU_HTTPS === "true" ? "443" : "80"),
       https: process.env.CCU_HTTPS === "true",
       tlsVerify: process.env.CCU_TLS_VERIFY === "true",
+      tlsFingerprint,
+      caCert,
       user: process.env.CCU_USER || "Admin",
       password,
       timeout: parseIntEnv("CCU_TIMEOUT", "10000"),

--- a/src/config.ts
+++ b/src/config.ts
@@ -121,7 +121,11 @@ export function loadConfig(): AppConfig {
     try {
       caCert = readFileSync(caCertPath, "utf-8");
     } catch (err) {
-      throw new Error(`CCU_CA_CERT could not be read at "${caCertPath}": ${(err as Error).message}`);
+      // Don't interpolate the env-derived path here: a fatal config error is
+      // logged at the top level, and echoing raw env values into logs is a
+      // leak vector (js/clear-text-logging). The fs error already names the
+      // path for the operator.
+      throw new Error(`CCU_CA_CERT could not be read: ${(err as Error).message}`);
     }
   }
 

--- a/test/unit/ccu-tls-verify.test.ts
+++ b/test/unit/ccu-tls-verify.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:https";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { X509Certificate } from "node:crypto";
+import { AddressInfo } from "node:net";
+import { Logger } from "../../src/logger.js";
+import { CcuClient } from "../../src/ccu/client.js";
+import { CcuError } from "../../src/middleware/error-mapper.js";
+
+// Issue #51: the CcuClient must actually verify the CCU's self-signed TLS cert
+// when CCU_TLS_FINGERPRINT or CCU_CA_CERT is configured. This drives a real
+// local HTTPS server (a self-signed cert minted with openssl) through the
+// client's connector. Skipped if openssl isn't available.
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+
+const logger = new Logger("error");
+
+describe.skipIf(!HAVE_OPENSSL)("CcuClient TLS verification (real HTTPS server)", () => {
+  let server: Server;
+  let port: number;
+  let certPem: string;
+  let fingerprint: string;
+  let tmpDir: string;
+
+  const base = {
+    host: "127.0.0.1",
+    https: true,
+    tlsVerify: false,
+    user: "Admin",
+    password: "pw",
+    timeout: 5000,
+    scriptTimeout: 30000,
+  };
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ccu-tls-"));
+    const certPath = join(tmpDir, "cert.pem");
+    const keyPath = join(tmpDir, "key.pem");
+    // SAN must carry IP:127.0.0.1 — Node (>=17) dropped subject-CN fallback, and
+    // CA-cert mode (rejectUnauthorized:true) checks identity against the host.
+    const gen = spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=ccu",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    if (gen.status !== 0) throw new Error("openssl failed to generate test cert");
+
+    certPem = readFileSync(certPath, "utf-8");
+    fingerprint = new X509Certificate(certPem).fingerprint256; // "AB:CD:.."
+
+    server = createServer(
+      { cert: certPem, key: readFileSync(keyPath) },
+      (_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ id: "1", version: "1.1", result: "ok", error: null }));
+      },
+    );
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", () => {
+        port = (server.address() as AddressInfo).port;
+        resolve();
+      }),
+    );
+  });
+
+  afterAll(() => {
+    server?.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("connects when the pinned fingerprint matches", async () => {
+    const client = new CcuClient({ ...base, port, tlsFingerprint: fingerprint }, logger);
+    await expect(client.call("Test", {})).resolves.toBe("ok");
+  });
+
+  it("accepts a fingerprint written without colons", async () => {
+    const client = new CcuClient(
+      { ...base, port, tlsFingerprint: fingerprint.replace(/:/g, "") },
+      logger,
+    );
+    await expect(client.call("Test", {})).resolves.toBe("ok");
+  });
+
+  it("refuses to connect when the pinned fingerprint does not match", async () => {
+    const wrong = "00:".repeat(31) + "00";
+    const client = new CcuClient({ ...base, port, tlsFingerprint: wrong }, logger);
+    try {
+      await client.call("Test", {});
+      expect.unreachable("should have rejected the cert");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CcuError);
+      expect((err as CcuError).structured.error).toBe("UNREACHABLE");
+    }
+  });
+
+  it("connects when the cert is trusted via caCert", async () => {
+    const client = new CcuClient({ ...base, port, caCert: certPem }, logger);
+    await expect(client.call("Test", {})).resolves.toBe("ok");
+  });
+
+  it("rejects an untrusted cert under caCert verification", async () => {
+    // A different (unrelated) CA must not validate the server's cert.
+    const otherDir = mkdtempSync(join(tmpdir(), "ccu-tls-other-"));
+    const otherCert = join(otherDir, "cert.pem");
+    spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", join(otherDir, "key.pem"), "-out", otherCert,
+      "-days", "1", "-subj", "/CN=other", "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    const client = new CcuClient(
+      { ...base, port, caCert: readFileSync(otherCert, "utf-8") },
+      logger,
+    );
+    try {
+      await client.call("Test", {});
+      expect.unreachable("should have rejected the untrusted cert");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CcuError);
+      expect((err as CcuError).structured.error).toBe("UNREACHABLE");
+    } finally {
+      rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { loadConfig } from "../../src/config.js";
 
 describe("loadConfig", () => {
@@ -27,6 +30,8 @@ describe("loadConfig", () => {
     delete process.env.CCU_TIMEOUT;
     delete process.env.CCU_SCRIPT_TIMEOUT;
     delete process.env.CCU_TLS_VERIFY;
+    delete process.env.CCU_TLS_FINGERPRINT;
+    delete process.env.CCU_CA_CERT;
     delete process.env.MCP_HOST;
     delete process.env.MCP_TLS_CERT;
     delete process.env.MCP_TLS_KEY;
@@ -200,6 +205,43 @@ describe("loadConfig", () => {
 
     process.env.CCU_TLS_VERIFY = "true";
     expect(loadConfig().ccu.tlsVerify).toBe(true);
+  });
+
+  // Issue #51: CCU TLS verification via fingerprint pin or CA cert
+  it("CCU TLS pinning is off by default", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    const config = loadConfig();
+    expect(config.ccu.tlsFingerprint).toBeUndefined();
+    expect(config.ccu.caCert).toBeUndefined();
+  });
+
+  it("parses CCU_TLS_FINGERPRINT", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.CCU_TLS_FINGERPRINT = "AB:CD:EF:01";
+    expect(loadConfig().ccu.tlsFingerprint).toBe("AB:CD:EF:01");
+  });
+
+  it("reads CCU_CA_CERT file contents", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ccu-ca-"));
+    const caPath = join(dir, "ca.pem");
+    writeFileSync(caPath, "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n");
+    try {
+      process.env.CCU_HOST = "test";
+      process.env.CCU_PASSWORD = "pw";
+      process.env.CCU_CA_CERT = caPath;
+      expect(loadConfig().ccu.caCert).toContain("BEGIN CERTIFICATE");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws if CCU_CA_CERT points at a missing file", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.CCU_CA_CERT = "/no/such/ca.pem";
+    expect(() => loadConfig()).toThrow(/CCU_CA_CERT could not be read/);
   });
 
   // Issue #50: native TLS for the HTTP transport (opt-in), bind host, plaintext ack


### PR DESCRIPTION
Closes #51.

The CCU connection ran with `rejectUnauthorized: false` by default (CCUs ship a self-signed cert), leaving a LAN man-in-the-middle open with no way to verify the peer. This adds verification.

## Changes
- **`CCU_TLS_FINGERPRINT`** — pin the self-signed leaf cert by its SHA-256 (hex, colons optional). The handshake completes without chain validation (a self-signed cert has no chain), then a custom undici connector inspects the peer cert and **rejects unless the fingerprint matches**. Strongest and simplest for an appliance.
- **`CCU_CA_CERT`** — trust a provided CA/self-signed PEM and do standard chain validation (`rejectUnauthorized: true`).
- **Precedence:** fingerprint → CA cert → `CCU_TLS_VERIFY` (system trust store).
- When none is set and verification is off, the client logs a loud `ccu_tls_unverified` warning instead of silently trusting any cert.

## Tests
- Config parsing for both vars, including reading the CA file and the missing-file error.
- A **real local HTTPS server** drives the clients connector end-to-end: fingerprint match, no-colon fingerprint form, fingerprint **mismatch rejected**, CA trust, and an unrelated CA **rejected**.

README documents all three options and the `openssl s_client … -fingerprint -sha256` one-liner to read the fingerprint.

Full suite green (299 passed), lint clean.