### PR TITLE
Add exhaustive .env.example with a drift guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,81 @@
+# debmatic-mcp configuration — copy to .env and adjust.
+# All settings are environment variables; values shown are the defaults.
+# Only CCU_HOST and CCU_PASSWORD are required; everything else is optional.
+
+# ─── CCU connection (required) ──────────────────────────────────────────────
+# Hostname or IP of your CCU / debmatic box.
+CCU_HOST=debmatic
+# CCU admin password.
+CCU_PASSWORD=
+
+# ─── CCU connection (optional) ──────────────────────────────────────────────
+# CCU username. Use a dedicated least-privilege account instead of Admin if you can.
+CCU_USER=Admin
+# API port. Defaults to 80, or 443 when CCU_HTTPS=true.
+CCU_PORT=80
+# Connect over HTTPS (self-signed certs supported — see TLS verification below).
+CCU_HTTPS=false
+# Per-request timeout in milliseconds.
+CCU_TIMEOUT=10000
+# Timeout for HM Script (ReGa) executions in milliseconds.
+CCU_SCRIPT_TIMEOUT=30000
+
+# ─── CCU TLS verification (optional) ────────────────────────────────────────
+# A CCU ships a self-signed cert, so verification is OFF by default and the
+# server logs a warning. Pick ONE of the three to actually verify the peer.
+# Precedence: CCU_TLS_FINGERPRINT > CCU_CA_CERT > CCU_TLS_VERIFY.
+#
+# Pin the self-signed leaf cert by its SHA-256 (hex, colons optional). Read it with:
+#   echo | openssl s_client -connect "$CCU_HOST:443" 2>/dev/null \
+#     | openssl x509 -noout -fingerprint -sha256
+CCU_TLS_FINGERPRINT=
+# Path to the CCU's CA / self-signed PEM for standard chain validation.
+CCU_CA_CERT=
+# Verify against the system trust store (only if the CCU has a publicly-trusted cert).
+CCU_TLS_VERIFY=false
+
+# ─── CCU rate limiting (optional) ───────────────────────────────────────────
+# Max burst of requests sent to the CCU.
+CCU_RATE_LIMIT_BURST=20
+# Sustained CCU requests per second.
+CCU_RATE_LIMIT_RATE=10
+
+# ─── MCP transport (optional) ───────────────────────────────────────────────
+# Transport: "http" or "stdio" (the --stdio / --http CLI flags override this).
+MCP_TRANSPORT=http
+# HTTP server port (HTTP mode only).
+MCP_PORT=3000
+# Bearer token for HTTP mode. If unset, one is generated and saved to $CACHE_DIR/.env.
+MCP_AUTH_TOKEN=
+# Bind address for the HTTP listener. Unset = all interfaces. Set 127.0.0.1 to
+# restrict to loopback (e.g. behind a TLS-terminating proxy); also silences the
+# plaintext warning.
+MCP_HOST=
+# Native HTTPS for the MCP transport: set BOTH to serve over TLS. Leave unset
+# for plain HTTP (the default). Setting only one is a configuration error.
+MCP_TLS_CERT=
+MCP_TLS_KEY=
+# Acknowledge serving the bearer token over plain HTTP and silence the
+# non-loopback plaintext warning.
+MCP_ALLOW_PLAINTEXT=false
+# Comma-separated allowlist of browser origins for CORS. Unset = no cross-origin
+# browser access (default-deny). An allowlisted origin is reflected exactly
+# (never "*"); the list also drives DNS-rebinding origin checks.
+# e.g. https://app.example,http://localhost:6274
+MCP_ALLOWED_ORIGINS=
+# Extra Host values accepted by DNS-rebinding protection (comma-separated
+# host:port). localhost/127.0.0.1 on MCP_PORT are always allowed; add your
+# hostname when behind a proxy or container DNS name.
+MCP_ALLOWED_HOSTS=
+
+# ─── Cache (optional) ───────────────────────────────────────────────────────
+# Directory for the device-type cache and the generated auth token.
+CACHE_DIR=/data
+# Cache lifetime in seconds (24h).
+CACHE_TTL=86400
+
+# ─── Misc (optional) ────────────────────────────────────────────────────────
+# Seconds between polls for MCP resource change notifications.
+RESOURCE_POLL_INTERVAL=60
+# Log level: error | warn | info | debug.
+LOG_LEVEL=info

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// Guard: .env.example must document every environment variable the code reads,
+// and must not list any that the code doesn't. Keeps the example exhaustive
+// (and honest) as env vars come and go.
+
+const SRC = join(__dirname, "../../src");
+const ENV_EXAMPLE = join(__dirname, "../../.env.example");
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectTsFiles(p));
+    else if (entry.name.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+
+function envKeysReferencedInCode(): Set<string> {
+  const keys = new Set<string>();
+  for (const file of collectTsFiles(SRC)) {
+    const text = readFileSync(file, "utf-8");
+    // process.env.FOO and process.env["FOO"]
+    for (const m of text.matchAll(/process\.env(?:\.([A-Z][A-Z0-9_]*)|\["([A-Z][A-Z0-9_]*)"\])/g)) {
+      keys.add(m[1] ?? m[2]);
+    }
+    // parseIntEnv("FOO", ...) — indirect numeric reads
+    for (const m of text.matchAll(/parseIntEnv\("([A-Z][A-Z0-9_]*)"/g)) {
+      keys.add(m[1]);
+    }
+  }
+  return keys;
+}
+
+function envKeysInExample(): Set<string> {
+  const keys = new Set<string>();
+  for (const line of readFileSync(ENV_EXAMPLE, "utf-8").split("\n")) {
+    const m = line.match(/^([A-Z][A-Z0-9_]*)=/);
+    if (m) keys.add(m[1]);
+  }
+  return keys;
+}
+
+describe(".env.example", () => {
+  it("documents every env var the code reads", () => {
+    const code = envKeysReferencedInCode();
+    const example = envKeysInExample();
+    const missing = [...code].filter((k) => !example.has(k)).sort();
+    expect(missing, `env vars read in code but missing from .env.example: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("does not list env vars the code never reads", () => {
+    const code = envKeysReferencedInCode();
+    const example = envKeysInExample();
+    const stale = [...example].filter((k) => !code.has(k)).sort();
+    expect(stale, `env vars in .env.example not read anywhere in code: ${stale.join(", ")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
There was no `.env.example`. This adds one listing **all 25** environment variables (required + optional) with their defaults, grouped by area: CCU connection, CCU TLS verification, rate limiting, MCP transport/TLS/CORS, cache, and misc.

To keep it honest, a unit test scans `src/` for every env var the code reads (`process.env.X`, `process.env["X"]`, and the indirect `parseIntEnv("X")`) and asserts `.env.example` lists **exactly** those — fails if a var is added to the code but not the example, or left in the example after being removed from the code.

Full suite green (302 passed), lint clean.