### PR TITLE
Fix: TLS fingerprint pinning broke on session resumption

### DIFF
--- a/src/ccu/client.ts
+++ b/src/ccu/client.ts
@@ -49,7 +49,12 @@ export class CcuClient {
       const expected = normalizeFingerprint(config.tlsFingerprint);
       // rejectUnauthorized:false lets the self-signed handshake complete; the
       // fingerprint check below is what actually authenticates the peer.
-      const connector = buildConnector({ rejectUnauthorized: false });
+      // maxCachedSessions:0 disables TLS session resumption: on a resumed
+      // session the server does NOT re-send its certificate, so
+      // getPeerCertificate() comes back empty and the fingerprint check would
+      // wrongly reject every connection after the first. Forcing a full
+      // handshake per connection guarantees the cert is always present to pin.
+      const connector = buildConnector({ rejectUnauthorized: false, maxCachedSessions: 0 });
       return (opts: buildConnector.Options, cb: buildConnector.Callback): void => {
         connector(opts, (err, socket) => {
           if (err || !socket) return cb(err ?? new Error("CCU TLS connect failed"), null);

--- a/test/unit/ccu-tls-verify.test.ts
+++ b/test/unit/ccu-tls-verify.test.ts
@@ -85,6 +85,18 @@ describe.skipIf(!HAVE_OPENSSL)("CcuClient TLS verification (real HTTPS server)",
     await expect(client.call("Test", {})).resolves.toBe("ok");
   });
 
+  // Regression: TLS session resumption returns an empty peer cert on a resumed
+  // connection, which made fingerprint pinning reject those requests. One
+  // awaited call caches the TLS session; the following concurrent burst then
+  // opens fresh connections that would resume it. The client disables session
+  // caching so every connection presents the cert and all calls verify.
+  it("verifies the fingerprint on connections that would resume the TLS session", async () => {
+    const client = new CcuClient({ ...base, port, tlsFingerprint: fingerprint }, logger);
+    await client.call("Test", {}); // full handshake, caches the session
+    const results = await Promise.all(Array.from({ length: 8 }, () => client.call("Test", {})));
+    expect(results).toEqual(Array(8).fill("ok"));
+  });
+
   it("refuses to connect when the pinned fingerprint does not match", async () => {
     const wrong = "00:".repeat(31) + "00";
     const client = new CcuClient({ ...base, port, tlsFingerprint: wrong }, logger);


### PR DESCRIPTION
Follow-up to #51 (found while enabling pinning against the live CCU).

## The bug
`CCU_TLS_FINGERPRINT` verified the cert on the **first** connection but rejected any connection that **resumed** the TLS session. On a resumed handshake the server does not re-send its certificate, so `getPeerCertificate()` returns an empty object and the fingerprint check saw `"none"` and rejected.

Against the real CCU this looked like `Session.login` succeeding, then the concurrent cache-warm / tool calls failing with `fetch failed` (`UNREACHABLE`) — i.e. pinning was effectively unusable.

## The fix
Build the undici connector with `maxCachedSessions: 0`, disabling TLS session resumption so every connection does a full handshake and always presents the certificate to pin. Socket keep-alive (sequential request reuse) is unaffected; only TLS session *resumption* on new connections is disabled — negligible cost on a LAN.

## Test
The regression test drives a real local HTTPS server: one awaited call caches the TLS session, then a concurrent burst opens connections that would resume it — all must verify. I confirmed the test **fails without the fix** and passes with it.

Also verified end-to-end against the live CCU: with the correct pinned fingerprint, `get_system_info` / `list_interfaces` now succeed across all calls; a wrong fingerprint is rejected.

Full suite green (300 passed), lint clean.