### PR TITLE
Auth token rotation and expiry (#52)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,17 @@ MCP_TRANSPORT=http
 MCP_PORT=3000
 # Bearer token for HTTP mode. If unset, one is generated and saved to $CACHE_DIR/.env.
 MCP_AUTH_TOKEN=
+# Previous bearer token, accepted alongside MCP_AUTH_TOKEN during a rotation so
+# clients still on the old token aren't dropped. Remove it (and restart) to end
+# the overlap. Applies to the explicit MCP_AUTH_TOKEN path only.
+MCP_AUTH_TOKEN_PREVIOUS=
+# Lifetime of the AUTO-GENERATED token, in days (fractional allowed). Unset =
+# never expires. Past expiry the token auto-rotates on the next startup; the old
+# one stays valid for MCP_AUTH_TOKEN_GRACE_HOURS. Ignored when MCP_AUTH_TOKEN is set.
+MCP_AUTH_TOKEN_TTL_DAYS=
+# Overlap (hours) after an auto-rotation during which the just-replaced token is
+# still accepted, so in-flight clients survive the swap. Default 24.
+MCP_AUTH_TOKEN_GRACE_HOURS=24
 # Bind address for the HTTP listener. Unset = all interfaces. Set 127.0.0.1 to
 # restrict to loopback (e.g. behind a TLS-terminating proxy); also silences the
 # plaintext warning.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ The HTTP transport also has **DNS-rebinding protection** on by default: it rejec
 
 **TLS.** The bearer token travels in the request, so anything beyond loopback should be encrypted. You have two options: terminate TLS at a reverse proxy (Caddy/nginx) in front and bind the server to loopback (`MCP_HOST=127.0.0.1`), or let the server serve HTTPS itself by setting `MCP_TLS_CERT` and `MCP_TLS_KEY` to a PEM cert/key pair. Plain HTTP is still fully supported — it stays the zero-config default — but the server logs a warning at startup when it's serving the token over unencrypted HTTP on a non-loopback bind; set `MCP_ALLOW_PLAINTEXT=true` to acknowledge that and silence it.
 
+**Token rotation & expiry.** By default the bearer token lives forever. Two optional, composable controls let you rotate it without dropping clients:
+
+- *Auto-generated token* — set `MCP_AUTH_TOKEN_TTL_DAYS` (fractional days allowed) to give the generated token a lifetime. Once it lapses, the server mints a fresh one **on the next startup** and prints it on stderr, while the just-replaced token keeps validating for `MCP_AUTH_TOKEN_GRACE_HOURS` (default 24) so in-flight clients survive the swap. Expiry is also enforced live: a lapsed token is rejected mid-run with a `401` + `WWW-Authenticate: Bearer … error="invalid_token"`. To force a rotation sooner, delete `$CACHE_DIR/.env` (or just its `MCP_AUTH_TOKEN` line) and restart.
+- *Explicit token* — when you set `MCP_AUTH_TOKEN` yourself, you own its lifetime (TTL doesn't apply). To rotate, put the new token in `MCP_AUTH_TOKEN`, move the old one to `MCP_AUTH_TOKEN_PREVIOUS`, and restart; both are accepted during the overlap. Drop `MCP_AUTH_TOKEN_PREVIOUS` and restart once every client is on the new token. Comparison stays timing-safe across every currently-valid token.
+
 CORS support was first implemented by [@marcinn2](https://github.com/marcinn2) in his fork [marcinn2/debmatic-mcp](https://github.com/marcinn2/debmatic-mcp) — thanks!
 
 ### HTTPS
@@ -183,6 +188,9 @@ All configuration is via environment variables:
 | `MCP_TRANSPORT` | `http` | `http` or `stdio` (the `--stdio` CLI flag overrides this) |
 | `MCP_PORT` | `3000` | HTTP server port (HTTP mode only) |
 | `MCP_AUTH_TOKEN` | auto-generated | Bearer token for HTTP mode; generated and saved to `$CACHE_DIR/.env` on first start |
+| `MCP_AUTH_TOKEN_PREVIOUS` | unset | Previous bearer token, accepted alongside `MCP_AUTH_TOKEN` during a rotation overlap; remove it (and restart) to end the overlap. Explicit-token path only |
+| `MCP_AUTH_TOKEN_TTL_DAYS` | unset (never expires) | Lifetime of the **auto-generated** token, in days (fractional allowed). Past expiry it auto-rotates on next startup; ignored when `MCP_AUTH_TOKEN` is set |
+| `MCP_AUTH_TOKEN_GRACE_HOURS` | `24` | Overlap (hours) after an auto-rotation during which the just-replaced token is still accepted |
 | `MCP_ALLOWED_ORIGINS` | unset | Comma-separated allowlist of browser origins. Unset = no cross-origin browser access (default-deny). An allowlisted origin is reflected exactly in `Access-Control-Allow-Origin` (never `*`); the list also drives DNS-rebinding origin checks |
 | `MCP_ALLOWED_HOSTS` | `localhost`/`127.0.0.1` | Extra `Host` values accepted by DNS-rebinding protection (comma-separated `host:port`); add your hostname when behind a proxy or container DNS name |
 | `MCP_HOST` | unset (all interfaces) | Bind address for the HTTP listener; set `127.0.0.1` to restrict to loopback (e.g. behind a TLS-terminating proxy), which also silences the plaintext warning |

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -1,52 +1,229 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { Logger } from "../logger.js";
 
 const ENV_FILENAME = ".env";
 
-export async function resolveAuthToken(
-  envToken: string | undefined,
-  dataDir: string,
-  logger: Logger,
-): Promise<string> {
-  // 1. Explicit env var takes priority
-  if (envToken) {
-    logger.info("auth_token_from_env");
-    return envToken;
-  }
+/** sha256 of a token — fixed width so timingSafeEqual never sees a length mismatch. */
+function sha256(value: string): Buffer {
+  return createHash("sha256").update(value).digest();
+}
 
-  // 2. Try loading from /data/.env
-  const envPath = join(dataDir, ENV_FILENAME);
-  try {
-    const content = await readFile(envPath, "utf-8");
-    const match = content.match(/^MCP_AUTH_TOKEN=(.+)$/m);
-    if (match?.[1]) {
-      logger.info("auth_token_from_file");
-      // trim: tolerate trailing \r if the file was edited with CRLF line endings
-      return match[1].trim();
+interface TokenEntry {
+  /** sha256 of the accepted token. */
+  hash: Buffer;
+  /** Epoch ms after which this token is rejected; null = never expires. */
+  expiresAt: number | null;
+  /** For diagnostics only — never the token itself. */
+  label: string;
+}
+
+/**
+ * A set of currently-acceptable bearer tokens. Expiry is evaluated live at
+ * verification time (against `now`), so a token stops validating the moment it
+ * lapses — no restart or background timer needed.
+ */
+export class AuthTokens {
+  constructor(private readonly entries: TokenEntry[]) {}
+
+  /**
+   * Timing-safe check of a presented token against every entry. Compares against
+   * ALL entries (no early return) so neither a match nor expiry leaks via timing,
+   * preserving the original single-token guarantee across the rotation set.
+   */
+  verify(presented: string, now: number = Date.now()): boolean {
+    // Empty / missing credentials never match. Cheap, and the only thing the
+    // short-circuit leaks ("no token presented") is already visible in the 401
+    // challenge the caller sends back.
+    if (!presented) return false;
+    const ph = sha256(presented);
+    let ok = false;
+    for (const entry of this.entries) {
+      const match = timingSafeEqual(ph, entry.hash);
+      const live = entry.expiresAt === null || now <= entry.expiresAt;
+      ok = ok || (match && live);
     }
-  } catch {
-    // File doesn't exist — will generate
+    return ok;
   }
 
-  // 3. Generate new token
-  const token = randomBytes(32).toString("base64url");
+  /** Count of entries still live at `now` — for the startup log, exposes no secrets. */
+  liveCount(now: number = Date.now()): number {
+    return this.entries.filter((e) => e.expiresAt === null || now <= e.expiresAt).length;
+  }
+}
 
+export interface ResolveAuthTokensOptions {
+  /** Explicit operator-managed token (`MCP_AUTH_TOKEN`). Highest priority. */
+  envToken?: string;
+  /** Previous operator-managed token kept valid for the rotation overlap (`MCP_AUTH_TOKEN_PREVIOUS`). */
+  envPreviousToken?: string;
+  /** Where the auto-generated token + its metadata are persisted. */
+  dataDir: string;
+  /** Lifetime of the auto-generated token in ms; undefined ⇒ never expires. */
+  ttlMs?: number;
+  /** Overlap after an auto-rotation during which the just-replaced token still validates. */
+  graceMs: number;
+}
+
+/** Persisted shape of the auto-generated token file. */
+interface PersistedToken {
+  token?: string;
+  issued?: number;
+  previous?: string;
+  previousExpires?: number;
+}
+
+function parsePersisted(content: string): PersistedToken {
+  // trim: tolerate a trailing \r if the file was edited with CRLF (issue #13)
+  const read = (key: string): string | undefined =>
+    content.match(new RegExp(`^${key}=(.+)$`, "m"))?.[1]?.trim();
+  const readNum = (key: string): number | undefined => {
+    const raw = read(key);
+    if (raw === undefined) return undefined;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : undefined;
+  };
+  return {
+    token: read("MCP_AUTH_TOKEN"),
+    issued: readNum("MCP_AUTH_TOKEN_ISSUED"),
+    previous: read("MCP_AUTH_TOKEN_PREVIOUS"),
+    previousExpires: readNum("MCP_AUTH_TOKEN_PREVIOUS_EXPIRES"),
+  };
+}
+
+function serialize(state: PersistedToken): string {
+  const lines = [`MCP_AUTH_TOKEN=${state.token}`];
+  if (state.issued !== undefined) lines.push(`MCP_AUTH_TOKEN_ISSUED=${state.issued}`);
+  if (state.previous !== undefined) {
+    lines.push(`MCP_AUTH_TOKEN_PREVIOUS=${state.previous}`);
+    if (state.previousExpires !== undefined) {
+      lines.push(`MCP_AUTH_TOKEN_PREVIOUS_EXPIRES=${state.previousExpires}`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+async function persist(dataDir: string, state: PersistedToken, logger: Logger): Promise<void> {
+  const envPath = join(dataDir, ENV_FILENAME);
   try {
     await mkdir(dataDir, { recursive: true });
     const tmpPath = envPath + ".tmp";
-    // 0600: file contains the bearer token for the HTTP transport
-    await writeFile(tmpPath, `MCP_AUTH_TOKEN=${token}\n`, { encoding: "utf-8", mode: 0o600 });
+    // 0600: file contains the bearer token(s) for the HTTP transport
+    await writeFile(tmpPath, serialize(state), { encoding: "utf-8", mode: 0o600 });
     await rename(tmpPath, envPath);
-    logger.info("auth_token_generated");
-    // Log to stderr so user can copy it
-    process.stderr.write(`\n[debmatic-mcp] Generated auth token: ${token}\n`);
-    process.stderr.write(`[debmatic-mcp] Token saved to ${envPath}\n`);
-    process.stderr.write(`[debmatic-mcp] Use this token in your MCP client configuration.\n\n`);
   } catch (err) {
     logger.error("auth_token_save_failed", { error: (err as Error).message });
   }
+}
 
-  return token;
+function announce(token: string, dataDir: string, rotated: boolean): void {
+  const envPath = join(dataDir, ENV_FILENAME);
+  const what = rotated ? "Rotated auth token" : "Generated auth token";
+  // stderr so the operator can copy it; never goes through the structured logger.
+  process.stderr.write(`\n[debmatic-mcp] ${what}: ${token}\n`);
+  process.stderr.write(`[debmatic-mcp] Token saved to ${envPath}\n`);
+  process.stderr.write(`[debmatic-mcp] Use this token in your MCP client configuration.\n\n`);
+}
+
+/**
+ * Resolve the set of currently-valid bearer tokens (issue #52).
+ *
+ * Precedence mirrors the original single-token resolver:
+ *  1. Explicit `MCP_AUTH_TOKEN` (operator-managed, never auto-expired). An
+ *     optional `MCP_AUTH_TOKEN_PREVIOUS` is accepted alongside it for the
+ *     rotation overlap; the operator ends the overlap by dropping it + restart.
+ *     TTL does not apply to operator-supplied tokens — the operator owns them.
+ *  2. The auto-generated token persisted under `dataDir/.env`. With `ttlMs` set
+ *     it carries an issued-at; once it lapses we rotate on startup: a fresh
+ *     token is generated and the just-replaced one stays valid for `graceMs`
+ *     so in-flight clients aren't cut off mid-migration.
+ *  3. If neither exists, generate and persist a new token.
+ */
+export async function resolveAuthTokens(
+  opts: ResolveAuthTokensOptions,
+  logger: Logger,
+  now: number = Date.now(),
+): Promise<AuthTokens> {
+  // 1. Explicit env token(s) — operator-managed, no TTL, file untouched.
+  if (opts.envToken) {
+    logger.info("auth_token_from_env", { previous: Boolean(opts.envPreviousToken) });
+    const entries: TokenEntry[] = [
+      { hash: sha256(opts.envToken), expiresAt: null, label: "env" },
+    ];
+    if (opts.envPreviousToken) {
+      entries.push({ hash: sha256(opts.envPreviousToken), expiresAt: null, label: "env-previous" });
+    }
+    return new AuthTokens(entries);
+  }
+
+  // 2 + 3. File-backed auto-generated token.
+  const { dataDir, ttlMs, graceMs } = opts;
+  let state: PersistedToken = {};
+  try {
+    state = parsePersisted(await readFile(join(dataDir, ENV_FILENAME), "utf-8"));
+  } catch {
+    // File doesn't exist (or is unreadable) — fall through to generation.
+  }
+
+  let changed = false;
+  let minted = false; // brand-new token this run (generate or rotate) → announce
+  let rotated = false;
+
+  if (!state.token) {
+    // 3. No usable token — generate.
+    state = { token: randomBytes(32).toString("base64url"), issued: now };
+    changed = true;
+    minted = true;
+    logger.info("auth_token_generated");
+  } else if (ttlMs !== undefined) {
+    if (state.issued === undefined) {
+      // Legacy file written before TTL existed: start the clock now rather than
+      // expiring a token whose true age we can't know.
+      state.issued = now;
+      changed = true;
+    } else if (now - state.issued >= ttlMs) {
+      // Expired → rotate. Keep the old token valid for the grace overlap.
+      state = {
+        token: randomBytes(32).toString("base64url"),
+        issued: now,
+        previous: state.token,
+        previousExpires: now + graceMs,
+      };
+      changed = true;
+      minted = true;
+      rotated = true;
+      logger.info("auth_token_rotated", { graceMs });
+    }
+  }
+
+  // Drop a previously-rotated token once its grace window has fully elapsed.
+  if (
+    state.previous !== undefined &&
+    state.previousExpires !== undefined &&
+    now > state.previousExpires
+  ) {
+    delete state.previous;
+    delete state.previousExpires;
+    changed = true;
+  }
+
+  if (changed) await persist(dataDir, state, logger);
+  if (minted) announce(state.token!, dataDir, rotated);
+
+  const entries: TokenEntry[] = [
+    {
+      hash: sha256(state.token!),
+      expiresAt: ttlMs !== undefined && state.issued !== undefined ? state.issued + ttlMs : null,
+      label: "generated",
+    },
+  ];
+  if (state.previous !== undefined && state.previousExpires !== undefined) {
+    entries.push({
+      hash: sha256(state.previous),
+      expiresAt: state.previousExpires,
+      label: "rotated-out",
+    });
+  }
+  return new AuthTokens(entries);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,26 @@ export interface AppConfig {
     port: number;
     authToken?: string;
     /**
+     * Previous bearer token kept valid for the rotation overlap
+     * (`MCP_AUTH_TOKEN_PREVIOUS`). Lets operators roll `MCP_AUTH_TOKEN` without
+     * dropping clients still on the old token; remove it (and restart) to end
+     * the overlap. Applies to the explicit-token path only.
+     */
+    authTokenPrevious?: string;
+    /**
+     * Lifetime of the AUTO-GENERATED bearer token in ms (`MCP_AUTH_TOKEN_TTL_DAYS`,
+     * fractional days allowed). Unset ⇒ the generated token never expires (the
+     * historical default). Does not apply to an explicit `MCP_AUTH_TOKEN`, which
+     * the operator owns. On startup past expiry the token auto-rotates.
+     */
+    authTokenTtlMs?: number;
+    /**
+     * Overlap after an auto-rotation during which the just-replaced token still
+     * validates, so in-flight clients survive the swap (`MCP_AUTH_TOKEN_GRACE_HOURS`,
+     * default 24).
+     */
+    authTokenGraceMs: number;
+    /**
      * Default-deny origin allowlist for browser-based MCP clients. Empty ⇒ no
      * cross-origin browser access (the secure default). A request whose `Origin`
      * is on this list gets that exact origin reflected in
@@ -80,6 +100,19 @@ export function loadConfig(): AppConfig {
     return val;
   };
 
+  // Optional positive duration in `unitMs` units; fractional values allowed
+  // (e.g. 0.5 days). Returns undefined when unset; throws on garbage so a
+  // typo'd TTL fails loudly instead of silently disabling expiry.
+  const parseDurationEnv = (name: string, unitMs: number): number | undefined => {
+    const raw = process.env[name]?.trim();
+    if (!raw) return undefined;
+    const val = Number(raw);
+    if (!Number.isFinite(val) || val <= 0) {
+      throw new Error(`${name} must be a positive number, got: "${process.env[name]}"`);
+    }
+    return Math.round(val * unitMs);
+  };
+
   const mcpPort = parseIntEnv("MCP_PORT", "3000");
   // DNS-rebinding defense: the transport rejects any Host header not on this
   // list. localhost/127.0.0.1 on the bound port covers local use; deployments
@@ -146,6 +179,9 @@ export function loadConfig(): AppConfig {
       transport,
       port: mcpPort,
       authToken: process.env.MCP_AUTH_TOKEN,
+      authTokenPrevious: process.env.MCP_AUTH_TOKEN_PREVIOUS?.trim() || undefined,
+      authTokenTtlMs: parseDurationEnv("MCP_AUTH_TOKEN_TTL_DAYS", 86_400_000),
+      authTokenGraceMs: parseDurationEnv("MCP_AUTH_TOKEN_GRACE_HOURS", 3_600_000) ?? 24 * 3_600_000,
       allowedOrigins,
       allowedHosts,
       host: process.env.MCP_HOST?.trim() || undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from "node:http";
 import { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
 import { readFile } from "node:fs/promises";
-import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -19,7 +19,7 @@ import { RateLimiter } from "./middleware/rate-limiter.js";
 import { DeviceTypeCache } from "./cache/device-type-cache.js";
 import { Resolver } from "./middleware/resolver.js";
 import { ResourcePoller } from "./resources/poller.js";
-import { resolveAuthToken } from "./auth/token.js";
+import { resolveAuthTokens } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
 import { createMcpServer } from "./server.js";
 import { extractBearerToken } from "./utils.js";
@@ -83,7 +83,16 @@ async function main(): Promise<void> {
     // A stateless StreamableHTTPServerTransport only survives a single request,
     // so each MCP session gets its own transport + server (deps are shared),
     // routed by the Mcp-Session-Id header per the SDK's session pattern.
-    const authToken = await resolveAuthToken(config.mcp.authToken, config.cache.dir, logger);
+    const authTokens = await resolveAuthTokens(
+      {
+        envToken: config.mcp.authToken,
+        envPreviousToken: config.mcp.authTokenPrevious,
+        dataDir: config.cache.dir,
+        ttlMs: config.mcp.authTokenTtlMs,
+        graceMs: config.mcp.authTokenGraceMs,
+      },
+      logger,
+    );
     const sessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
 
     const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
@@ -132,12 +141,11 @@ async function main(): Promise<void> {
         }
 
         // Auth check for MCP endpoints. Token parsing tolerates the
-        // case-insensitive scheme (RFC 7235); the comparison is timing-safe
-        // (hash both sides so length differences don't leak via timing).
+        // case-insensitive scheme (RFC 7235); verify() is timing-safe across all
+        // currently-valid tokens (it hashes both sides and checks every entry
+        // without early return) and enforces expiry live (issue #52).
         const presented = extractBearerToken(req.headers.authorization ?? "");
-        const ha = createHash("sha256").update(presented).digest();
-        const hb = createHash("sha256").update(authToken).digest();
-        const headerValid = timingSafeEqual(ha, hb);
+        const headerValid = authTokens.verify(presented);
         if (!headerValid) {
           // Challenge header so clients can discover the scheme (RFC 6750 /
           // MCP auth spec). Add error=invalid_token only when a (bad) token was
@@ -249,6 +257,7 @@ async function main(): Promise<void> {
         port: config.mcp.port,
         host: config.mcp.host ?? "0.0.0.0",
         tls: useTls,
+        authTokens: authTokens.liveCount(),
       });
     });
   }

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -44,7 +44,7 @@ describeIf("MCP tools against live CCU", () => {
     deps = {
       config: {
         ccu: config,
-        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
+        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
         cache: { dir: tempDir, ttl: 86400 },
         rateLimiter: { burst: 20, rate: 10 },
         resourcePollInterval: 3600,

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -13,7 +13,7 @@ export function createMockDeps(overrides?: {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,

--- a/test/unit/auth-token.test.ts
+++ b/test/unit/auth-token.test.ts
@@ -1,96 +1,186 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { resolveAuthToken } from "../../src/auth/token.js";
+import { resolveAuthTokens } from "../../src/auth/token.js";
 import { Logger } from "../../src/logger.js";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 const logger = new Logger("error");
 
-describe("resolveAuthToken", () => {
-  let tempDir: string;
+const DAY = 86_400_000;
+const HOUR = 3_600_000;
+
+// Pull the persisted token straight out of the .env file the resolver wrote.
+async function fileToken(dir: string): Promise<string> {
+  const content = await readFile(join(dir, ".env"), "utf-8");
+  return content.match(/^MCP_AUTH_TOKEN=(.+)$/m)![1].trim();
+}
+
+describe("resolveAuthTokens", () => {
+  let dir: string;
 
   beforeEach(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "debmatic-auth-test-"));
+    dir = await mkdtemp(join(tmpdir(), "debmatic-auth-test-"));
     vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   });
 
   afterEach(async () => {
-    await rm(tempDir, { recursive: true, force: true });
+    await rm(dir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
 
-  it("returns explicit env token if provided", async () => {
-    const token = await resolveAuthToken("my-explicit-token", tempDir, logger);
-    expect(token).toBe("my-explicit-token");
+  it("accepts the explicit env token and rejects everything else", async () => {
+    const tokens = await resolveAuthTokens(
+      { envToken: "my-explicit-token", dataDir: dir, graceMs: 24 * HOUR },
+      logger,
+    );
+    expect(tokens.verify("my-explicit-token")).toBe(true);
+    expect(tokens.verify("nope")).toBe(false);
+    expect(tokens.verify("")).toBe(false);
   });
 
-  it("generates token and saves to .env if none exists", async () => {
-    const token = await resolveAuthToken(undefined, tempDir, logger);
+  it("env token takes priority and leaves the data dir untouched", async () => {
+    const tokens = await resolveAuthTokens(
+      { envToken: "override", dataDir: dir, graceMs: 24 * HOUR },
+      logger,
+    );
+    expect(tokens.verify("override")).toBe(true);
+    // No file should have been written for the explicit-token path.
+    await expect(readFile(join(dir, ".env"), "utf-8")).rejects.toThrow();
+  });
 
+  it("accepts both env current and previous during a rotation overlap", async () => {
+    const tokens = await resolveAuthTokens(
+      { envToken: "new", envPreviousToken: "old", dataDir: dir, graceMs: 24 * HOUR },
+      logger,
+    );
+    expect(tokens.verify("new")).toBe(true);
+    expect(tokens.verify("old")).toBe(true);
+    expect(tokens.verify("ancient")).toBe(false);
+  });
+
+  it("generates and persists a token when none exists", async () => {
+    const tokens = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    const token = await fileToken(dir);
     expect(token.length).toBeGreaterThan(20);
-
-    // Check file was created
-    const content = await readFile(join(tempDir, ".env"), "utf-8");
-    expect(content).toBe(`MCP_AUTH_TOKEN=${token}\n`);
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/); // base64url, no padding
+    expect(tokens.verify(token)).toBe(true);
   });
 
-  it("loads existing token from .env", async () => {
-    // First call generates
-    const token1 = await resolveAuthToken(undefined, tempDir, logger);
-
-    // Second call loads
-    const token2 = await resolveAuthToken(undefined, tempDir, logger);
-
-    expect(token2).toBe(token1);
+  it("loads the same token across runs", async () => {
+    await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    const token = await fileToken(dir);
+    const tokens2 = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    expect(tokens2.verify(token)).toBe(true);
   });
 
-  it("env token takes priority over .env file", async () => {
-    // Generate a file token first
-    await resolveAuthToken(undefined, tempDir, logger);
-
-    // Explicit env should win
-    const token = await resolveAuthToken("override-token", tempDir, logger);
-    expect(token).toBe("override-token");
+  it("trims a trailing CR from CRLF-edited files (issue #13)", async () => {
+    await writeFile(join(dir, ".env"), "MCP_AUTH_TOKEN=crlf-token\r\n", "utf-8");
+    const tokens = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    expect(tokens.verify("crlf-token")).toBe(true);
   });
 
-  // Regression: trailing \r from CRLF line endings was kept in the token (issue #13)
-  it("trims trailing CR when .env has CRLF line endings", async () => {
-    const { writeFile } = await import("node:fs/promises");
-    await writeFile(join(tempDir, ".env"), "MCP_AUTH_TOKEN=crlf-token\r\n", "utf-8");
-
-    const token = await resolveAuthToken(undefined, tempDir, logger);
-    expect(token).toBe("crlf-token");
+  it("generates a fresh token when .env lacks MCP_AUTH_TOKEN", async () => {
+    await writeFile(join(dir, ".env"), "OTHER_VAR=x\n", "utf-8");
+    const tokens = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    const token = await fileToken(dir);
+    expect(tokens.verify(token)).toBe(true);
   });
 
-  it("generates base64url token (no padding, URL-safe)", async () => {
-    const token = await resolveAuthToken(undefined, tempDir, logger);
-    // base64url uses only [A-Za-z0-9_-], no = padding
-    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
-  });
-});
+  describe("expiry (TTL)", () => {
+    it("a generated token is rejected once its TTL lapses", async () => {
+      const t0 = 1_000_000_000_000;
+      const tokens = await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR },
+        logger,
+        t0,
+      );
+      const token = await fileToken(dir);
+      // boundary: valid right up to the edge, rejected past it
+      expect(tokens.verify(token, t0)).toBe(true);
+      expect(tokens.verify(token, t0 + 30 * DAY)).toBe(true);
+      expect(tokens.verify(token, t0 + 30 * DAY + 1)).toBe(false);
+    });
 
-describe("save failure (coverage round)", () => {
-  it("still returns a usable token when the data dir is not writable", async () => {
-    // /dev/null is a file, so creating a directory beneath it fails fast (ENOTDIR)
-    const token = await resolveAuthToken(undefined, "/dev/null/not-writable", logger);
-    expect(token.length).toBeGreaterThan(20);
-  });
-});
+    it("without a TTL the generated token never expires", async () => {
+      const t0 = 1_000_000_000_000;
+      const tokens = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger, t0);
+      const token = await fileToken(dir);
+      expect(tokens.verify(token, t0 + 3650 * DAY)).toBe(true);
+    });
 
-describe("malformed .env (coverage round)", () => {
-  it("generates a new token when .env exists without MCP_AUTH_TOKEN", async () => {
-    const { writeFile, mkdtemp, rm } = await import("node:fs/promises");
-    const { tmpdir } = await import("node:os");
-    const dir = await mkdtemp(join(tmpdir(), "debmatic-auth-test2-"));
-    try {
-      await writeFile(join(dir, ".env"), "OTHER_VAR=x\n", "utf-8");
-      const token = await resolveAuthToken(undefined, dir, logger);
-      expect(token.length).toBeGreaterThan(20);
+    it("backfills issued-at for a legacy file so TTL starts from first sight", async () => {
+      await writeFile(join(dir, ".env"), "MCP_AUTH_TOKEN=legacy\n", "utf-8");
+      const t0 = 1_000_000_000_000;
+      const tokens = await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 10 * DAY, graceMs: 24 * HOUR },
+        logger,
+        t0,
+      );
+      // legacy token kept, now carrying an issued-at == t0
+      expect(tokens.verify("legacy", t0)).toBe(true);
+      expect(tokens.verify("legacy", t0 + 10 * DAY + 1)).toBe(false);
       const content = await readFile(join(dir, ".env"), "utf-8");
-      expect(content).toContain(`MCP_AUTH_TOKEN=${token}`);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
+      expect(content).toContain(`MCP_AUTH_TOKEN_ISSUED=${t0}`);
+    });
+  });
+
+  describe("rotation overlap", () => {
+    it("rotates an expired generated token but keeps the old one valid during grace", async () => {
+      const t0 = 1_000_000_000_000;
+      // First run mints token A.
+      await resolveAuthTokens({ dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR }, logger, t0);
+      const tokenA = await fileToken(dir);
+
+      // Second run, past A's TTL → rotate to token B, A stays valid for grace.
+      const tRotate = t0 + 31 * DAY;
+      const tokens = await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR },
+        logger,
+        tRotate,
+      );
+      const tokenB = await fileToken(dir);
+      expect(tokenB).not.toBe(tokenA);
+
+      // Both accepted inside the overlap (in-flight clients survive the swap).
+      expect(tokens.verify(tokenB, tRotate)).toBe(true);
+      expect(tokens.verify(tokenA, tRotate)).toBe(true);
+      // Old token lapses at the grace boundary; new one lives on.
+      expect(tokens.verify(tokenA, tRotate + 24 * HOUR + 1)).toBe(false);
+      expect(tokens.verify(tokenB, tRotate + 24 * HOUR + 1)).toBe(true);
+    });
+
+    it("drops a rotated-out token from the file once its grace fully elapses", async () => {
+      const t0 = 1_000_000_000_000;
+      await resolveAuthTokens({ dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR }, logger, t0);
+      const tokenA = await fileToken(dir);
+      // Rotate to B.
+      await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR },
+        logger,
+        t0 + 31 * DAY,
+      );
+      // A later run, well past the grace window: A should be pruned from the file.
+      const tokens = await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR },
+        logger,
+        t0 + 40 * DAY,
+      );
+      const content = await readFile(join(dir, ".env"), "utf-8");
+      expect(content).not.toContain("MCP_AUTH_TOKEN_PREVIOUS");
+      expect(tokens.verify(tokenA, t0 + 40 * DAY)).toBe(false);
+    });
+  });
+
+  it("still returns a usable verifier when the data dir is not writable", async () => {
+    // /dev/null is a file, so creating a dir beneath it fails fast (ENOTDIR).
+    const tokens = await resolveAuthTokens(
+      { dataDir: "/dev/null/nope", graceMs: 24 * HOUR },
+      logger,
+    );
+    // It minted an in-memory token even though persistence failed; the operator
+    // gets it on stderr. We can't read it from a file, but a bogus token fails.
+    expect(tokens.verify("definitely-not-it")).toBe(false);
+    expect(tokens.liveCount()).toBe(1);
   });
 });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -20,6 +20,9 @@ describe("loadConfig", () => {
     delete process.env.MCP_TRANSPORT;
     delete process.env.MCP_PORT;
     delete process.env.MCP_AUTH_TOKEN;
+    delete process.env.MCP_AUTH_TOKEN_PREVIOUS;
+    delete process.env.MCP_AUTH_TOKEN_TTL_DAYS;
+    delete process.env.MCP_AUTH_TOKEN_GRACE_HOURS;
     delete process.env.MCP_ALLOWED_ORIGINS;
     delete process.env.MCP_ALLOWED_HOSTS;
     delete process.env.CACHE_DIR;
@@ -285,5 +288,36 @@ describe("loadConfig", () => {
     const config = loadConfig();
     expect(config.mcp.host).toBe("127.0.0.1");
     expect(config.mcp.allowPlaintext).toBe(true);
+  });
+
+  // Issue #52: token rotation + expiry
+  it("token TTL/previous default to none; grace defaults to 24h", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    const config = loadConfig();
+    expect(config.mcp.authTokenPrevious).toBeUndefined();
+    expect(config.mcp.authTokenTtlMs).toBeUndefined();
+    expect(config.mcp.authTokenGraceMs).toBe(24 * 3_600_000);
+  });
+
+  it("parses MCP_AUTH_TOKEN_TTL_DAYS / _GRACE_HOURS / _PREVIOUS (fractional ok)", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_AUTH_TOKEN_PREVIOUS = "old-token";
+    process.env.MCP_AUTH_TOKEN_TTL_DAYS = "30";
+    process.env.MCP_AUTH_TOKEN_GRACE_HOURS = "0.5";
+    const config = loadConfig();
+    expect(config.mcp.authTokenPrevious).toBe("old-token");
+    expect(config.mcp.authTokenTtlMs).toBe(30 * 86_400_000);
+    expect(config.mcp.authTokenGraceMs).toBe(Math.round(0.5 * 3_600_000));
+  });
+
+  it("throws on a non-positive / garbage MCP_AUTH_TOKEN_TTL_DAYS", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_AUTH_TOKEN_TTL_DAYS = "0";
+    expect(() => loadConfig()).toThrow(/MCP_AUTH_TOKEN_TTL_DAYS must be a positive number/);
+    process.env.MCP_AUTH_TOKEN_TTL_DAYS = "soon";
+    expect(() => loadConfig()).toThrow(/MCP_AUTH_TOKEN_TTL_DAYS must be a positive number/);
   });
 });

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -27,8 +27,8 @@ function envKeysReferencedInCode(): Set<string> {
     for (const m of text.matchAll(/process\.env(?:\.([A-Z][A-Z0-9_]*)|\["([A-Z][A-Z0-9_]*)"\])/g)) {
       keys.add(m[1] ?? m[2]);
     }
-    // parseIntEnv("FOO", ...) — indirect numeric reads
-    for (const m of text.matchAll(/parseIntEnv\("([A-Z][A-Z0-9_]*)"/g)) {
+    // parseIntEnv("FOO", ...) / parseDurationEnv("FOO", ...) — indirect reads
+    for (const m of text.matchAll(/parse(?:Int|Duration)Env\("([A-Z][A-Z0-9_]*)"/g)) {
       keys.add(m[1]);
     }
   }

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -10,7 +10,7 @@ function createMockDeps() {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 20, rate: 10 },
       resourcePollInterval: 60,


### PR DESCRIPTION
Closes #52.

The generated HTTP bearer token previously lived forever — no expiry, no rotation. This adds optional, composable lifetime controls and keeps the zero-config default (token never expires) unchanged.

## What's added

**Auto-generated token (file-backed):**
- `MCP_AUTH_TOKEN_TTL_DAYS` (fractional days) gives the generated token a lifetime. Unset ⇒ never expires (historical behavior).
- Past expiry, the server mints a fresh token **on next startup** and prints it on stderr; the just-replaced token stays valid for `MCP_AUTH_TOKEN_GRACE_HOURS` (default 24) so in-flight clients survive the swap.
- Expiry is enforced **live** (checked against the clock per request), so a lapsed token is rejected mid-run with the existing `401` + `WWW-Authenticate: Bearer … error="invalid_token"`.
- Manual rotation trigger: delete `$CACHE_DIR/.env` (or its `MCP_AUTH_TOKEN` line) and restart.

**Explicit token (operator-managed):**
- `MCP_AUTH_TOKEN_PREVIOUS` is accepted alongside `MCP_AUTH_TOKEN` for a rotation overlap. TTL does not apply here — the operator owns the token's lifetime.

**Verification:**
- Moved into an `AuthTokens` verifier that checks the presented token against **every** currently-valid entry without early return, so the timing-safe guarantee now holds across the whole rotation set (not just one token).

**Persistence:**
- `/data/.env` now also carries `MCP_AUTH_TOKEN_ISSUED` and, during an overlap, `MCP_AUTH_TOKEN_PREVIOUS(_EXPIRES)`. Legacy files without an issued-at get one backfilled, so TTL starts from first sight rather than expiring a token of unknown age. Rotated-out tokens are pruned from the file once their grace fully elapses.

## Acceptance criteria (from #52)
- [x] An expired token is rejected with a 401 + challenge.
- [x] Rotation works without dropping in-flight sessions during the overlap window.
- [x] Timing-safe comparison preserved across all currently-valid tokens.
- [x] Unit coverage for the expiry boundary and rotation overlap.

## Notes
- Env names use explicit units (`_TTL_DAYS`, `_GRACE_HOURS`) rather than the bare `MCP_AUTH_TOKEN_TTL` sketched in the issue, to avoid unit ambiguity and allow fractional values.
- `.env.example`, the README env table + a new prose section, and the `.env.example` drift-guard test (now recognizes the `parseDurationEnv` indirection) are all updated.

## Testing
`npm run lint` clean; `npm test` → 310 passed, 25 skipped (live-CCU integration).