### PR TITLE
ci: release-gate workflow (Release vX.Y.Z title check on main PRs)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,31 @@
+name: Release gate
+
+# Enforce the release convention (see CLAUDE.md): main only advances via a PR
+# titled "Release vX.Y.Z". Runs solely on PRs targeting main, so everyday dev
+# PRs are unaffected. It's a required status check, but branch protection keeps
+# enforce_admins off, so an admin can still override for emergency hotfixes.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+
+# No repo access needed: the title comes from the event payload.
+permissions: {}
+
+jobs:
+  release-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a "Release vX.Y.Z" title
+        # Pass the title via env, never interpolate ${{ }} into the script body
+        # (avoids shell injection from an attacker-controllable PR title).
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "PR title: $PR_TITLE"
+          if [[ "$PR_TITLE" =~ ^Release\ v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Title matches the release convention."
+          else
+            echo "::error::PRs into main must be titled 'Release vX.Y.Z' (e.g. 'Release v1.3.0'). See CLAUDE.md. An admin can override for hotfixes."
+            exit 1
+          fi


### PR DESCRIPTION
Adds `.github/workflows/release-gate.yml`: a check that fails any PR **into `main`** whose title isn't `Release vX.Y.Z`, enforcing the documented release convention.

- Triggers only on `pull_request` → `main` (types: opened/edited/reopened/synchronize), so everyday dev PRs are never affected.
- PR title is read from the event payload via an env var — never interpolated into the shell — to avoid injection from an attacker-controllable title.
- `permissions: {}` (no repo access needed).

Intended to be wired up as a **required status check** on `main` (context `release-title`). Branch protection keeps `enforce_admins` off, so an admin can still override for emergency patches/hotfixes (e.g. a hotfix PR straight into `main`).

Once merged to `dev`, it'll be present on the head of the next `dev → main` release PR and run there. I'll add `release-title` to `main`'s required checks after this merges.