### PR TITLE
Release v1.3.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,81 @@
+# debmatic-mcp configuration — copy to .env and adjust.
+# All settings are environment variables; values shown are the defaults.
+# Only CCU_HOST and CCU_PASSWORD are required; everything else is optional.
+
+# ─── CCU connection (required) ──────────────────────────────────────────────
+# Hostname or IP of your CCU / debmatic box.
+CCU_HOST=debmatic
+# CCU admin password.
+CCU_PASSWORD=
+
+# ─── CCU connection (optional) ──────────────────────────────────────────────
+# CCU username. Use a dedicated least-privilege account instead of Admin if you can.
+CCU_USER=Admin
+# API port. Defaults to 80, or 443 when CCU_HTTPS=true.
+CCU_PORT=80
+# Connect over HTTPS (self-signed certs supported — see TLS verification below).
+CCU_HTTPS=false
+# Per-request timeout in milliseconds.
+CCU_TIMEOUT=10000
+# Timeout for HM Script (ReGa) executions in milliseconds.
+CCU_SCRIPT_TIMEOUT=30000
+
+# ─── CCU TLS verification (optional) ────────────────────────────────────────
+# A CCU ships a self-signed cert, so verification is OFF by default and the
+# server logs a warning. Pick ONE of the three to actually verify the peer.
+# Precedence: CCU_TLS_FINGERPRINT > CCU_CA_CERT > CCU_TLS_VERIFY.
+#
+# Pin the self-signed leaf cert by its SHA-256 (hex, colons optional). Read it with:
+#   echo | openssl s_client -connect "$CCU_HOST:443" 2>/dev/null \
+#     | openssl x509 -noout -fingerprint -sha256
+CCU_TLS_FINGERPRINT=
+# Path to the CCU's CA / self-signed PEM for standard chain validation.
+CCU_CA_CERT=
+# Verify against the system trust store (only if the CCU has a publicly-trusted cert).
+CCU_TLS_VERIFY=false
+
+# ─── CCU rate limiting (optional) ───────────────────────────────────────────
+# Max burst of requests sent to the CCU.
+CCU_RATE_LIMIT_BURST=20
+# Sustained CCU requests per second.
+CCU_RATE_LIMIT_RATE=10
+
+# ─── MCP transport (optional) ───────────────────────────────────────────────
+# Transport: "http" or "stdio" (the --stdio / --http CLI flags override this).
+MCP_TRANSPORT=http
+# HTTP server port (HTTP mode only).
+MCP_PORT=3000
+# Bearer token for HTTP mode. If unset, one is generated and saved to $CACHE_DIR/.env.
+MCP_AUTH_TOKEN=
+# Bind address for the HTTP listener. Unset = all interfaces. Set 127.0.0.1 to
+# restrict to loopback (e.g. behind a TLS-terminating proxy); also silences the
+# plaintext warning.
+MCP_HOST=
+# Native HTTPS for the MCP transport: set BOTH to serve over TLS. Leave unset
+# for plain HTTP (the default). Setting only one is a configuration error.
+MCP_TLS_CERT=
+MCP_TLS_KEY=
+# Acknowledge serving the bearer token over plain HTTP and silence the
+# non-loopback plaintext warning.
+MCP_ALLOW_PLAINTEXT=false
+# Comma-separated allowlist of browser origins for CORS. Unset = no cross-origin
+# browser access (default-deny). An allowlisted origin is reflected exactly
+# (never "*"); the list also drives DNS-rebinding origin checks.
+# e.g. https://app.example,http://localhost:6274
+MCP_ALLOWED_ORIGINS=
+# Extra Host values accepted by DNS-rebinding protection (comma-separated
+# host:port). localhost/127.0.0.1 on MCP_PORT are always allowed; add your
+# hostname when behind a proxy or container DNS name.
+MCP_ALLOWED_HOSTS=
+
+# ─── Cache (optional) ───────────────────────────────────────────────────────
+# Directory for the device-type cache and the generated auth token.
+CACHE_DIR=/data
+# Cache lifetime in seconds (24h).
+CACHE_TTL=86400
+
+# ─── Misc (optional) ────────────────────────────────────────────────────────
+# Seconds between polls for MCP resource change notifications.
+RESOURCE_POLL_INTERVAL=60
+# Log level: error | warn | info | debug.
+LOG_LEVEL=info

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,17 @@ MCP_TRANSPORT=http
 MCP_PORT=3000
 # Bearer token for HTTP mode. If unset, one is generated and saved to $CACHE_DIR/.env.
 MCP_AUTH_TOKEN=
+# Previous bearer token, accepted alongside MCP_AUTH_TOKEN during a rotation so
+# clients still on the old token aren't dropped. Remove it (and restart) to end
+# the overlap. Applies to the explicit MCP_AUTH_TOKEN path only.
+MCP_AUTH_TOKEN_PREVIOUS=
+# Lifetime of the AUTO-GENERATED token, in days (fractional allowed). Unset =
+# never expires. Past expiry the token auto-rotates on the next startup; the old
+# one stays valid for MCP_AUTH_TOKEN_GRACE_HOURS. Ignored when MCP_AUTH_TOKEN is set.
+MCP_AUTH_TOKEN_TTL_DAYS=
+# Overlap (hours) after an auto-rotation during which the just-replaced token is
+# still accepted, so in-flight clients survive the swap. Default 24.
+MCP_AUTH_TOKEN_GRACE_HOURS=24
 # Bind address for the HTTP listener. Unset = all interfaces. Set 127.0.0.1 to
 # restrict to loopback (e.g. behind a TLS-terminating proxy); also silences the
 # plaintext warning.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: CI only reads the repo (build + test).
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Version sync check
+        run: npm run check:versions
+
       - name: Audit dependencies
         run: npm audit --audit-level=high
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,31 @@
+name: Release gate
+
+# Enforce the release convention (see CLAUDE.md): main only advances via a PR
+# titled "Release vX.Y.Z". Runs solely on PRs targeting main, so everyday dev
+# PRs are unaffected. It's a required status check, but branch protection keeps
+# enforce_admins off, so an admin can still override for emergency hotfixes.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+
+# No repo access needed: the title comes from the event payload.
+permissions: {}
+
+jobs:
+  release-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a "Release vX.Y.Z" title
+        # Pass the title via env, never interpolate ${{ }} into the script body
+        # (avoids shell injection from an attacker-controllable PR title).
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "PR title: $PR_TITLE"
+          if [[ "$PR_TITLE" =~ ^Release\ v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Title matches the release convention."
+          else
+            echo "::error::PRs into main must be titled 'Release vX.Y.Z' (e.g. 'Release v1.3.0'). See CLAUDE.md. An admin can override for hotfixes."
+            exit 1
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -6,7 +6,7 @@ COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npx tsc
 
-FROM node:22-alpine
+FROM node:24-alpine
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev

--- a/README.md
+++ b/README.md
@@ -150,7 +150,16 @@ CCU_HTTPS=true
 CCU_PORT=443
 ```
 
-The server accepts self-signed certificates automatically — certificate verification is **off by default** because CCUs ship with self-signed certs. If your CCU has a proper certificate, enable verification with `CCU_TLS_VERIFY=true`.
+The server accepts self-signed certificates automatically — certificate verification is **off by default** because CCUs ship with self-signed certs (the server logs a warning when running unverified). To actually verify the connection and close the MITM gap, you have three options:
+
+- **Pin the fingerprint** (simplest for a self-signed appliance cert): set `CCU_TLS_FINGERPRINT` to the cert's SHA-256 (hex, with or without colons). The connection is rejected unless the CCU presents exactly that certificate. Read it with:
+  ```bash
+  echo | openssl s_client -connect "$CCU_HOST:443" 2>/dev/null | openssl x509 -noout -fingerprint -sha256
+  ```
+- **Trust a CA/self-signed PEM**: point `CCU_CA_CERT` at the certificate file for standard chain validation.
+- **System trust store**: if your CCU has a publicly-trusted certificate, set `CCU_TLS_VERIFY=true`.
+
+`CCU_TLS_FINGERPRINT` takes precedence over `CCU_CA_CERT`, which takes precedence over `CCU_TLS_VERIFY`.
 
 ## Configuration
 
@@ -163,7 +172,9 @@ All configuration is via environment variables:
 | `CCU_USER` | `Admin` | CCU username |
 | `CCU_PORT` | `80` | API port (`443` when using HTTPS) |
 | `CCU_HTTPS` | `false` | Connect via HTTPS (self-signed certs supported) |
-| `CCU_TLS_VERIFY` | `false` | Verify the CCU's TLS certificate (enable if you have a proper cert) |
+| `CCU_TLS_VERIFY` | `false` | Verify the CCU's TLS certificate against the system trust store (for a publicly-trusted cert) |
+| `CCU_TLS_FINGERPRINT` | unset | Pin the CCU's self-signed leaf cert by its SHA-256 fingerprint (hex, colons optional). Takes precedence over the other TLS options |
+| `CCU_CA_CERT` | unset | Path to the CCU's CA/self-signed PEM for chain validation |
 | `CCU_TIMEOUT` | `10000` | CCU request timeout in milliseconds |
 | `CCU_SCRIPT_TIMEOUT` | `30000` | HM Script execution timeout in milliseconds |
 | `LOG_LEVEL` | `info` | `error`, `warn`, `info`, or `debug` |

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ All configuration is via environment variables:
 
 ## Tools
 
-19 tools organized by what you'd actually want to do:
+20 tools organized by what you'd actually want to do:
 
 **Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `describe_device_type`
 
@@ -186,7 +186,7 @@ All configuration is via environment variables:
 
 **Change things** — `set_value`, `put_paramset`, `set_system_variable`, `execute_program`
 
-**Check health** — `get_service_messages`, `acknowledge_service_messages`, `get_system_info`
+**Check health** — `get_service_messages`, `acknowledge_service_messages`, `get_rssi`, `get_system_info`
 
 **Other** — `help` (context-aware), `run_script` (raw HomeMatic Script for bulk operations, renaming devices/channels, querying room membership, or anything not covered by the other tools)
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ curl http://localhost:3000/health
 
 #### Browser-based clients (CORS)
 
-The HTTP server sends permissive CORS headers and answers `OPTIONS` preflight requests, so browser-based MCP clients like [MCP Inspector](https://github.com/modelcontextprotocol/inspector) can connect directly — no proxy needed. Authentication is still enforced: browsers can read the endpoint, but every MCP request needs the bearer token.
+By default the HTTP server sends **no** CORS headers, so a random web page can't drive a local instance. To let a browser-based MCP client like [MCP Inspector](https://github.com/modelcontextprotocol/inspector) connect directly, set `MCP_CORS_ALLOW_ORIGIN` — `*` for local dev, or a single trusted origin (e.g. `https://inspector.example`). Authentication is always enforced regardless: every MCP request needs the bearer token.
+
+The HTTP transport also has **DNS-rebinding protection** on by default: it rejects requests whose `Host` header isn't `localhost`/`127.0.0.1` on the configured port. If you reach the server under another hostname (reverse proxy, container DNS name), list those hosts in `MCP_ALLOWED_HOSTS` or legitimate requests get a `403`.
 
 CORS support was first implemented by [@marcinn2](https://github.com/marcinn2) in his fork [marcinn2/debmatic-mcp](https://github.com/marcinn2/debmatic-mcp) — thanks!
 
@@ -168,6 +170,8 @@ All configuration is via environment variables:
 | `MCP_TRANSPORT` | `http` | `http` or `stdio` (the `--stdio` CLI flag overrides this) |
 | `MCP_PORT` | `3000` | HTTP server port (HTTP mode only) |
 | `MCP_AUTH_TOKEN` | auto-generated | Bearer token for HTTP mode; generated and saved to `$CACHE_DIR/.env` on first start |
+| `MCP_CORS_ALLOW_ORIGIN` | unset | CORS `Access-Control-Allow-Origin` for browser clients. Unset = no CORS (default-deny). Use `*` for dev/MCP Inspector, or one trusted origin |
+| `MCP_ALLOWED_HOSTS` | `localhost`/`127.0.0.1` | Extra `Host` values accepted by DNS-rebinding protection (comma-separated `host:port`); add your hostname when behind a proxy or container DNS name |
 | `CCU_RATE_LIMIT_BURST` | `20` | Max burst of requests sent to the CCU |
 | `CCU_RATE_LIMIT_RATE` | `10` | Sustained CCU requests per second |
 | `RESOURCE_POLL_INTERVAL` | `60` | Seconds between polls for MCP resource change notifications |

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ By default the HTTP server sends **no** CORS headers, so a random web page can't
 
 The HTTP transport also has **DNS-rebinding protection** on by default: it rejects requests whose `Host` header isn't `localhost`/`127.0.0.1` on the configured port. If you reach the server under another hostname (reverse proxy, container DNS name), list those hosts in `MCP_ALLOWED_HOSTS` or legitimate requests get a `403`.
 
+**TLS.** The bearer token travels in the request, so anything beyond loopback should be encrypted. You have two options: terminate TLS at a reverse proxy (Caddy/nginx) in front and bind the server to loopback (`MCP_HOST=127.0.0.1`), or let the server serve HTTPS itself by setting `MCP_TLS_CERT` and `MCP_TLS_KEY` to a PEM cert/key pair. Plain HTTP is still fully supported — it stays the zero-config default — but the server logs a warning at startup when it's serving the token over unencrypted HTTP on a non-loopback bind; set `MCP_ALLOW_PLAINTEXT=true` to acknowledge that and silence it.
+
 CORS support was first implemented by [@marcinn2](https://github.com/marcinn2) in his fork [marcinn2/debmatic-mcp](https://github.com/marcinn2/debmatic-mcp) — thanks!
 
 ### HTTPS
@@ -172,6 +174,9 @@ All configuration is via environment variables:
 | `MCP_AUTH_TOKEN` | auto-generated | Bearer token for HTTP mode; generated and saved to `$CACHE_DIR/.env` on first start |
 | `MCP_ALLOWED_ORIGINS` | unset | Comma-separated allowlist of browser origins. Unset = no cross-origin browser access (default-deny). An allowlisted origin is reflected exactly in `Access-Control-Allow-Origin` (never `*`); the list also drives DNS-rebinding origin checks |
 | `MCP_ALLOWED_HOSTS` | `localhost`/`127.0.0.1` | Extra `Host` values accepted by DNS-rebinding protection (comma-separated `host:port`); add your hostname when behind a proxy or container DNS name |
+| `MCP_HOST` | unset (all interfaces) | Bind address for the HTTP listener; set `127.0.0.1` to restrict to loopback (e.g. behind a TLS-terminating proxy), which also silences the plaintext warning |
+| `MCP_TLS_CERT` / `MCP_TLS_KEY` | unset | PEM cert/key paths. Set **both** to serve MCP over HTTPS natively; leave unset for plain HTTP. Setting only one is a configuration error |
+| `MCP_ALLOW_PLAINTEXT` | `false` | Set `true` to acknowledge serving the bearer token over plain HTTP and silence the non-loopback plaintext warning |
 | `CCU_RATE_LIMIT_BURST` | `20` | Max burst of requests sent to the CCU |
 | `CCU_RATE_LIMIT_RATE` | `10` | Sustained CCU requests per second |
 | `RESOURCE_POLL_INTERVAL` | `60` | Seconds between polls for MCP resource change notifications |

--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ All configuration is via environment variables:
 
 ## Tools
 
-23 tools organized by what you'd actually want to do:
+25 tools organized by what you'd actually want to do:
 
 **Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `list_links`, `describe_device_type`
 
 **Read state** — `get_value`, `get_values` (bulk), `get_paramset`
 
-**Change things** — `set_value`, `put_paramset`, `set_system_variable`, `create_system_variable`, `delete_system_variable`, `execute_program`
+**Change things** — `set_value`, `put_paramset`, `set_system_variable`, `create_system_variable`, `delete_system_variable`, `assign_channel`, `unassign_channel`, `execute_program`
 
 **Check health** — `get_service_messages`, `acknowledge_service_messages`, `get_rssi`, `get_system_info`
 

--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ All configuration is via environment variables:
 
 ## Tools
 
-21 tools organized by what you'd actually want to do:
+23 tools organized by what you'd actually want to do:
 
 **Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `list_links`, `describe_device_type`
 
 **Read state** — `get_value`, `get_values` (bulk), `get_paramset`
 
-**Change things** — `set_value`, `put_paramset`, `set_system_variable`, `execute_program`
+**Change things** — `set_value`, `put_paramset`, `set_system_variable`, `create_system_variable`, `delete_system_variable`, `execute_program`
 
 **Check health** — `get_service_messages`, `acknowledge_service_messages`, `get_rssi`, `get_system_info`
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ All configuration is via environment variables:
 
 ## Tools
 
-18 tools organized by what you'd actually want to do:
+19 tools organized by what you'd actually want to do:
 
 **Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `describe_device_type`
 
@@ -186,7 +186,7 @@ All configuration is via environment variables:
 
 **Change things** — `set_value`, `put_paramset`, `set_system_variable`, `execute_program`
 
-**Check health** — `get_service_messages`, `get_system_info`
+**Check health** — `get_service_messages`, `acknowledge_service_messages`, `get_system_info`
 
 **Other** — `help` (context-aware), `run_script` (raw HomeMatic Script for bulk operations, renaming devices/channels, querying room membership, or anything not covered by the other tools)
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ curl http://localhost:3000/health
 
 #### Browser-based clients (CORS)
 
-By default the HTTP server sends **no** CORS headers, so a random web page can't drive a local instance. To let a browser-based MCP client like [MCP Inspector](https://github.com/modelcontextprotocol/inspector) connect directly, set `MCP_CORS_ALLOW_ORIGIN` — `*` for local dev, or a single trusted origin (e.g. `https://inspector.example`). Authentication is always enforced regardless: every MCP request needs the bearer token.
+By default the HTTP server sends **no** CORS headers, so a random web page can't drive a local instance. To let browser-based MCP clients like [MCP Inspector](https://github.com/modelcontextprotocol/inspector) connect directly, set `MCP_ALLOWED_ORIGINS` to a comma-separated allowlist of trusted origins (e.g. `https://app.example,http://localhost:6274`). A request whose `Origin` is on the list gets that **exact** origin reflected in `Access-Control-Allow-Origin` — never the wildcard `*`, which would let any site drive a local instance that controls real CCU hardware. A request from any other origin gets no CORS headers (the browser blocks it) and is rejected server-side by DNS-rebinding protection. Authentication is always enforced regardless: every MCP request needs the bearer token.
 
 The HTTP transport also has **DNS-rebinding protection** on by default: it rejects requests whose `Host` header isn't `localhost`/`127.0.0.1` on the configured port. If you reach the server under another hostname (reverse proxy, container DNS name), list those hosts in `MCP_ALLOWED_HOSTS` or legitimate requests get a `403`.
 
@@ -170,7 +170,7 @@ All configuration is via environment variables:
 | `MCP_TRANSPORT` | `http` | `http` or `stdio` (the `--stdio` CLI flag overrides this) |
 | `MCP_PORT` | `3000` | HTTP server port (HTTP mode only) |
 | `MCP_AUTH_TOKEN` | auto-generated | Bearer token for HTTP mode; generated and saved to `$CACHE_DIR/.env` on first start |
-| `MCP_CORS_ALLOW_ORIGIN` | unset | CORS `Access-Control-Allow-Origin` for browser clients. Unset = no CORS (default-deny). Use `*` for dev/MCP Inspector, or one trusted origin |
+| `MCP_ALLOWED_ORIGINS` | unset | Comma-separated allowlist of browser origins. Unset = no cross-origin browser access (default-deny). An allowlisted origin is reflected exactly in `Access-Control-Allow-Origin` (never `*`); the list also drives DNS-rebinding origin checks |
 | `MCP_ALLOWED_HOSTS` | `localhost`/`127.0.0.1` | Extra `Host` values accepted by DNS-rebinding protection (comma-separated `host:port`); add your hostname when behind a proxy or container DNS name |
 | `CCU_RATE_LIMIT_BURST` | `20` | Max burst of requests sent to the CCU |
 | `CCU_RATE_LIMIT_RATE` | `10` | Sustained CCU requests per second |

--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ All configuration is via environment variables:
 
 ## Tools
 
-20 tools organized by what you'd actually want to do:
+21 tools organized by what you'd actually want to do:
 
-**Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `describe_device_type`
+**Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `list_links`, `describe_device_type`
 
 **Read state** — `get_value`, `get_values` (bulk), `get_paramset`
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ The HTTP transport also has **DNS-rebinding protection** on by default: it rejec
 
 **TLS.** The bearer token travels in the request, so anything beyond loopback should be encrypted. You have two options: terminate TLS at a reverse proxy (Caddy/nginx) in front and bind the server to loopback (`MCP_HOST=127.0.0.1`), or let the server serve HTTPS itself by setting `MCP_TLS_CERT` and `MCP_TLS_KEY` to a PEM cert/key pair. Plain HTTP is still fully supported — it stays the zero-config default — but the server logs a warning at startup when it's serving the token over unencrypted HTTP on a non-loopback bind; set `MCP_ALLOW_PLAINTEXT=true` to acknowledge that and silence it.
 
+**Token rotation & expiry.** By default the bearer token lives forever. Two optional, composable controls let you rotate it without dropping clients:
+
+- *Auto-generated token* — set `MCP_AUTH_TOKEN_TTL_DAYS` (fractional days allowed) to give the generated token a lifetime. Once it lapses, the server mints a fresh one **on the next startup** and prints it on stderr, while the just-replaced token keeps validating for `MCP_AUTH_TOKEN_GRACE_HOURS` (default 24) so in-flight clients survive the swap. Expiry is also enforced live: a lapsed token is rejected mid-run with a `401` + `WWW-Authenticate: Bearer … error="invalid_token"`. To force a rotation sooner, delete `$CACHE_DIR/.env` (or just its `MCP_AUTH_TOKEN` line) and restart.
+- *Explicit token* — when you set `MCP_AUTH_TOKEN` yourself, you own its lifetime (TTL doesn't apply). To rotate, put the new token in `MCP_AUTH_TOKEN`, move the old one to `MCP_AUTH_TOKEN_PREVIOUS`, and restart; both are accepted during the overlap. Drop `MCP_AUTH_TOKEN_PREVIOUS` and restart once every client is on the new token. Comparison stays timing-safe across every currently-valid token.
+
 CORS support was first implemented by [@marcinn2](https://github.com/marcinn2) in his fork [marcinn2/debmatic-mcp](https://github.com/marcinn2/debmatic-mcp) — thanks!
 
 ### HTTPS
@@ -183,6 +188,9 @@ All configuration is via environment variables:
 | `MCP_TRANSPORT` | `http` | `http` or `stdio` (the `--stdio` CLI flag overrides this) |
 | `MCP_PORT` | `3000` | HTTP server port (HTTP mode only) |
 | `MCP_AUTH_TOKEN` | auto-generated | Bearer token for HTTP mode; generated and saved to `$CACHE_DIR/.env` on first start |
+| `MCP_AUTH_TOKEN_PREVIOUS` | unset | Previous bearer token, accepted alongside `MCP_AUTH_TOKEN` during a rotation overlap; remove it (and restart) to end the overlap. Explicit-token path only |
+| `MCP_AUTH_TOKEN_TTL_DAYS` | unset (never expires) | Lifetime of the **auto-generated** token, in days (fractional allowed). Past expiry it auto-rotates on next startup; ignored when `MCP_AUTH_TOKEN` is set |
+| `MCP_AUTH_TOKEN_GRACE_HOURS` | `24` | Overlap (hours) after an auto-rotation during which the just-replaced token is still accepted |
 | `MCP_ALLOWED_ORIGINS` | unset | Comma-separated allowlist of browser origins. Unset = no cross-origin browser access (default-deny). An allowlisted origin is reflected exactly in `Access-Control-Allow-Origin` (never `*`); the list also drives DNS-rebinding origin checks |
 | `MCP_ALLOWED_HOSTS` | `localhost`/`127.0.0.1` | Extra `Host` values accepted by DNS-rebinding protection (comma-separated `host:port`); add your hostname when behind a proxy or container DNS name |
 | `MCP_HOST` | unset (all interfaces) | Bind address for the HTTP listener; set `127.0.0.1` to restrict to loopback (e.g. behind a TLS-terminating proxy), which also silences the plaintext warning |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # - MCP_TRANSPORT=http
       # - MCP_PORT=3000
       # - MCP_AUTH_TOKEN=           # auto-generated if unset
-      # - MCP_CORS_ALLOW_ORIGIN=*   # unset = no CORS (default-deny); '*' for dev/MCP Inspector, or one trusted origin
+      # - MCP_ALLOWED_ORIGINS=      # comma-separated browser origin allowlist; unset = no cross-origin browser access (default-deny). Exact origin reflected, never '*'
       # - MCP_ALLOWED_HOSTS=        # extra Host values for DNS-rebinding protection (comma-separated host:port)
 
       # === Cache (optional) ===

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       # - MCP_TRANSPORT=http
       # - MCP_PORT=3000
       # - MCP_AUTH_TOKEN=           # auto-generated if unset
+      # - MCP_CORS_ALLOW_ORIGIN=*   # unset = no CORS (default-deny); '*' for dev/MCP Inspector, or one trusted origin
+      # - MCP_ALLOWED_HOSTS=        # extra Host values for DNS-rebinding protection (comma-separated host:port)
 
       # === Cache (optional) ===
       # - CACHE_DIR=/data

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -57,6 +57,7 @@ Both publish targets have a dry-run that touches nothing remote. Run them on
 the release branch before tagging:
 
 ```sh
+npm run check:versions       # package.json <-> server.json versions agree
 npm publish --dry-run        # lists the tarball contents; no upload
 mcp-publisher validate       # validates server.json against the live schema
 ```
@@ -72,27 +73,26 @@ milestone — it's the source of the `Closes #N` list in the release PR.
 
 1. **Branch off `dev`:** `git checkout -b release/vX.Y.Z origin/dev`
 
-2. **Bump the version — three files must agree.** The MCP registry rejects a
-   publish where `server.json` and the npm package disagree, and the npm
-   version is immutable once published, so get this right before tagging:
-   - `package.json` `version` (and `package-lock.json`) — bump together with:
-     ```sh
-     npm version <patch|minor|major> --no-git-tag-version
-     ```
-     `--no-git-tag-version` is deliberate: it edits `package.json` +
-     `package-lock.json` only. The git tag is created later, on `main`
-     (step 7) — not here on the release branch.
-   - `server.json` — **two** spots: the root `version` and
-     `packages[0].version`. Both must equal the new `package.json` version.
-     (`packages[0].identifier` stays `debmatic-mcp`; the `$schema` date is a
-     schema version, not the release version — leave it.)
-
-   Verify they line up:
+2. **Bump the version — one command, three files.** The version lives in
+   `package.json`, `server.json` root `version`, and `server.json`
+   `packages[0].version`; the MCP registry rejects a publish where they
+   disagree and the npm version is immutable once published. A single command
+   keeps all three in sync:
    ```sh
-   node -e "const s=require('./server.json'),p=require('./package.json');
-   console.log(p.version, s.version, s.packages[0].version,
-   '->', p.version===s.version && p.version===s.packages[0].version)"
+   npm version <patch|minor|major> --no-git-tag-version
    ```
+   `npm version` runs the `version` lifecycle hook (`scripts/sync-server-version.mjs`),
+   which copies the new version into both `server.json` spots and stages it —
+   so you never hand-edit `server.json`. `--no-git-tag-version` is deliberate:
+   it edits `package.json` + `package-lock.json` (+ syncs `server.json`) but
+   creates **no** commit/tag here; the tag is made later on `main` (step 7).
+
+   Confirm they agree (the same check CI runs):
+   ```sh
+   npm run check:versions     # exits non-zero on any drift
+   ```
+   This gate also runs in CI on every push and in `prepublishOnly`, so a
+   drifted manifest can't merge or publish even if the bump is done by hand.
    The README install snippets use unversioned `npx debmatic-mcp` /
    `claude mcp add` — there are **no pinned version strings to bump there**.
    Keep it that way; don't add versioned `npx debmatic-mcp@X.Y.Z` snippets to

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,222 @@
+# Release runbook
+
+How to publish a `vX.Y.Z` of `debmatic-mcp`. The release is **manual** —
+there is no release workflow (CI only builds and tests). The publish
+targets are **npm** (`npx debmatic-mcp`, the primary install path) and the
+**official MCP registry** (`registry.modelcontextprotocol.io`). The Docker
+image is build-your-own (`docker-compose` builds from source); nothing is
+pushed to a container registry, so there is no image-publish step.
+
+The goal: a release is a tag plus two `publish` commands, with version
+numbers that agree everywhere before any of it happens.
+
+## Branching context
+
+This repo runs the `main ⇄ dev` model (see the project brief). `dev` is the
+default/integration branch; `main` is protected and holds released code;
+each release is a tag `vX.Y.Z` on `main`. Branch off `dev`, never `main`.
+This runbook expands the release half of that model.
+
+## One-time prerequisites
+
+Per-account setup, **not** per-release. Done once when the publishing chain
+is first wired up.
+
+### npm — publish auth
+
+`debmatic-mcp` is published to npm under the unscoped name `debmatic-mcp`
+(`package.json` `name`). Publishing needs an authenticated npm session with
+publish rights on that package.
+
+1. `npm login` (or set `NPM_TOKEN` / `~/.npmrc` with an automation token).
+   Confirm with `npm whoami`.
+2. If the npm account has 2FA set to **auth-and-publish**, `npm publish`
+   prompts for a one-time code — pass it with `--otp=<code>` in
+   non-interactive shells. 2FA set to **auth-only** doesn't prompt on
+   publish.
+
+Symptom if missed: `npm publish` ends `ENEEDAUTH` (not logged in) or
+`EOTP` (OTP required). Neither mutates anything — fix auth and re-run.
+
+### MCP registry — publisher auth
+
+The registry listing is published from `server.json` with the
+`mcp-publisher` CLI. The server namespace is `io.github.claymore666/*`, which
+is authorized via GitHub login (OIDC) — the GitHub account must own the
+`claymore666` namespace.
+
+1. `mcp-publisher login github` (interactive; opens a device-code flow).
+2. Authorization persists locally; re-login only when the token expires.
+
+The `io.github.<user>/*` namespace maps to the GitHub user, so no DNS TXT
+record is needed (that path is only for custom-domain namespaces).
+
+### Pre-flight validation (do this every release, costs nothing)
+
+Both publish targets have a dry-run that touches nothing remote. Run them on
+the release branch before tagging:
+
+```sh
+npm publish --dry-run        # lists the tarball contents; no upload
+mcp-publisher validate       # validates server.json against the live schema
+```
+
+`npm publish --dry-run` is the cheap check that `files` in `package.json`
+ships what you expect (`dist`, `README.md`, `LICENSE`) and nothing secret.
+`mcp-publisher validate` must print `✅ server.json is valid`.
+
+## Per-release procedure
+
+Pre-flight: every issue/PR going into the release should be on the `vX.Y.Z`
+milestone — it's the source of the `Closes #N` list in the release PR.
+
+1. **Branch off `dev`:** `git checkout -b release/vX.Y.Z origin/dev`
+
+2. **Bump the version — three files must agree.** The MCP registry rejects a
+   publish where `server.json` and the npm package disagree, and the npm
+   version is immutable once published, so get this right before tagging:
+   - `package.json` `version` (and `package-lock.json`) — bump together with:
+     ```sh
+     npm version <patch|minor|major> --no-git-tag-version
+     ```
+     `--no-git-tag-version` is deliberate: it edits `package.json` +
+     `package-lock.json` only. The git tag is created later, on `main`
+     (step 7) — not here on the release branch.
+   - `server.json` — **two** spots: the root `version` and
+     `packages[0].version`. Both must equal the new `package.json` version.
+     (`packages[0].identifier` stays `debmatic-mcp`; the `$schema` date is a
+     schema version, not the release version — leave it.)
+
+   Verify they line up:
+   ```sh
+   node -e "const s=require('./server.json'),p=require('./package.json');
+   console.log(p.version, s.version, s.packages[0].version,
+   '->', p.version===s.version && p.version===s.packages[0].version)"
+   ```
+   The README install snippets use unversioned `npx debmatic-mcp` /
+   `claude mcp add` — there are **no pinned version strings to bump there**.
+   Keep it that way; don't add versioned `npx debmatic-mcp@X.Y.Z` snippets to
+   the README, or this list grows.
+
+3. **Documentation review — against the milestone, not from memory.** List
+   every PR on the `vX.Y.Z` milestone and reconcile each user-visible change
+   against the docs:
+   ```sh
+   gh pr list --state merged --limit 200 \
+     --json number,title,milestone \
+     --jq '.[] | select(.milestone.title=="vX.Y.Z") | "#\(.number) \(.title)"'
+   ```
+   For **each** merged PR: a new or changed tool lands in the README tool
+   list and in the `help` tool's `CONCEPTUAL_GUIDE` / `TOOL_HELP`
+   (`src/tools/meta.ts`) — these are user-facing surfaces that drift
+   silently. New env vars land in the README config table, `docker-compose.yml`
+   comments, and `server.json` `environmentVariables`. A milestone PR that
+   changed behaviour but carries no doc/help delta is the signal to look
+   harder, not to wave through. Then still read the README top-to-bottom for
+   anything the per-PR pass missed.
+
+4. **Write the release notes.** This repo has no `RELEASE_NOTES.md` /
+   `CHANGELOG.md`; the notes live in the **GitHub Release body** (step 8).
+   Draft them now while the change set is fresh — summarise in user-visible
+   terms and call out any compatibility notes (new required env var, changed
+   tool contract, dropped behaviour). If you'd rather have an in-repo
+   changelog, that's a separate decision — introduce it before, not during, a
+   release.
+
+5. **PR `release/vX.Y.Z` → `dev`.** Required check: `CI` (build + test +
+   `npm audit --audit-level=high`). Merge when green.
+
+6. **Open the release PR `dev` → `main`** titled `Release vX.Y.Z`, with a
+   `Closes #N` line for **every issue** in the milestone — that list is what
+   auto-closes them and lets the milestone close. `main` is protected, so
+   this PR is the only way in; merge it when CI is green.
+
+7. **Tag `vX.Y.Z` on `main`:**
+   ```sh
+   git checkout main && git pull --ff-only
+   git tag -s vX.Y.Z -m "vX.Y.Z — <one-liner>"   # -s = signed; shows Verified
+   git push origin vX.Y.Z
+   ```
+   `-s` signs the tag (shows **Verified** on GitHub) if a signing key is
+   configured; plain `git tag vX.Y.Z` is acceptable if not. Confirm with
+   `git tag -v vX.Y.Z` when signed.
+
+8. **Publish — npm, then the MCP registry, then the GitHub Release.** All
+   from the tagged `main` checkout, so the artifacts match the tag:
+   ```sh
+   npm publish                       # add --otp=<code> if 2FA prompts
+   mcp-publisher publish             # reads server.json
+   gh release create vX.Y.Z --title "vX.Y.Z" --notes "<step 4 notes>"
+   ```
+   `prepublishOnly` re-runs `npm run lint && npm test` before the upload, so a
+   broken build can't ship. Order matters only in that npm must succeed first
+   — the registry entry points consumers at the npm package.
+
+9. **Fast-forward `dev` to `main`** so the version bump and any release-branch
+   edits land on `dev` too:
+   ```sh
+   git checkout dev && git merge --ff-only main && git push origin dev
+   ```
+   Skipping this leaves the next feature branch starting from the previous
+   version's `package.json`/`server.json`, and the next release PR has to
+   re-bump them.
+
+10. **Prune merged branches.** If *Automatically delete head branches* is on,
+    PR heads go on merge. The `release/vX.Y.Z` branch was never a PR head into
+    `main` directly, so remove it and sweep for stragglers:
+    ```sh
+    git push origin --delete release/vX.Y.Z
+    git fetch --prune origin
+    git branch -r --merged origin/dev | grep -vE 'origin/(dev|main|HEAD)$'
+    ```
+    Delete what the sweep lists; leave open-PR and Dependabot branches alone.
+
+## Verifying
+
+After publishing:
+
+- `npm view debmatic-mcp version` returns `vX.Y.Z` (allow a minute for the
+  registry to update). `npx -y debmatic-mcp@X.Y.Z --help` from a clean
+  machine pulls and runs it.
+- The MCP registry shows the new version:
+  `curl -s 'https://registry.modelcontextprotocol.io/v0/servers?search=io.github.claymore666/debmatic-mcp' | jq '.servers[].version'`.
+- `gh release view vX.Y.Z` shows the notes body.
+- The milestone is closed:
+  `gh issue list --milestone vX.Y.Z --state open` — should be empty.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| `npm publish` ends `EOTP` | npm 2FA set to auth-and-publish | re-run with `--otp=<code>` |
+| `npm publish` ends `ENEEDAUTH` | not logged in / token expired | `npm login`, confirm `npm whoami`, re-run |
+| `npm publish` ends `403 cannot publish over previously published version` | version already on npm (npm is immutable) | bump to the next patch; never re-use a version |
+| `mcp-publisher publish` rejects the version | `server.json` version ≠ npm package version, or `mcpName` missing in `package.json` | align all three version spots (step 2); ensure `package.json` `mcpName` matches `server.json` `name` |
+| `mcp-publisher` 401 / auth error | publisher login expired | `mcp-publisher login github` again |
+| GitHub Release exists but npm/registry don't | published the release before the `publish` commands | run `npm publish` + `mcp-publisher publish` from the tagged checkout |
+
+## Backports between `dev` and `main`
+
+When a release-blocking hotfix must land on `main` without going through
+`dev`:
+
+1. Branch off `main`, fix, PR to `main`, merge. Don't push to `main`
+   directly — branch protection and the audit trail.
+2. Cherry-pick the same commit onto a branch off `dev`, PR to `dev`, so `dev`
+   doesn't regress on the next release PR.
+
+## Not applicable (deliberately omitted)
+
+These are in the docker-net-dhcp runbook but don't apply here, noted so their
+absence reads as a decision, not an oversight:
+
+- **Container registry publish (GHCR / Docker Hub), image signing (cosign),
+  SBOM, provenance** — no image is published; the Dockerfile is built locally
+  by `docker-compose`. If a published image is ever added, the GHCR-linking
+  and signing prerequisites from that runbook become relevant.
+- **Versioned docs site (mkdocs / GitHub Pages)** — docs are the README plus
+  this `docs/` folder; there's no published site to reconcile.
+- **rc dry-run via the release workflow / coverage ratchet** — there's no
+  release workflow to dry-run and no coverage gate. The pre-flight
+  `npm publish --dry-run` + `mcp-publisher validate` (above) are the
+  equivalent cheap checks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "debmatic-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "debmatic-mcp",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debmatic-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/debmatic-mcp",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit && tsc -p tsconfig.test.json",
-    "prepublishOnly": "npm run lint && npm test"
+    "check:versions": "node scripts/check-version-sync.mjs",
+    "version": "node scripts/sync-server-version.mjs && git add server.json",
+    "prepublishOnly": "npm run check:versions && npm run lint && npm test"
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepublishOnly": "npm run check:versions && npm run lint && npm test"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -14,7 +14,7 @@
 //
 // Test seam: PKG_FILE / SERVER_FILE env vars point the check at synthetic
 // fixtures, so scripts gate logic is exercisable offline
-// (see test/check-version-sync.test.ts).
+// (see test/unit/version-sync.test.ts).
 import { readFileSync } from "node:fs";
 
 const PKG = process.env.PKG_FILE ?? "package.json";

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Failsafe gate: assert the release version is consistent across the three
+// places it lives, plus that the package identity matches. Exits non-zero
+// (with a remediation hint) on any drift, so CI and `prepublishOnly` block a
+// release whose npm package and MCP registry manifest disagree.
+//
+// Checks:
+//   1. package.json  version            == server.json  version
+//   2. package.json  version            == server.json  packages[].version
+//   3. package.json  mcpName            == server.json  name
+//
+// Usage:
+//   node scripts/check-version-sync.mjs      # exit 0 in sync, 1 on drift
+//
+// Test seam: PKG_FILE / SERVER_FILE env vars point the check at synthetic
+// fixtures, so scripts gate logic is exercisable offline
+// (see test/check-version-sync.test.ts).
+import { readFileSync } from "node:fs";
+
+const PKG = process.env.PKG_FILE ?? "package.json";
+const SERVER = process.env.SERVER_FILE ?? "server.json";
+
+const pkg = JSON.parse(readFileSync(PKG, "utf8"));
+const server = JSON.parse(readFileSync(SERVER, "utf8"));
+
+const problems = [];
+const rows = [];
+
+const pkgVersion = pkg.version;
+rows.push([`${PKG} version`, pkgVersion]);
+
+if (server.version !== pkgVersion) {
+  problems.push(`${SERVER} version "${server.version}" != ${PKG} version "${pkgVersion}"`);
+}
+rows.push([`${SERVER} version`, server.version]);
+
+const packages = Array.isArray(server.packages) ? server.packages : [];
+packages.forEach((p, i) => {
+  if (p.version !== pkgVersion) {
+    problems.push(`${SERVER} packages[${i}].version "${p.version}" != ${PKG} version "${pkgVersion}"`);
+  }
+  rows.push([`${SERVER} packages[${i}].version`, p.version]);
+});
+
+if (pkg.mcpName !== server.name) {
+  problems.push(`${PKG} mcpName "${pkg.mcpName}" != ${SERVER} name "${server.name}"`);
+}
+rows.push([`${PKG} mcpName`, pkg.mcpName]);
+rows.push([`${SERVER} name`, server.name]);
+
+const width = Math.max(...rows.map(([label]) => label.length));
+for (const [label, value] of rows) {
+  console.log(`  ${label.padEnd(width)}  ${value}`);
+}
+console.log();
+
+if (problems.length > 0) {
+  console.error("Version/identity drift:");
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error();
+  console.error("Fix: bump with `npm version <patch|minor|major>` (auto-syncs");
+  console.error("server.json), or run `node scripts/sync-server-version.mjs`.");
+  process.exit(1);
+}
+
+console.log("Versions in sync.");

--- a/scripts/sync-server-version.mjs
+++ b/scripts/sync-server-version.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Automatism: copy package.json's version into server.json's two version
+// fields (root `version` and `packages[0].version`), so the MCP registry
+// manifest always matches the npm package.
+//
+// Runs automatically from the `version` npm lifecycle hook (see
+// package.json "scripts.version"), so `npm version <patch|minor|major>`
+// bumps all three spots in one command. Also runnable by hand:
+//   node scripts/sync-server-version.mjs
+//
+// Idempotent: a no-op (and prints so) when already in sync. Preserves the
+// file's 2-space indentation and trailing newline.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const PKG = process.env.PKG_FILE ?? "package.json";
+const SERVER = process.env.SERVER_FILE ?? "server.json";
+
+const pkg = JSON.parse(readFileSync(PKG, "utf8"));
+const raw = readFileSync(SERVER, "utf8");
+const server = JSON.parse(raw);
+
+const version = pkg.version;
+if (!version) {
+  console.error(`sync-server-version: no "version" in ${PKG}`);
+  process.exit(1);
+}
+
+let changed = false;
+if (server.version !== version) {
+  server.version = version;
+  changed = true;
+}
+if (Array.isArray(server.packages)) {
+  for (const p of server.packages) {
+    if (p.version !== version) {
+      p.version = version;
+      changed = true;
+    }
+  }
+}
+
+if (!changed) {
+  console.log(`sync-server-version: ${SERVER} already at ${version} — no change`);
+  process.exit(0);
+}
+
+writeFileSync(SERVER, JSON.stringify(server, null, 2) + "\n");
+console.log(`sync-server-version: set ${SERVER} version → ${version}`);

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/debmatic-mcp",
     "source": "github"
   },
-  "version": "1.2.0",
+  "version": "1.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "debmatic-mcp",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -61,8 +61,8 @@
           "format": "string"
         },
         {
-          "name": "MCP_CORS_ALLOW_ORIGIN",
-          "description": "CORS Access-Control-Allow-Origin for browser clients. Unset = no CORS (default-deny); use '*' for dev/MCP Inspector or a single trusted origin",
+          "name": "MCP_ALLOWED_ORIGINS",
+          "description": "Comma-separated allowlist of browser origins. Unset = no cross-origin browser access (default-deny). An allowlisted origin is reflected exactly in Access-Control-Allow-Origin (never '*'); the list also drives DNS-rebinding origin checks",
           "format": "string"
         },
         {

--- a/server.json
+++ b/server.json
@@ -59,6 +59,16 @@
           "description": "Directory for the device type cache and session persistence",
           "default": "/data",
           "format": "string"
+        },
+        {
+          "name": "MCP_CORS_ALLOW_ORIGIN",
+          "description": "CORS Access-Control-Allow-Origin for browser clients. Unset = no CORS (default-deny); use '*' for dev/MCP Inspector or a single trusted origin",
+          "format": "string"
+        },
+        {
+          "name": "MCP_ALLOWED_HOSTS",
+          "description": "Extra Host header values accepted by DNS-rebinding protection (comma-separated host:port); add your hostname when behind a proxy or container DNS name",
+          "format": "string"
         }
       ]
     }

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -1,52 +1,229 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { Logger } from "../logger.js";
 
 const ENV_FILENAME = ".env";
 
-export async function resolveAuthToken(
-  envToken: string | undefined,
-  dataDir: string,
-  logger: Logger,
-): Promise<string> {
-  // 1. Explicit env var takes priority
-  if (envToken) {
-    logger.info("auth_token_from_env");
-    return envToken;
-  }
+/** sha256 of a token — fixed width so timingSafeEqual never sees a length mismatch. */
+function sha256(value: string): Buffer {
+  return createHash("sha256").update(value).digest();
+}
 
-  // 2. Try loading from /data/.env
-  const envPath = join(dataDir, ENV_FILENAME);
-  try {
-    const content = await readFile(envPath, "utf-8");
-    const match = content.match(/^MCP_AUTH_TOKEN=(.+)$/m);
-    if (match?.[1]) {
-      logger.info("auth_token_from_file");
-      // trim: tolerate trailing \r if the file was edited with CRLF line endings
-      return match[1].trim();
+interface TokenEntry {
+  /** sha256 of the accepted token. */
+  hash: Buffer;
+  /** Epoch ms after which this token is rejected; null = never expires. */
+  expiresAt: number | null;
+  /** For diagnostics only — never the token itself. */
+  label: string;
+}
+
+/**
+ * A set of currently-acceptable bearer tokens. Expiry is evaluated live at
+ * verification time (against `now`), so a token stops validating the moment it
+ * lapses — no restart or background timer needed.
+ */
+export class AuthTokens {
+  constructor(private readonly entries: TokenEntry[]) {}
+
+  /**
+   * Timing-safe check of a presented token against every entry. Compares against
+   * ALL entries (no early return) so neither a match nor expiry leaks via timing,
+   * preserving the original single-token guarantee across the rotation set.
+   */
+  verify(presented: string, now: number = Date.now()): boolean {
+    // Empty / missing credentials never match. Cheap, and the only thing the
+    // short-circuit leaks ("no token presented") is already visible in the 401
+    // challenge the caller sends back.
+    if (!presented) return false;
+    const ph = sha256(presented);
+    let ok = false;
+    for (const entry of this.entries) {
+      const match = timingSafeEqual(ph, entry.hash);
+      const live = entry.expiresAt === null || now <= entry.expiresAt;
+      ok = ok || (match && live);
     }
-  } catch {
-    // File doesn't exist — will generate
+    return ok;
   }
 
-  // 3. Generate new token
-  const token = randomBytes(32).toString("base64url");
+  /** Count of entries still live at `now` — for the startup log, exposes no secrets. */
+  liveCount(now: number = Date.now()): number {
+    return this.entries.filter((e) => e.expiresAt === null || now <= e.expiresAt).length;
+  }
+}
 
+export interface ResolveAuthTokensOptions {
+  /** Explicit operator-managed token (`MCP_AUTH_TOKEN`). Highest priority. */
+  envToken?: string;
+  /** Previous operator-managed token kept valid for the rotation overlap (`MCP_AUTH_TOKEN_PREVIOUS`). */
+  envPreviousToken?: string;
+  /** Where the auto-generated token + its metadata are persisted. */
+  dataDir: string;
+  /** Lifetime of the auto-generated token in ms; undefined ⇒ never expires. */
+  ttlMs?: number;
+  /** Overlap after an auto-rotation during which the just-replaced token still validates. */
+  graceMs: number;
+}
+
+/** Persisted shape of the auto-generated token file. */
+interface PersistedToken {
+  token?: string;
+  issued?: number;
+  previous?: string;
+  previousExpires?: number;
+}
+
+function parsePersisted(content: string): PersistedToken {
+  // trim: tolerate a trailing \r if the file was edited with CRLF (issue #13)
+  const read = (key: string): string | undefined =>
+    content.match(new RegExp(`^${key}=(.+)$`, "m"))?.[1]?.trim();
+  const readNum = (key: string): number | undefined => {
+    const raw = read(key);
+    if (raw === undefined) return undefined;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : undefined;
+  };
+  return {
+    token: read("MCP_AUTH_TOKEN"),
+    issued: readNum("MCP_AUTH_TOKEN_ISSUED"),
+    previous: read("MCP_AUTH_TOKEN_PREVIOUS"),
+    previousExpires: readNum("MCP_AUTH_TOKEN_PREVIOUS_EXPIRES"),
+  };
+}
+
+function serialize(state: PersistedToken): string {
+  const lines = [`MCP_AUTH_TOKEN=${state.token}`];
+  if (state.issued !== undefined) lines.push(`MCP_AUTH_TOKEN_ISSUED=${state.issued}`);
+  if (state.previous !== undefined) {
+    lines.push(`MCP_AUTH_TOKEN_PREVIOUS=${state.previous}`);
+    if (state.previousExpires !== undefined) {
+      lines.push(`MCP_AUTH_TOKEN_PREVIOUS_EXPIRES=${state.previousExpires}`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+async function persist(dataDir: string, state: PersistedToken, logger: Logger): Promise<void> {
+  const envPath = join(dataDir, ENV_FILENAME);
   try {
     await mkdir(dataDir, { recursive: true });
     const tmpPath = envPath + ".tmp";
-    // 0600: file contains the bearer token for the HTTP transport
-    await writeFile(tmpPath, `MCP_AUTH_TOKEN=${token}\n`, { encoding: "utf-8", mode: 0o600 });
+    // 0600: file contains the bearer token(s) for the HTTP transport
+    await writeFile(tmpPath, serialize(state), { encoding: "utf-8", mode: 0o600 });
     await rename(tmpPath, envPath);
-    logger.info("auth_token_generated");
-    // Log to stderr so user can copy it
-    process.stderr.write(`\n[debmatic-mcp] Generated auth token: ${token}\n`);
-    process.stderr.write(`[debmatic-mcp] Token saved to ${envPath}\n`);
-    process.stderr.write(`[debmatic-mcp] Use this token in your MCP client configuration.\n\n`);
   } catch (err) {
     logger.error("auth_token_save_failed", { error: (err as Error).message });
   }
+}
 
-  return token;
+function announce(token: string, dataDir: string, rotated: boolean): void {
+  const envPath = join(dataDir, ENV_FILENAME);
+  const what = rotated ? "Rotated auth token" : "Generated auth token";
+  // stderr so the operator can copy it; never goes through the structured logger.
+  process.stderr.write(`\n[debmatic-mcp] ${what}: ${token}\n`);
+  process.stderr.write(`[debmatic-mcp] Token saved to ${envPath}\n`);
+  process.stderr.write(`[debmatic-mcp] Use this token in your MCP client configuration.\n\n`);
+}
+
+/**
+ * Resolve the set of currently-valid bearer tokens (issue #52).
+ *
+ * Precedence mirrors the original single-token resolver:
+ *  1. Explicit `MCP_AUTH_TOKEN` (operator-managed, never auto-expired). An
+ *     optional `MCP_AUTH_TOKEN_PREVIOUS` is accepted alongside it for the
+ *     rotation overlap; the operator ends the overlap by dropping it + restart.
+ *     TTL does not apply to operator-supplied tokens — the operator owns them.
+ *  2. The auto-generated token persisted under `dataDir/.env`. With `ttlMs` set
+ *     it carries an issued-at; once it lapses we rotate on startup: a fresh
+ *     token is generated and the just-replaced one stays valid for `graceMs`
+ *     so in-flight clients aren't cut off mid-migration.
+ *  3. If neither exists, generate and persist a new token.
+ */
+export async function resolveAuthTokens(
+  opts: ResolveAuthTokensOptions,
+  logger: Logger,
+  now: number = Date.now(),
+): Promise<AuthTokens> {
+  // 1. Explicit env token(s) — operator-managed, no TTL, file untouched.
+  if (opts.envToken) {
+    logger.info("auth_token_from_env", { previous: Boolean(opts.envPreviousToken) });
+    const entries: TokenEntry[] = [
+      { hash: sha256(opts.envToken), expiresAt: null, label: "env" },
+    ];
+    if (opts.envPreviousToken) {
+      entries.push({ hash: sha256(opts.envPreviousToken), expiresAt: null, label: "env-previous" });
+    }
+    return new AuthTokens(entries);
+  }
+
+  // 2 + 3. File-backed auto-generated token.
+  const { dataDir, ttlMs, graceMs } = opts;
+  let state: PersistedToken = {};
+  try {
+    state = parsePersisted(await readFile(join(dataDir, ENV_FILENAME), "utf-8"));
+  } catch {
+    // File doesn't exist (or is unreadable) — fall through to generation.
+  }
+
+  let changed = false;
+  let minted = false; // brand-new token this run (generate or rotate) → announce
+  let rotated = false;
+
+  if (!state.token) {
+    // 3. No usable token — generate.
+    state = { token: randomBytes(32).toString("base64url"), issued: now };
+    changed = true;
+    minted = true;
+    logger.info("auth_token_generated");
+  } else if (ttlMs !== undefined) {
+    if (state.issued === undefined) {
+      // Legacy file written before TTL existed: start the clock now rather than
+      // expiring a token whose true age we can't know.
+      state.issued = now;
+      changed = true;
+    } else if (now - state.issued >= ttlMs) {
+      // Expired → rotate. Keep the old token valid for the grace overlap.
+      state = {
+        token: randomBytes(32).toString("base64url"),
+        issued: now,
+        previous: state.token,
+        previousExpires: now + graceMs,
+      };
+      changed = true;
+      minted = true;
+      rotated = true;
+      logger.info("auth_token_rotated", { graceMs });
+    }
+  }
+
+  // Drop a previously-rotated token once its grace window has fully elapsed.
+  if (
+    state.previous !== undefined &&
+    state.previousExpires !== undefined &&
+    now > state.previousExpires
+  ) {
+    delete state.previous;
+    delete state.previousExpires;
+    changed = true;
+  }
+
+  if (changed) await persist(dataDir, state, logger);
+  if (minted) announce(state.token!, dataDir, rotated);
+
+  const entries: TokenEntry[] = [
+    {
+      hash: sha256(state.token!),
+      expiresAt: ttlMs !== undefined && state.issued !== undefined ? state.issued + ttlMs : null,
+      label: "generated",
+    },
+  ];
+  if (state.previous !== undefined && state.previousExpires !== undefined) {
+    entries.push({
+      hash: sha256(state.previous),
+      expiresAt: state.previousExpires,
+      label: "rotated-out",
+    });
+  }
+  return new AuthTokens(entries);
 }

--- a/src/ccu/client.ts
+++ b/src/ccu/client.ts
@@ -1,7 +1,13 @@
-import { Agent, fetch as undiciFetch } from "undici";
+import { Agent, buildConnector, fetch as undiciFetch } from "undici";
+import type { TLSSocket } from "node:tls";
 import type { CcuConfig, CcuRpcRequest, CcuRpcResponse } from "./types.js";
 import { CcuError, mapCcuError, mapNetworkError } from "../middleware/error-mapper.js";
 import type { Logger } from "../logger.js";
+
+/** Normalize a SHA-256 fingerprint for comparison: drop colons, lowercase. */
+function normalizeFingerprint(fp: string): string {
+  return fp.replace(/:/g, "").toLowerCase();
+}
 
 export class CcuClient {
   private readonly baseUrl: string;
@@ -18,11 +24,64 @@ export class CcuClient {
 
     if (config.https) {
       this.dispatcher = new Agent({
-        connect: { rejectUnauthorized: config.tlsVerify },
+        connect: this.buildConnect(config, logger),
         pipelining: 0,
         keepAliveTimeout: 1000,
       });
     }
+  }
+
+  /**
+   * Decide how the CCU's TLS certificate is verified (issue #51), most specific
+   * first:
+   *  1. CCU_TLS_FINGERPRINT — pin the exact self-signed leaf cert. Strongest
+   *     for an appliance; we complete the handshake without chain validation
+   *     (a self-signed cert has no chain) and reject unless the presented
+   *     cert's SHA-256 matches.
+   *  2. CCU_CA_CERT — trust a provided CA/self-signed PEM and do standard
+   *     chain validation.
+   *  3. CCU_TLS_VERIFY — verify against the system trust store (public CA).
+   *  4. Default — unverified, with a loud warning (a CCU ships a self-signed
+   *     cert, so this is the zero-config fallback, but it's MITM-exposed).
+   */
+  private buildConnect(config: CcuConfig, logger: Logger) {
+    if (config.tlsFingerprint) {
+      const expected = normalizeFingerprint(config.tlsFingerprint);
+      // rejectUnauthorized:false lets the self-signed handshake complete; the
+      // fingerprint check below is what actually authenticates the peer.
+      const connector = buildConnector({ rejectUnauthorized: false });
+      return (opts: buildConnector.Options, cb: buildConnector.Callback): void => {
+        connector(opts, (err, socket) => {
+          if (err || !socket) return cb(err ?? new Error("CCU TLS connect failed"), null);
+          const cert = (socket as TLSSocket).getPeerCertificate?.();
+          const actual = cert?.fingerprint256 ? normalizeFingerprint(cert.fingerprint256) : "";
+          if (!actual || actual !== expected) {
+            socket.destroy();
+            return cb(
+              new Error(
+                `CCU TLS certificate fingerprint mismatch (expected ${expected}, got ${actual || "none"})`,
+              ),
+              null,
+            );
+          }
+          cb(null, socket);
+        });
+      };
+    }
+
+    if (config.caCert) {
+      return { ca: config.caCert, rejectUnauthorized: true };
+    }
+
+    if (!config.tlsVerify) {
+      logger.warn("ccu_tls_unverified", {
+        hint:
+          "CCU TLS certificate is NOT verified (MITM-exposed). Pin it with " +
+          "CCU_TLS_FINGERPRINT, trust it with CCU_CA_CERT, or set CCU_TLS_VERIFY=true " +
+          "if the CCU presents a publicly-trusted certificate.",
+      });
+    }
+    return { rejectUnauthorized: config.tlsVerify };
   }
 
   async call(method: string, params: Record<string, unknown>, timeout?: number): Promise<unknown> {

--- a/src/ccu/client.ts
+++ b/src/ccu/client.ts
@@ -49,7 +49,12 @@ export class CcuClient {
       const expected = normalizeFingerprint(config.tlsFingerprint);
       // rejectUnauthorized:false lets the self-signed handshake complete; the
       // fingerprint check below is what actually authenticates the peer.
-      const connector = buildConnector({ rejectUnauthorized: false });
+      // maxCachedSessions:0 disables TLS session resumption: on a resumed
+      // session the server does NOT re-send its certificate, so
+      // getPeerCertificate() comes back empty and the fingerprint check would
+      // wrongly reject every connection after the first. Forcing a full
+      // handshake per connection guarantees the cert is always present to pin.
+      const connector = buildConnector({ rejectUnauthorized: false, maxCachedSessions: 0 });
       return (opts: buildConnector.Options, cb: buildConnector.Callback): void => {
         connector(opts, (err, socket) => {
           if (err || !socket) return cb(err ?? new Error("CCU TLS connect failed"), null);

--- a/src/ccu/types.ts
+++ b/src/ccu/types.ts
@@ -149,6 +149,19 @@ export interface CcuConfig {
   https: boolean;
   /** Verify the CCU's TLS certificate. Off by default: CCUs ship self-signed certs. */
   tlsVerify: boolean;
+  /**
+   * Pin the CCU's self-signed leaf certificate by its SHA-256 fingerprint
+   * (`CCU_TLS_FINGERPRINT`, hex, with or without colons). When set, the
+   * connection is rejected unless the presented cert matches — the simplest way
+   * to verify a self-signed appliance cert. Takes precedence over `caCert`.
+   */
+  tlsFingerprint?: string;
+  /**
+   * PEM contents of the CCU's CA / self-signed certificate (`CCU_CA_CERT`
+   * points at the file). When set, the connection is validated against this CA
+   * with standard chain verification.
+   */
+  caCert?: string;
   user: string;
   password: string;
   timeout: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import type { CcuConfig } from "./ccu/types.js";
 
 export interface AppConfig {
@@ -110,12 +111,28 @@ export function loadConfig(): AppConfig {
     throw new Error("MCP_TLS_CERT and MCP_TLS_KEY must both be set (or both unset)");
   }
 
+  // CCU TLS verification (issue #51). A CCU ships a self-signed cert, so verify
+  // it either by pinning the leaf fingerprint (CCU_TLS_FINGERPRINT) or by
+  // trusting a CA/self-signed PEM (CCU_CA_CERT). Fingerprint takes precedence.
+  const tlsFingerprint = process.env.CCU_TLS_FINGERPRINT?.trim() || undefined;
+  const caCertPath = process.env.CCU_CA_CERT?.trim() || undefined;
+  let caCert: string | undefined;
+  if (caCertPath) {
+    try {
+      caCert = readFileSync(caCertPath, "utf-8");
+    } catch (err) {
+      throw new Error(`CCU_CA_CERT could not be read at "${caCertPath}": ${(err as Error).message}`);
+    }
+  }
+
   return {
     ccu: {
       host,
       port: parseIntEnv("CCU_PORT", process.env.CCU_HTTPS === "true" ? "443" : "80"),
       https: process.env.CCU_HTTPS === "true",
       tlsVerify: process.env.CCU_TLS_VERIFY === "true",
+      tlsFingerprint,
+      caCert,
       user: process.env.CCU_USER || "Admin",
       password,
       timeout: parseIntEnv("CCU_TIMEOUT", "10000"),

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,11 +7,15 @@ export interface AppConfig {
     port: number;
     authToken?: string;
     /**
-     * Value echoed in `Access-Control-Allow-Origin`. Unset ⇒ no CORS header is
-     * sent (browsers are blocked by default). Set `MCP_CORS_ALLOW_ORIGIN=*` for
-     * local dev / MCP Inspector, or a single trusted origin.
+     * Default-deny origin allowlist for browser-based MCP clients. Empty ⇒ no
+     * cross-origin browser access (the secure default). A request whose `Origin`
+     * is on this list gets that exact origin reflected in
+     * `Access-Control-Allow-Origin` (never `*`); the same list drives the
+     * transport's DNS-rebinding `allowedOrigins` so CORS and rebinding
+     * protection can't drift apart. Set via `MCP_ALLOWED_ORIGINS`
+     * (comma-separated, e.g. `https://app.example,http://localhost:6274`).
      */
-    corsAllowOrigin?: string;
+    allowedOrigins: string[];
     /**
      * Host-header allowlist for the StreamableHTTP transport's DNS-rebinding
      * protection. Defaults to localhost/127.0.0.1 on the MCP port; extend via
@@ -69,6 +73,14 @@ export function loadConfig(): AppConfig {
       .filter(Boolean),
   ];
 
+  // Default-deny browser origin allowlist. Empty unless MCP_ALLOWED_ORIGINS is
+  // set; it feeds both the reflective CORS headers and the transport's
+  // DNS-rebinding Origin check (single source of truth).
+  const allowedOrigins = (process.env.MCP_ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
   return {
     ccu: {
       host,
@@ -84,7 +96,7 @@ export function loadConfig(): AppConfig {
       transport,
       port: mcpPort,
       authToken: process.env.MCP_AUTH_TOKEN,
-      corsAllowOrigin: process.env.MCP_CORS_ALLOW_ORIGIN || undefined,
+      allowedOrigins,
       allowedHosts,
     },
     cache: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,18 @@ export interface AppConfig {
     transport: "http" | "stdio";
     port: number;
     authToken?: string;
+    /**
+     * Value echoed in `Access-Control-Allow-Origin`. Unset ⇒ no CORS header is
+     * sent (browsers are blocked by default). Set `MCP_CORS_ALLOW_ORIGIN=*` for
+     * local dev / MCP Inspector, or a single trusted origin.
+     */
+    corsAllowOrigin?: string;
+    /**
+     * Host-header allowlist for the StreamableHTTP transport's DNS-rebinding
+     * protection. Defaults to localhost/127.0.0.1 on the MCP port; extend via
+     * `MCP_ALLOWED_HOSTS` when the server is reached under another hostname.
+     */
+    allowedHosts: string[];
   };
   cache: {
     dir: string;
@@ -43,6 +55,20 @@ export function loadConfig(): AppConfig {
     return val;
   };
 
+  const mcpPort = parseIntEnv("MCP_PORT", "3000");
+  // DNS-rebinding defense: the transport rejects any Host header not on this
+  // list. localhost/127.0.0.1 on the bound port covers local use; deployments
+  // reached under another hostname (reverse proxy, container DNS name) add it
+  // via MCP_ALLOWED_HOSTS (comma-separated, "host:port").
+  const allowedHosts = [
+    `127.0.0.1:${mcpPort}`,
+    `localhost:${mcpPort}`,
+    ...(process.env.MCP_ALLOWED_HOSTS || "")
+      .split(",")
+      .map((h) => h.trim())
+      .filter(Boolean),
+  ];
+
   return {
     ccu: {
       host,
@@ -56,8 +82,10 @@ export function loadConfig(): AppConfig {
     },
     mcp: {
       transport,
-      port: parseIntEnv("MCP_PORT", "3000"),
+      port: mcpPort,
       authToken: process.env.MCP_AUTH_TOKEN,
+      corsAllowOrigin: process.env.MCP_CORS_ALLOW_ORIGIN || undefined,
+      allowedHosts,
     },
     cache: {
       dir: process.env.CACHE_DIR || "/data",

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,26 @@ export interface AppConfig {
      * `MCP_ALLOWED_HOSTS` when the server is reached under another hostname.
      */
     allowedHosts: string[];
+    /**
+     * Optional bind address for the HTTP listener (`MCP_HOST`). Unset ⇒ bind
+     * all interfaces (the unchanged default). Set to `127.0.0.1`/`::1` to
+     * restrict the server to loopback (e.g. when a reverse proxy terminates TLS
+     * in front), which also suppresses the plaintext warning.
+     */
+    host?: string;
+    /**
+     * Optional TLS cert/key paths (`MCP_TLS_CERT` / `MCP_TLS_KEY`). When BOTH
+     * are set the server listens over HTTPS natively; otherwise it serves plain
+     * HTTP (the zero-config default). Setting only one is a configuration error.
+     */
+    tlsCertPath?: string;
+    tlsKeyPath?: string;
+    /**
+     * Acknowledge that serving over plain HTTP is intended
+     * (`MCP_ALLOW_PLAINTEXT=true`). Silences the non-loopback plaintext warning
+     * for operators who deliberately run without TLS (e.g. a trusted LAN).
+     */
+    allowPlaintext: boolean;
   };
   cache: {
     dir: string;
@@ -81,6 +101,15 @@ export function loadConfig(): AppConfig {
     .map((o) => o.trim())
     .filter(Boolean);
 
+  // Native TLS for the HTTP transport is opt-in: set BOTH cert and key. Plain
+  // HTTP stays the zero-config default (issue #50). Setting only one is almost
+  // certainly a mistake, so fail loudly rather than silently serving plaintext.
+  const tlsCertPath = process.env.MCP_TLS_CERT?.trim() || undefined;
+  const tlsKeyPath = process.env.MCP_TLS_KEY?.trim() || undefined;
+  if (Boolean(tlsCertPath) !== Boolean(tlsKeyPath)) {
+    throw new Error("MCP_TLS_CERT and MCP_TLS_KEY must both be set (or both unset)");
+  }
+
   return {
     ccu: {
       host,
@@ -98,6 +127,10 @@ export function loadConfig(): AppConfig {
       authToken: process.env.MCP_AUTH_TOKEN,
       allowedOrigins,
       allowedHosts,
+      host: process.env.MCP_HOST?.trim() || undefined,
+      tlsCertPath,
+      tlsKeyPath,
+      allowPlaintext: process.env.MCP_ALLOW_PLAINTEXT === "true",
     },
     cache: {
       dir: process.env.CACHE_DIR || "/data",

--- a/src/config.ts
+++ b/src/config.ts
@@ -121,7 +121,11 @@ export function loadConfig(): AppConfig {
     try {
       caCert = readFileSync(caCertPath, "utf-8");
     } catch (err) {
-      throw new Error(`CCU_CA_CERT could not be read at "${caCertPath}": ${(err as Error).message}`);
+      // Don't interpolate the env-derived path here: a fatal config error is
+      // logged at the top level, and echoing raw env values into logs is a
+      // leak vector (js/clear-text-logging). The fs error already names the
+      // path for the operator.
+      throw new Error(`CCU_CA_CERT could not be read: ${(err as Error).message}`);
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,26 @@ export interface AppConfig {
     port: number;
     authToken?: string;
     /**
+     * Previous bearer token kept valid for the rotation overlap
+     * (`MCP_AUTH_TOKEN_PREVIOUS`). Lets operators roll `MCP_AUTH_TOKEN` without
+     * dropping clients still on the old token; remove it (and restart) to end
+     * the overlap. Applies to the explicit-token path only.
+     */
+    authTokenPrevious?: string;
+    /**
+     * Lifetime of the AUTO-GENERATED bearer token in ms (`MCP_AUTH_TOKEN_TTL_DAYS`,
+     * fractional days allowed). Unset ⇒ the generated token never expires (the
+     * historical default). Does not apply to an explicit `MCP_AUTH_TOKEN`, which
+     * the operator owns. On startup past expiry the token auto-rotates.
+     */
+    authTokenTtlMs?: number;
+    /**
+     * Overlap after an auto-rotation during which the just-replaced token still
+     * validates, so in-flight clients survive the swap (`MCP_AUTH_TOKEN_GRACE_HOURS`,
+     * default 24).
+     */
+    authTokenGraceMs: number;
+    /**
      * Default-deny origin allowlist for browser-based MCP clients. Empty ⇒ no
      * cross-origin browser access (the secure default). A request whose `Origin`
      * is on this list gets that exact origin reflected in
@@ -80,6 +100,19 @@ export function loadConfig(): AppConfig {
     return val;
   };
 
+  // Optional positive duration in `unitMs` units; fractional values allowed
+  // (e.g. 0.5 days). Returns undefined when unset; throws on garbage so a
+  // typo'd TTL fails loudly instead of silently disabling expiry.
+  const parseDurationEnv = (name: string, unitMs: number): number | undefined => {
+    const raw = process.env[name]?.trim();
+    if (!raw) return undefined;
+    const val = Number(raw);
+    if (!Number.isFinite(val) || val <= 0) {
+      throw new Error(`${name} must be a positive number, got: "${process.env[name]}"`);
+    }
+    return Math.round(val * unitMs);
+  };
+
   const mcpPort = parseIntEnv("MCP_PORT", "3000");
   // DNS-rebinding defense: the transport rejects any Host header not on this
   // list. localhost/127.0.0.1 on the bound port covers local use; deployments
@@ -146,6 +179,9 @@ export function loadConfig(): AppConfig {
       transport,
       port: mcpPort,
       authToken: process.env.MCP_AUTH_TOKEN,
+      authTokenPrevious: process.env.MCP_AUTH_TOKEN_PREVIOUS?.trim() || undefined,
+      authTokenTtlMs: parseDurationEnv("MCP_AUTH_TOKEN_TTL_DAYS", 86_400_000),
+      authTokenGraceMs: parseDurationEnv("MCP_AUTH_TOKEN_GRACE_HOURS", 3_600_000) ?? 24 * 3_600_000,
       allowedOrigins,
       allowedHosts,
       host: process.env.MCP_HOST?.trim() || undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { ResourcePoller } from "./resources/poller.js";
 import { resolveAuthToken } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
 import { createMcpServer } from "./server.js";
+import { extractBearerToken } from "./utils.js";
 
 async function main(): Promise<void> {
   const logger = createLogger();
@@ -105,11 +106,10 @@ async function main(): Promise<void> {
           return;
         }
 
-        // Auth check for MCP endpoints. The scheme is case-insensitive per
-        // RFC 7235; the token comparison is timing-safe (hash both sides so
-        // length differences don't create a timing side-channel).
-        const authHeader = req.headers.authorization ?? "";
-        const presented = authHeader.match(/^Bearer\s+(.+)$/i)?.[1] ?? "";
+        // Auth check for MCP endpoints. Token parsing tolerates the
+        // case-insensitive scheme (RFC 7235); the comparison is timing-safe
+        // (hash both sides so length differences don't leak via timing).
+        const presented = extractBearerToken(req.headers.authorization ?? "");
         const ha = createHash("sha256").update(presented).digest();
         const hb = createHash("sha256").update(authToken).digest();
         const headerValid = timingSafeEqual(ha, hb);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from "node:http";
 import { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
 import { readFile } from "node:fs/promises";
-import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -19,7 +19,7 @@ import { RateLimiter } from "./middleware/rate-limiter.js";
 import { DeviceTypeCache } from "./cache/device-type-cache.js";
 import { Resolver } from "./middleware/resolver.js";
 import { ResourcePoller } from "./resources/poller.js";
-import { resolveAuthToken } from "./auth/token.js";
+import { resolveAuthTokens } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
 import { createMcpServer } from "./server.js";
 import { extractBearerToken } from "./utils.js";
@@ -83,7 +83,16 @@ async function main(): Promise<void> {
     // A stateless StreamableHTTPServerTransport only survives a single request,
     // so each MCP session gets its own transport + server (deps are shared),
     // routed by the Mcp-Session-Id header per the SDK's session pattern.
-    const authToken = await resolveAuthToken(config.mcp.authToken, config.cache.dir, logger);
+    const authTokens = await resolveAuthTokens(
+      {
+        envToken: config.mcp.authToken,
+        envPreviousToken: config.mcp.authTokenPrevious,
+        dataDir: config.cache.dir,
+        ttlMs: config.mcp.authTokenTtlMs,
+        graceMs: config.mcp.authTokenGraceMs,
+      },
+      logger,
+    );
     const sessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
 
     const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
@@ -132,12 +141,11 @@ async function main(): Promise<void> {
         }
 
         // Auth check for MCP endpoints. Token parsing tolerates the
-        // case-insensitive scheme (RFC 7235); the comparison is timing-safe
-        // (hash both sides so length differences don't leak via timing).
+        // case-insensitive scheme (RFC 7235); verify() is timing-safe across all
+        // currently-valid tokens (it hashes both sides and checks every entry
+        // without early return) and enforces expiry live (issue #52).
         const presented = extractBearerToken(req.headers.authorization ?? "");
-        const ha = createHash("sha256").update(presented).digest();
-        const hb = createHash("sha256").update(authToken).digest();
-        const headerValid = timingSafeEqual(ha, hb);
+        const headerValid = authTokens.verify(presented);
         if (!headerValid) {
           // Challenge header so clients can discover the scheme (RFC 6750 /
           // MCP auth spec). Add error=invalid_token only when a (bad) token was
@@ -249,6 +257,7 @@ async function main(): Promise<void> {
         port: config.mcp.port,
         host: config.mcp.host ?? "0.0.0.0",
         tls: useTls,
+        authTokens: authTokens.liveCount(),
       });
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,17 @@ async function main(): Promise<void> {
         const hb = createHash("sha256").update(authToken).digest();
         const headerValid = timingSafeEqual(ha, hb);
         if (!headerValid) {
-          res.writeHead(401, { "Content-Type": "application/json" });
+          // Challenge header so clients can discover the scheme (RFC 6750 /
+          // MCP auth spec). Add error=invalid_token only when a (bad) token was
+          // actually presented; RFC 6750 §3 omits the error param when no
+          // credentials were sent.
+          const challenge = presented
+            ? 'Bearer realm="debmatic-mcp", error="invalid_token"'
+            : 'Bearer realm="debmatic-mcp"';
+          res.writeHead(401, {
+            "Content-Type": "application/json",
+            "WWW-Authenticate": challenge,
+          });
           res.end(JSON.stringify({ error: "Unauthorized" }));
           return;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,16 +82,24 @@ async function main(): Promise<void> {
     httpServer = createServer(async (req, res) => {
       try {
         // CORS so browser-based MCP clients (e.g. MCP Inspector) can connect
-        // directly. Opt-in only: a cross-origin browser is allowed solely when
-        // MCP_CORS_ALLOW_ORIGIN is configured (`*` for dev, or one trusted
-        // origin). Default is no CORS header at all, so a random web page can't
-        // reach a local instance. DNS-rebinding protection on the transport
-        // (allowedHosts, below) is the matching Host-header defense. Auth is
-        // still enforced via the bearer token regardless.
+        // directly. Default-deny against a configurable origin allowlist
+        // (MCP_ALLOWED_ORIGINS): a cross-origin browser is allowed solely when
+        // its Origin is on the list, and we reflect that exact origin back —
+        // never `*`, which would let any web page drive a local instance that
+        // controls real CCU hardware (the DNS-rebinding vector). With the list
+        // empty (the default) no CORS headers are sent at all. The same list
+        // also feeds the transport's DNS-rebinding `allowedOrigins` (below), so
+        // a disallowed origin is rejected server-side too. Auth is still
+        // enforced via the bearer token regardless.
         // CORS first implemented by @marcinn2 (marcinn2/debmatic-mcp@d33a0cb).
-        const corsOrigin = config.mcp.corsAllowOrigin;
-        if (corsOrigin) {
-          res.setHeader("Access-Control-Allow-Origin", corsOrigin);
+        const requestOrigin = req.headers.origin;
+        const originAllowed =
+          typeof requestOrigin === "string" && config.mcp.allowedOrigins.includes(requestOrigin);
+        if (originAllowed) {
+          // Reflect the exact origin (never `*`); Vary so shared caches don't
+          // serve this response to a different origin.
+          res.setHeader("Access-Control-Allow-Origin", requestOrigin);
+          res.setHeader("Vary", "Origin");
           res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
           res.setHeader(
             "Access-Control-Allow-Headers",
@@ -99,13 +107,13 @@ async function main(): Promise<void> {
           );
           res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
           res.setHeader("Access-Control-Max-Age", "86400");
-          // A specific origin makes the response vary by Origin; mark it so
-          // shared caches don't serve it to a different origin.
-          if (corsOrigin !== "*") res.setHeader("Vary", "Origin");
         }
 
         if (req.method === "OPTIONS") {
-          res.writeHead(204);
+          // Preflight succeeds (204, with the CORS headers above) only for an
+          // allowed origin; anything else gets 403 and no allow headers, so the
+          // browser blocks the actual request.
+          res.writeHead(originAllowed ? 204 : 403);
           res.end();
           return;
         }
@@ -153,8 +161,14 @@ async function main(): Promise<void> {
           // Defense-in-depth against DNS rebinding: reject requests whose Host
           // header isn't an expected one (a browser tricked into hitting a
           // local instance carries the attacker's host, not localhost:port).
+          // allowedOrigins mirrors the CORS allowlist so a browser request with
+          // a disallowed Origin is also rejected server-side; an empty list
+          // disables the Origin check (the SDK only enforces it when non-empty,
+          // and only when an Origin header is present — non-browser clients that
+          // send no Origin are unaffected).
           enableDnsRebindingProtection: true,
           allowedHosts: config.mcp.allowedHosts,
+          allowedOrigins: config.mcp.allowedOrigins,
           onsessioninitialized: (sid) => {
             sessions.set(sid, { server: sessionServer, transport });
             logger.info("mcp_session_started", { sessions: sessions.size });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 
-import { createServer, type Server as HttpServer } from "node:http";
+import {
+  createServer as createHttpServer,
+  type Server as HttpServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
+import { readFile } from "node:fs/promises";
 import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -58,7 +65,7 @@ async function main(): Promise<void> {
 
   let poller: ResourcePoller;
   let closeTransports: () => Promise<void>;
-  let httpServer: HttpServer | null = null;
+  let httpServer: HttpServer | HttpsServer | null = null;
 
   if (config.mcp.transport === "stdio") {
     const mcpServer = createMcpServer(deps);
@@ -79,7 +86,7 @@ async function main(): Promise<void> {
     const authToken = await resolveAuthToken(config.mcp.authToken, config.cache.dir, logger);
     const sessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
 
-    httpServer = createServer(async (req, res) => {
+    const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       try {
         // CORS so browser-based MCP clients (e.g. MCP Inspector) can connect
         // directly. Default-deny against a configurable origin allowlist
@@ -190,7 +197,37 @@ async function main(): Promise<void> {
         }
         res.end(JSON.stringify({ error: "Internal error" }));
       }
-    });
+    };
+
+    // Native TLS is opt-in (issue #50): with both cert and key set we serve
+    // HTTPS so the bearer token isn't exposed in transit; otherwise we keep
+    // plain HTTP (the zero-config default). config validates that cert/key are
+    // set together.
+    const useTls = Boolean(config.mcp.tlsCertPath && config.mcp.tlsKeyPath);
+    if (useTls) {
+      const [cert, key] = await Promise.all([
+        readFile(config.mcp.tlsCertPath!),
+        readFile(config.mcp.tlsKeyPath!),
+      ]);
+      httpServer = createHttpsServer({ cert, key }, handleRequest);
+    } else {
+      httpServer = createHttpServer(handleRequest);
+      // Plain HTTP is allowed (some run behind a TLS-terminating proxy, or on a
+      // trusted LAN), but the bearer token then travels in the clear. Warn once
+      // at startup unless the listener is loopback-only or the operator has
+      // acknowledged it via MCP_ALLOW_PLAINTEXT.
+      const host = config.mcp.host;
+      const loopbackOnly = host === "127.0.0.1" || host === "::1" || host === "localhost";
+      if (!loopbackOnly && !config.mcp.allowPlaintext) {
+        logger.warn("plaintext_http", {
+          hint:
+            "MCP is serving the bearer token over unencrypted HTTP on a non-loopback " +
+            "address. Set MCP_TLS_CERT/MCP_TLS_KEY for native TLS, put a TLS-terminating " +
+            "reverse proxy in front, bind loopback with MCP_HOST=127.0.0.1, or set " +
+            "MCP_ALLOW_PLAINTEXT=true to silence this warning.",
+        });
+      }
+    }
 
     poller = new ResourcePoller(
       async () => {
@@ -206,8 +243,13 @@ async function main(): Promise<void> {
       sessions.clear();
     };
 
-    httpServer.listen(config.mcp.port, () => {
-      logger.info("server_ready", { transport: "http", port: config.mcp.port });
+    httpServer.listen(config.mcp.port, config.mcp.host, () => {
+      logger.info("server_ready", {
+        transport: useTls ? "https" : "http",
+        port: config.mcp.port,
+        host: config.mcp.host ?? "0.0.0.0",
+        tls: useTls,
+      });
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,17 +82,27 @@ async function main(): Promise<void> {
     httpServer = createServer(async (req, res) => {
       try {
         // CORS so browser-based MCP clients (e.g. MCP Inspector) can connect
-        // directly. Auth is still enforced via the bearer token below.
-        // Mcp-Session-Id must be exposed or browsers can't reuse the session.
-        // Credit: @marcinn2 (marcinn2/debmatic-mcp@d33a0cb)
-        res.setHeader("Access-Control-Allow-Origin", "*");
-        res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-        res.setHeader(
-          "Access-Control-Allow-Headers",
-          "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID",
-        );
-        res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
-        res.setHeader("Access-Control-Max-Age", "86400");
+        // directly. Opt-in only: a cross-origin browser is allowed solely when
+        // MCP_CORS_ALLOW_ORIGIN is configured (`*` for dev, or one trusted
+        // origin). Default is no CORS header at all, so a random web page can't
+        // reach a local instance. DNS-rebinding protection on the transport
+        // (allowedHosts, below) is the matching Host-header defense. Auth is
+        // still enforced via the bearer token regardless.
+        // CORS first implemented by @marcinn2 (marcinn2/debmatic-mcp@d33a0cb).
+        const corsOrigin = config.mcp.corsAllowOrigin;
+        if (corsOrigin) {
+          res.setHeader("Access-Control-Allow-Origin", corsOrigin);
+          res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+          res.setHeader(
+            "Access-Control-Allow-Headers",
+            "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID",
+          );
+          res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
+          res.setHeader("Access-Control-Max-Age", "86400");
+          // A specific origin makes the response vary by Origin; mark it so
+          // shared caches don't serve it to a different origin.
+          if (corsOrigin !== "*") res.setHeader("Vary", "Origin");
+        }
 
         if (req.method === "OPTIONS") {
           res.writeHead(204);
@@ -130,6 +140,11 @@ async function main(): Promise<void> {
         // transport itself rejects non-initialize requests without a session.
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
+          // Defense-in-depth against DNS rebinding: reject requests whose Host
+          // header isn't an expected one (a browser tricked into hitting a
+          // local instance carries the attacker's host, not localhost:port).
+          enableDnsRebindingProtection: true,
+          allowedHosts: config.mcp.allowedHosts,
           onsessioninitialized: (sid) => {
             sessions.set(sid, { server: sessionServer, transport });
             logger.info("mcp_session_started", { sessions: sessions.size });

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -313,8 +313,11 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
         }
 
         // Create via ReGa (no SysVar.createString exists, and this keeps all four
-        // types on one code path). dom.CreateObject(OT_VARDP) + ValueType/SubType
-        // is the WebUI's own mechanism for new system variables.
+        // types on one code path). Modeled exactly on the CCU's own JSON-RPC
+        // method scripts (occu WebUI/www/api/methods/sysvar/create*.tcl): set
+        // ValueType + type-specifics, then oSysVars.Add(sv.ID()) LAST. We add
+        // ValueUnit (float) and DPInfo (description), which those methods don't
+        // expose as parameters. There is no createString method, hence ReGa.
         const name = escapeHmScript(args.name);
         const info = escapeHmScript(args.description ?? "");
         let typeSetup: string;
@@ -333,11 +336,10 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
             const max = Number.isFinite(args.max) ? args.max : 100;
             typeSetup =
               'sv.ValueType(ivtFloat);\n' +
-              'sv.ValueSubType(istGeneric);\n' +
-              `sv.ValueUnit("${unit}");\n` +
               `sv.ValueMin(${min});\n` +
               `sv.ValueMax(${max});\n` +
-              `sv.State(${min});`;
+              `sv.ValueUnit("${unit}");\n` +
+              'sv.State(0);';
             break;
           }
           case "enum": {
@@ -346,8 +348,6 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
               'sv.ValueType(ivtInteger);\n' +
               'sv.ValueSubType(istEnum);\n' +
               `sv.ValueList("${list}");\n` +
-              'sv.ValueMin(0);\n' +
-              `sv.ValueMax(${(args.values ?? []).length - 1});\n` +
               'sv.State(0);';
             break;
           }
@@ -355,20 +355,18 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
           default:
             typeSetup =
               'sv.ValueType(ivtString);\n' +
-              'sv.ValueSubType(istChar8859);\n' +
               'sv.State("");';
             break;
         }
 
         const script =
+          `object oSysVars = dom.GetObject(ID_SYSTEM_VARIABLES);\n` +
           `object sv = dom.CreateObject(OT_VARDP);\n` +
           `sv.Name("${name}");\n` +
-          `dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());\n` +
           `${typeSetup}\n` +
           `sv.DPInfo("${info}");\n` +
           `sv.Internal(false);\n` +
-          `sv.Visible(true);\n` +
-          `dom.RTUpdate(false);`;
+          `oSysVars.Add(sv.ID());`;
 
         await rateLimiter.acquire();
         await withRetry(

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -316,32 +316,33 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
         }
 
         // Create via ReGa (no SysVar.createString exists, and this keeps all four
-        // types on one code path). Modeled exactly on the CCU's own JSON-RPC
-        // method scripts (occu WebUI/www/api/methods/sysvar/create*.tcl): set
-        // ValueType + type-specifics, then oSysVars.Add(sv.ID()) LAST. We add
-        // ValueUnit (float) and DPInfo (description), which those methods don't
-        // expose as parameters. There is no createString method, hence ReGa.
+        // types on one code path). Ordering matters and was verified live: set
+        // ValueType + Name + type-specifics, Add(sv.ID()), and only THEN set
+        // ValueUnit/DPInfo — setting those *before* Add makes the CCU store the
+        // variable under a deduplicated " N" name (silent rename). The script
+        // returns the actual stored name so we never report a name we didn't get.
         const name = escapeHmScript(args.name);
         const info = escapeHmScript(args.description ?? "");
+        const unit = escapeHmScript(args.unit ?? "");
         let typeSetup: string;
         switch (args.type) {
           case "bool":
             typeSetup =
               'sv.ValueType(ivtBinary);\n' +
               'sv.ValueSubType(istBool);\n' +
+              `sv.Name("${name}");\n` +
               'sv.ValueName0("false");\n' +
               'sv.ValueName1("true");\n' +
               'sv.State(false);';
             break;
           case "float": {
-            const unit = escapeHmScript(args.unit ?? "");
             const min = Number.isFinite(args.min) ? args.min : 0;
             const max = Number.isFinite(args.max) ? args.max : 100;
             typeSetup =
               'sv.ValueType(ivtFloat);\n' +
+              `sv.Name("${name}");\n` +
               `sv.ValueMin(${min});\n` +
               `sv.ValueMax(${max});\n` +
-              `sv.ValueUnit("${unit}");\n` +
               'sv.State(0);';
             break;
           }
@@ -350,6 +351,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
             typeSetup =
               'sv.ValueType(ivtInteger);\n' +
               'sv.ValueSubType(istEnum);\n' +
+              `sv.Name("${name}");\n` +
               `sv.ValueList("${list}");\n` +
               'sv.State(0);';
             break;
@@ -358,29 +360,58 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
           default:
             typeSetup =
               'sv.ValueType(ivtString);\n' +
+              `sv.Name("${name}");\n` +
               'sv.State("");';
             break;
         }
 
+        // ValueUnit applies to float only; DPInfo (description) to all. Both go
+        // AFTER Add (see comment above).
+        const postAdd =
+          (args.type === "float" ? `sv.ValueUnit("${unit}");\n` : "") +
+          `sv.DPInfo("${info}");`;
+
         const script =
           `object oSysVars = dom.GetObject(ID_SYSTEM_VARIABLES);\n` +
           `object sv = dom.CreateObject(OT_VARDP);\n` +
-          `sv.Name("${name}");\n` +
           `${typeSetup}\n` +
-          `sv.DPInfo("${info}");\n` +
           `sv.Internal(false);\n` +
-          `oSysVars.Add(sv.ID());`;
+          `oSysVars.Add(sv.ID());\n` +
+          `${postAdd}\n` +
+          `dom.RTUpdate(false);\n` +
+          `WriteLine(sv.Name());`;
 
         await rateLimiter.acquire();
-        await withRetry(
+        const createResult = await withRetry(
           () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
 
+        // The script echoes the ACTUAL stored name. The CCU silently dedups a
+        // requested name against existing similar names (e.g. "X" becomes "X 1"
+        // when an "X 2" already exists), which the exact-match pre-check above
+        // can't see. If we didn't get the name we asked for, undo it and report
+        // the collision rather than leaving a surprise variable behind.
+        const actualName = typeof createResult === "string" && createResult.trim()
+          ? createResult.trim()
+          : args.name;
+        if (actualName !== args.name) {
+          try {
+            await rateLimiter.acquire();
+            await session.call("SysVar.deleteSysVarByName", { name: actualName });
+          } catch { /* best-effort cleanup of the unintended object */ }
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: `System variable name unavailable: "${args.name}" (the CCU would store it as "${actualName}")`,
+            hint: "Pick a different name — the CCU deduplicates against existing similar names.",
+          });
+        }
+
         typeCacheHolder.entry = null; // new variable must be visible to the next set
         logger.info("tool_call", { tool: "create_system_variable", duration_ms: Date.now() - start, status: "ok", type: args.type });
-        return toolResult({ name: args.name, type: args.type, created: true });
+        return toolResult({ name: actualName, type: args.type, created: true });
       } catch (err) {
         logger.info("tool_call", { tool: "create_system_variable", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
+import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
 import { toolResult, parseValue, escapeHmScript } from "../utils.js";
@@ -19,6 +20,8 @@ export function registerControlTools(server: McpServer, deps: ServerDeps): void 
   registerCreateSystemVariable(server, deps, sysVarTypeCache);
   registerDeleteSystemVariable(server, deps, sysVarTypeCache);
   registerExecuteProgram(server, deps);
+  registerAssignChannel(server, deps, "add");
+  registerAssignChannel(server, deps, "remove");
 }
 
 function registerSetValue(server: McpServer, deps: ServerDeps): void {
@@ -436,6 +439,132 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps, typeC
         return toolResult({ name: args.name, deleted: true });
       } catch (err) {
         logger.info("tool_call", { tool: "delete_system_variable", duration_ms: Date.now() - start, status: "error" });
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+    },
+  );
+}
+
+function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" | "remove"): void {
+  const toolName = mode === "add" ? "assign_channel" : "unassign_channel";
+  const verb = mode === "add" ? "Assign" : "Remove";
+  const prep = mode === "add" ? "to" : "from";
+
+  server.registerTool(
+    toolName,
+    {
+      title: `${verb} Channel ${mode === "add" ? "to" : "from"} Room/Function`,
+      description:
+        `${verb} a channel ${prep} a room and/or a function group. Identify the channel by address ` +
+        "and the room/function by name (use list_rooms / list_functions to see names). " +
+        "At least one of room or function is required.",
+      inputSchema: {
+        channel: z.string().describe("Channel address (e.g. '000A1BE9A71F15:1')"),
+        room: z.string().optional().describe("Room name (exact match)"),
+        function: z.string().optional().describe("Function group name (exact match)"),
+      },
+      annotations: {
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      const { session, rateLimiter, logger } = deps;
+      const start = Date.now();
+
+      try {
+        if (!args.room && !args.function) {
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: "Provide a room and/or a function to assign the channel to.",
+            hint: "Pass room and/or function by name (see list_rooms / list_functions).",
+          });
+        }
+
+        // Resolve the channel address → channel ID (the membership APIs take IDs).
+        await rateLimiter.acquire();
+        const devices = await withRetry(
+          () => session.call("Device.listAllDetail"),
+          "Device.listAllDetail",
+          logger,
+        ) as CcuDevice[];
+        deps.resolver.updateDeviceList(devices);
+        let channelId: string | undefined;
+        for (const d of devices) {
+          const ch = d.channels.find((c) => c.address === args.channel);
+          if (ch) { channelId = ch.id; break; }
+        }
+        if (!channelId) {
+          throw new CcuError({
+            error: "NOT_FOUND",
+            code: 0,
+            message: `Channel not found: ${args.channel}`,
+            hint: "Call list_devices to find valid channel addresses.",
+          });
+        }
+
+        const applied: Array<{ kind: "room" | "function"; name: string }> = [];
+
+        if (args.room) {
+          await rateLimiter.acquire();
+          const rooms = await withRetry(
+            () => session.call("Room.getAll"),
+            "Room.getAll",
+            logger,
+          ) as Array<{ id: string; name: string }>;
+          const room = rooms.find((r) => r.name === args.room);
+          if (!room) {
+            throw new CcuError({
+              error: "NOT_FOUND",
+              code: 0,
+              message: `Room not found: ${args.room}`,
+              hint: `Valid rooms: ${rooms.map((r) => r.name).join(", ")}`,
+            });
+          }
+          await rateLimiter.acquire();
+          await withRetry(
+            () => session.call(mode === "add" ? "Room.addChannel" : "Room.removeChannel", { id: room.id, channelId }),
+            "Room.modifyChannel",
+            logger,
+          );
+          applied.push({ kind: "room", name: room.name });
+        }
+
+        if (args.function) {
+          await rateLimiter.acquire();
+          const functions = await withRetry(
+            () => session.call("Subsection.getAll"),
+            "Subsection.getAll",
+            logger,
+          ) as Array<{ id: string; name: string }>;
+          const fn = functions.find((f) => f.name === args.function);
+          if (!fn) {
+            throw new CcuError({
+              error: "NOT_FOUND",
+              code: 0,
+              message: `Function not found: ${args.function}`,
+              hint: `Valid functions: ${functions.map((f) => f.name).join(", ")}`,
+            });
+          }
+          await rateLimiter.acquire();
+          await withRetry(
+            () => session.call(mode === "add" ? "Subsection.addChannel" : "Subsection.removeChannel", { id: fn.id, channelId }),
+            "Subsection.modifyChannel",
+            logger,
+          );
+          applied.push({ kind: "function", name: fn.name });
+        }
+
+        logger.info("tool_call", { tool: toolName, duration_ms: Date.now() - start, status: "ok" });
+        return toolResult({
+          channel: args.channel,
+          [mode === "add" ? "assignedTo" : "removedFrom"]: applied,
+        });
+      } catch (err) {
+        logger.info("tool_call", { tool: toolName, duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
         throw err;
       }

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -5,10 +5,19 @@ import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
 import { toolResult, parseValue, escapeHmScript } from "../utils.js";
 
+// Short-lived name→type cache (#9), shared so create/delete can invalidate it
+// and a freshly created/removed variable is reflected on the next set.
+interface SysVarTypeCacheHolder {
+  entry: { ts: number; types: Map<string, string> } | null;
+}
+
 export function registerControlTools(server: McpServer, deps: ServerDeps): void {
+  const sysVarTypeCache: SysVarTypeCacheHolder = { entry: null };
   registerSetValue(server, deps);
   registerPutParamset(server, deps);
-  registerSetSystemVariable(server, deps);
+  registerSetSystemVariable(server, deps, sysVarTypeCache);
+  registerCreateSystemVariable(server, deps, sysVarTypeCache);
+  registerDeleteSystemVariable(server, deps, sysVarTypeCache);
   registerExecuteProgram(server, deps);
 }
 
@@ -148,11 +157,10 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
 
 const SYSVAR_TYPE_TTL_MS = 30_000;
 
-function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
-  // Short-lived name→type cache: avoids fetching the full sysvar list on every
-  // write. Types virtually never change; a fresh-cache miss still refetches,
-  // so newly created variables are picked up immediately.
-  let typeCache: { ts: number; types: Map<string, string> } | null = null;
+function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCacheHolder: SysVarTypeCacheHolder): void {
+  // Short-lived name→type cache (shared via the holder): avoids fetching the
+  // full sysvar list on every write. create/delete clear it so new/removed
+  // variables are reflected immediately.
 
   server.registerTool(
     "set_system_variable",
@@ -178,8 +186,8 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         // Look up variable type (cached) to choose correct setter
         let method: string;
         let sysVarType: string | undefined;
-        if (typeCache && Date.now() - typeCache.ts < SYSVAR_TYPE_TTL_MS) {
-          sysVarType = typeCache.types.get(args.name);
+        if (typeCacheHolder.entry && Date.now() - typeCacheHolder.entry.ts < SYSVAR_TYPE_TTL_MS) {
+          sysVarType = typeCacheHolder.entry.types.get(args.name);
         }
         if (sysVarType === undefined) {
           await rateLimiter.acquire();
@@ -188,8 +196,8 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
             "SysVar.getAll",
             logger,
           ) as Array<{ name: string; type: string }>;
-          typeCache = { ts: Date.now(), types: new Map(allVars.map((v) => [v.name, v.type])) };
-          sysVarType = typeCache.types.get(args.name);
+          typeCacheHolder.entry = { ts: Date.now(), types: new Map(allVars.map((v) => [v.name, v.type])) };
+          sysVarType = typeCacheHolder.entry.types.get(args.name);
         }
 
         if (sysVarType !== undefined) {
@@ -244,6 +252,192 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         return toolResult({ name: args.name, value: args.value, method });
       } catch (err) {
         logger.info("tool_call", { tool: "set_system_variable", duration_ms: Date.now() - start, status: "error" });
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+    },
+  );
+}
+
+function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeCacheHolder: SysVarTypeCacheHolder): void {
+  server.registerTool(
+    "create_system_variable",
+    {
+      title: "Create System Variable",
+      description:
+        "Create a new system variable. Types: 'bool', 'float' (optional min/max/unit), " +
+        "'enum' (requires values list), 'string'. Use set_system_variable to write it afterwards, " +
+        "list_system_variables to see existing ones.",
+      inputSchema: {
+        name: z.string().describe("New variable name (must not already exist)"),
+        type: z.enum(["bool", "float", "enum", "string"]).describe("Variable type"),
+        description: z.string().optional().describe("Human-readable description shown in the WebUI"),
+        unit: z.string().optional().describe("Unit label (float only, e.g. '°C')"),
+        min: z.number().optional().describe("Minimum value (float only)"),
+        max: z.number().optional().describe("Maximum value (float only)"),
+        values: z.array(z.string()).optional().describe("Enum value labels in order (enum only, e.g. ['off','low','high'])"),
+      },
+      annotations: {
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      const { session, rateLimiter, logger } = deps;
+      const start = Date.now();
+
+      try {
+        if (args.type === "enum" && (!args.values || args.values.length === 0)) {
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: "An enum system variable requires a non-empty 'values' list.",
+            hint: "Pass values, e.g. [\"off\", \"low\", \"high\"].",
+          });
+        }
+
+        // Reject duplicates up front (creating over an existing name corrupts it).
+        await rateLimiter.acquire();
+        const existing = await withRetry(
+          () => session.call("SysVar.getAll"),
+          "SysVar.getAll",
+          logger,
+        ) as Array<{ name: string }>;
+        if (existing.some((v) => v.name === args.name)) {
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: `System variable already exists: ${args.name}`,
+            hint: "Pick a unique name, or use set_system_variable to change the existing one.",
+          });
+        }
+
+        // Create via ReGa (no SysVar.createString exists, and this keeps all four
+        // types on one code path). dom.CreateObject(OT_VARDP) + ValueType/SubType
+        // is the WebUI's own mechanism for new system variables.
+        const name = escapeHmScript(args.name);
+        const info = escapeHmScript(args.description ?? "");
+        let typeSetup: string;
+        switch (args.type) {
+          case "bool":
+            typeSetup =
+              'sv.ValueType(ivtBinary);\n' +
+              'sv.ValueSubType(istBool);\n' +
+              'sv.ValueName0("false");\n' +
+              'sv.ValueName1("true");\n' +
+              'sv.State(false);';
+            break;
+          case "float": {
+            const unit = escapeHmScript(args.unit ?? "");
+            const min = Number.isFinite(args.min) ? args.min : 0;
+            const max = Number.isFinite(args.max) ? args.max : 100;
+            typeSetup =
+              'sv.ValueType(ivtFloat);\n' +
+              'sv.ValueSubType(istGeneric);\n' +
+              `sv.ValueUnit("${unit}");\n` +
+              `sv.ValueMin(${min});\n` +
+              `sv.ValueMax(${max});\n` +
+              `sv.State(${min});`;
+            break;
+          }
+          case "enum": {
+            const list = escapeHmScript((args.values ?? []).join(";"));
+            typeSetup =
+              'sv.ValueType(ivtInteger);\n' +
+              'sv.ValueSubType(istEnum);\n' +
+              `sv.ValueList("${list}");\n` +
+              'sv.ValueMin(0);\n' +
+              `sv.ValueMax(${(args.values ?? []).length - 1});\n` +
+              'sv.State(0);';
+            break;
+          }
+          case "string":
+          default:
+            typeSetup =
+              'sv.ValueType(ivtString);\n' +
+              'sv.ValueSubType(istChar8859);\n' +
+              'sv.State("");';
+            break;
+        }
+
+        const script =
+          `object sv = dom.CreateObject(OT_VARDP);\n` +
+          `sv.Name("${name}");\n` +
+          `dom.GetObject(ID_SYSTEM_VARIABLES).Add(sv.ID());\n` +
+          `${typeSetup}\n` +
+          `sv.DPInfo("${info}");\n` +
+          `sv.Internal(false);\n` +
+          `sv.Visible(true);\n` +
+          `dom.RTUpdate(false);`;
+
+        await rateLimiter.acquire();
+        await withRetry(
+          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          "ReGa.runScript",
+          logger,
+        );
+
+        typeCacheHolder.entry = null; // new variable must be visible to the next set
+        logger.info("tool_call", { tool: "create_system_variable", duration_ms: Date.now() - start, status: "ok", type: args.type });
+        return toolResult({ name: args.name, type: args.type, created: true });
+      } catch (err) {
+        logger.info("tool_call", { tool: "create_system_variable", duration_ms: Date.now() - start, status: "error" });
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+    },
+  );
+}
+
+function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps, typeCacheHolder: SysVarTypeCacheHolder): void {
+  server.registerTool(
+    "delete_system_variable",
+    {
+      title: "Delete System Variable",
+      description: "Delete a system variable by name. Use list_system_variables to see existing names.",
+      inputSchema: {
+        name: z.string().describe("Variable name (exact match)"),
+      },
+      annotations: {
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      const { session, rateLimiter, logger } = deps;
+      const start = Date.now();
+
+      try {
+        // Validate existence so an unknown name is a clean NOT_FOUND rather than
+        // a silent no-op (deleteSysVarByName doesn't report a missing name).
+        await rateLimiter.acquire();
+        const existing = await withRetry(
+          () => session.call("SysVar.getAll"),
+          "SysVar.getAll",
+          logger,
+        ) as Array<{ name: string }>;
+        if (!existing.some((v) => v.name === args.name)) {
+          throw new CcuError({
+            error: "NOT_FOUND",
+            code: 0,
+            message: `System variable not found: ${args.name}`,
+            hint: "Call list_system_variables to see available variables (name must match exactly).",
+          });
+        }
+
+        await rateLimiter.acquire();
+        await withRetry(
+          () => session.call("SysVar.deleteSysVarByName", { name: args.name }),
+          "SysVar.deleteSysVarByName",
+          logger,
+        );
+
+        typeCacheHolder.entry = null; // removed variable must not linger in the cache
+        logger.info("tool_call", { tool: "delete_system_variable", duration_ms: Date.now() - start, status: "ok" });
+        return toolResult({ name: args.name, deleted: true });
+      } catch (err) {
+        logger.info("tool_call", { tool: "delete_system_variable", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
         throw err;
       }

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -29,8 +29,9 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
         type: z.enum(["bool", "int", "double", "string"]).optional().describe("Value type override (auto-resolved if omitted)"),
       },
       annotations: {
-        title: "Set Value",
         destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
       },
     },
     async (args) => {
@@ -102,8 +103,9 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
         interface: z.string().optional().describe("Interface name override"),
       },
       annotations: {
-        title: "Put Paramset",
         destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
       },
     },
     async (args) => {
@@ -163,8 +165,9 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         value: z.union([z.string(), z.number(), z.boolean()]).describe("Value to set"),
       },
       annotations: {
-        title: "Set System Variable",
         destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
       },
     },
     async (args) => {
@@ -260,8 +263,8 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
         id: z.string().describe("Program ID. Get from list_programs."),
       },
       annotations: {
-        title: "Execute Program",
         destructiveHint: true,
+        openWorldHint: true,
       },
     },
     async (args) => {

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -16,6 +16,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
       title: "Get Service Messages",
       description:
         "Get all active service messages (low battery, unreachable, etc.) with device details and timestamps.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
       const { session, rateLimiter, logger } = deps;
@@ -118,6 +119,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
     {
       title: "Get System Info",
       description: "Get CCU system information: firmware version, serial number, addresses.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
       const { session, rateLimiter, logger, deviceTypeCache } = deps;

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
+import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
 import { toolResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
@@ -9,6 +10,13 @@ export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): v
   registerGetServiceMessages(server, deps);
   registerAcknowledgeServiceMessages(server, deps);
   registerGetSystemInfo(server, deps);
+  registerGetRssi(server, deps);
+}
+
+// rssiInfo reports 65536 (0x10000) when no measurement is available; real
+// values are already in dBm. Map the sentinel (and any non-number) to null.
+function normalizeRssi(v: unknown): number | null {
+  return typeof v === "number" && v !== 65536 ? v : null;
 }
 
 function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
@@ -267,6 +275,115 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
         return toolResult(results);
       } catch (err) {
         logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "error" });
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+    },
+  );
+}
+
+function registerGetRssi(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "get_rssi",
+    {
+      title: "Get RSSI / Radio Quality",
+      description:
+        "Report radio link quality (RSSI, in dBm) for every device, resolved to device names, " +
+        "plus BidCos interface health (duty cycle, connected state). Use to answer 'why is this " +
+        "sensor flaky?'. Higher (closer to 0) dBm is better; null means no measurement available.",
+      inputSchema: {
+        name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) => {
+      const { session, rateLimiter, logger } = deps;
+      const start = Date.now();
+
+      try {
+        // Device list → address→{name,interface}. Same call list_devices uses;
+        // also refresh the resolver so later interface lookups are warm.
+        await rateLimiter.acquire();
+        const devices = await withRetry(
+          () => session.call("Device.listAllDetail"),
+          "Device.listAllDetail",
+          logger,
+        ) as CcuDevice[];
+        deps.resolver.updateDeviceList(devices);
+        const nameByAddress = new Map<string, string>();
+        const ifaceByAddress = new Map<string, string>();
+        for (const d of devices) {
+          nameByAddress.set(d.address, d.name);
+          ifaceByAddress.set(d.address, d.interface);
+        }
+
+        // Enumerate interfaces and pull rssiInfo per interface. rssiInfo maps
+        // device1 → device2 → [rssiAtDevice1, rssiAtDevice2] (dBm; 65536 = none).
+        await rateLimiter.acquire();
+        const interfaces = await withRetry(
+          () => session.call("Interface.listInterfaces"),
+          "Interface.listInterfaces",
+          logger,
+        ) as Array<{ name: string }>;
+
+        const needle = args.name?.toLowerCase();
+        const deviceEntries: Array<Record<string, unknown>> = [];
+
+        for (const iface of interfaces) {
+          let info: Record<string, Record<string, unknown>> | null = null;
+          try {
+            await rateLimiter.acquire();
+            info = await withRetry(
+              () => session.call("Interface.rssiInfo", { interface: iface.name }),
+              "Interface.rssiInfo",
+              logger,
+            ) as Record<string, Record<string, unknown>>;
+          } catch {
+            // Interfaces without RF (e.g. VirtualDevices) don't support rssiInfo.
+            continue;
+          }
+          if (!info || typeof info !== "object") continue;
+
+          for (const [address, peers] of Object.entries(info)) {
+            if (!peers || typeof peers !== "object") continue;
+            const links = Object.entries(peers).map(([peer, pair]) => {
+              const [atDevice, atPeer] = Array.isArray(pair) ? pair : [];
+              return {
+                peer,
+                peerName: nameByAddress.get(peer) ?? "",
+                rssiDevice: normalizeRssi(atDevice), // dBm received by this device from peer
+                rssiPeer: normalizeRssi(atPeer),     // dBm received by the peer from this device
+              };
+            });
+            const entry = {
+              address,
+              name: nameByAddress.get(address) ?? "",
+              interface: ifaceByAddress.get(address) ?? iface.name,
+              links,
+            };
+            if (needle && !`${entry.address} ${entry.name}`.toLowerCase().includes(needle)) continue;
+            deviceEntries.push(entry);
+          }
+        }
+
+        // BidCos interface health (duty cycle, connected). Optional — not all
+        // setups expose it; tolerate failure rather than failing the whole call.
+        let bidcosInterfaces: unknown = [];
+        try {
+          await rateLimiter.acquire();
+          bidcosInterfaces = await withRetry(
+            () => session.call("Interface.listBidcosInterfaces"),
+            "Interface.listBidcosInterfaces",
+            logger,
+          );
+        } catch {
+          bidcosInterfaces = [];
+        }
+
+        logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "ok", devices: deviceEntries.length });
+        return toolResult({ devices: deviceEntries, interfaces: bidcosInterfaces });
+      } catch (err) {
+        logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
         throw err;
       }

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -1,11 +1,13 @@
+import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
-import { toolResult, tryParseJson, VERSION } from "../utils.js";
+import { toolResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
   registerGetServiceMessages(server, deps);
+  registerAcknowledgeServiceMessages(server, deps);
   registerGetSystemInfo(server, deps);
 }
 
@@ -106,6 +108,120 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
         return toolResult(messages);
       } catch (err) {
         logger.info("tool_call", { tool: "get_service_messages", duration_ms: Date.now() - start, status: "error" });
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+    },
+  );
+}
+
+function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "acknowledge_service_messages",
+    {
+      title: "Acknowledge Service Messages",
+      description:
+        "Confirm/dismiss active service messages (e.g. clear a low-battery or unreachable warning). " +
+        "Provide an alarm id (from get_service_messages) to confirm one message, or a channel address " +
+        "to confirm all active messages on that channel. A warning reappears if its condition persists.",
+      inputSchema: {
+        id: z.string().optional().describe("Alarm id from get_service_messages (confirm a single message)"),
+        address: z.string().optional().describe("Channel address — confirm all active messages on this channel (e.g. '000A1BE9A71F15:0')"),
+      },
+      annotations: {
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      const { session, rateLimiter, logger } = deps;
+      const start = Date.now();
+
+      try {
+        if (!args.id && !args.address) {
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: "Provide either an alarm id or a channel address to acknowledge.",
+            hint: "Call get_service_messages to see active alarms with their ids and addresses.",
+          });
+        }
+
+        // Enumerate active alarms (same OT_ALARMDP objects get_service_messages
+        // lists), AlConfirm() the ones matching the requested id/address, and
+        // report what was confirmed. Confirming in ReGa avoids a second round
+        // trip and means we only ever confirm currently-active alarms.
+        const wantId = escapeHmScript(args.id ?? "");
+        const wantAddr = escapeHmScript(args.address ?? "");
+        const script = `
+          string wantId = "${wantId}";
+          string wantAddr = "${wantAddr}";
+          object svcs = dom.GetObject(ID_SERVICES);
+          boolean first = true;
+          Write('{"confirmed":[');
+          if (svcs) {
+            string sId;
+            foreach(sId, svcs.EnumIDs()) {
+              object svc = dom.GetObject(sId);
+              if (svc && svc.IsTypeOf(OT_ALARMDP) && svc.AlState() == asOncoming) {
+                string alName = svc.Name();
+                string chAddr = "";
+                string dpName = "";
+                integer alPos = alName.Find("AL-");
+                if (alPos >= 0) {
+                  string rest = alName.Substr(3, alName.Length());
+                  integer dotPos = rest.Find(".");
+                  if (dotPos > 0) {
+                    chAddr = rest.Substr(0, dotPos);
+                    dpName = rest.Substr(dotPos + 1, rest.Length());
+                  }
+                }
+                boolean match = false;
+                if (wantId != "" && sId == wantId) { match = true; }
+                if (wantAddr != "" && chAddr == wantAddr) { match = true; }
+                if (match) {
+                  svc.AlConfirm();
+                  if (!first) { Write(","); } first = false;
+                  ! JSON-escape user-controlled names (backslash first, then quote)
+                  dpName = dpName.Replace("\\\\", "\\\\\\\\");
+                  dpName = dpName.Replace("\\"", "\\\\\\"");
+                  Write('{"id":"' # sId # '","type":"' # dpName # '","address":"' # chAddr # '"}');
+                }
+              }
+            }
+          }
+          Write(']}');
+        `;
+
+        await rateLimiter.acquire();
+        const result = await withRetry(
+          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          "ReGa.runScript",
+          logger,
+        );
+
+        const parsed = typeof result === "string" ? tryParseJson(result) : result;
+        const confirmed = (parsed && typeof parsed === "object" && !Array.isArray(parsed)
+          && Array.isArray((parsed as Record<string, unknown>).confirmed))
+          ? (parsed as Record<string, unknown>).confirmed as Array<Record<string, unknown>>
+          : [];
+
+        if (confirmed.length === 0) {
+          throw new CcuError({
+            error: "NOT_FOUND",
+            code: 0,
+            message: args.id
+              ? `No active service message with id: ${args.id}`
+              : `No active service messages on channel: ${args.address}`,
+            hint: "Call get_service_messages to see currently active alarms.",
+          });
+        }
+
+        logger.info("tool_call", { tool: "acknowledge_service_messages", duration_ms: Date.now() - start, status: "ok", count: confirmed.length });
+        return toolResult({ confirmed, count: confirmed.length });
+      } catch (err) {
+        logger.info("tool_call", { tool: "acknowledge_service_messages", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
         throw err;
       }

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -4,7 +4,7 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
-import { toolResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
+import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
   registerGetServiceMessages(server, deps);
@@ -26,6 +26,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
       title: "Get Service Messages",
       description:
         "Get all active service messages (low battery, unreachable, etc.) with device details and timestamps.",
+      outputSchema: { messages: z.array(z.unknown()).describe("Active alarms: {id, type, address, channelName, timestamp}") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
@@ -113,7 +114,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
         }
 
         logger.info("tool_call", { tool: "get_service_messages", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(messages);
+        return structuredResult({ messages: Array.isArray(messages) ? messages : [] }, messages);
       } catch (err) {
         logger.info("tool_call", { tool: "get_service_messages", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -243,6 +244,15 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
     {
       title: "Get System Info",
       description: "Get CCU system information: firmware version, serial number, addresses.",
+      outputSchema: {
+        serverVersion: z.string().optional(),
+        version: z.unknown().optional(),
+        serial: z.unknown().optional(),
+        address: z.unknown().optional(),
+        hmipAddress: z.unknown().optional(),
+        cacheTypes: z.number().optional(),
+        cacheWarming: z.boolean().optional(),
+      },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
@@ -272,7 +282,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
         results.cacheWarming = deviceTypeCache.isWarming();
 
         logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(results);
+        return structuredResult(results as Record<string, unknown>);
       } catch (err) {
         logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -294,6 +304,10 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
         "Use to answer 'why is this sensor flaky?'. Higher (closer to 0) dBm is better; null = no measurement.",
       inputSchema: {
         name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
+      },
+      outputSchema: {
+        devices: z.array(z.unknown()).describe("Per device: {address, name, interface, links:[{peer, rssiDevice, rssiPeer}]}"),
+        interfaces: z.unknown().describe("BidCos interface health (duty cycle, connected)"),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
@@ -427,7 +441,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
         }
 
         logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "ok", devices: deviceEntries.length });
-        return toolResult({ devices: deviceEntries, interfaces: bidcosInterfaces });
+        return structuredResult({ devices: deviceEntries, interfaces: bidcosInterfaces });
       } catch (err) {
         logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -288,11 +288,10 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
     {
       title: "Get RSSI / Radio Quality",
       description:
-        "Report radio link quality (RSSI, in dBm) from Interface.rssiInfo, resolved to device names, " +
-        "plus BidCos interface health (duty cycle, connected state). Use to answer 'why is this " +
-        "sensor flaky?'. Higher (closer to 0) dBm is better; null means no measurement available. " +
-        "Note: rssiInfo covers BidCos-RF; HmIP-RF does not expose it, so pure-HmIP setups return no " +
-        "rssiInfo data (HmIP RSSI lives in per-device RSSI_DEVICE/RSSI_PEER datapoints — not yet read here).",
+        "Report radio link quality (RSSI, in dBm) for every device, resolved to device names, plus " +
+        "BidCos interface health (duty cycle, connected state). Covers both transports: BidCos-RF via " +
+        "Interface.rssiInfo, and HmIP-RF via each device's RSSI_DEVICE/RSSI_PEER maintenance datapoints. " +
+        "Use to answer 'why is this sensor flaky?'. Higher (closer to 0) dBm is better; null = no measurement.",
       inputSchema: {
         name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
       },
@@ -371,6 +370,45 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
             };
             if (needle && !`${entry.address} ${entry.name}`.toLowerCase().includes(needle)) continue;
             deviceEntries.push(entry);
+          }
+        }
+
+        // HmIP devices don't expose rssiInfo; their RSSI lives in the :0
+        // maintenance channel's RSSI_DEVICE / RSSI_PEER datapoints (dBm, negative).
+        // Read the :0 VALUES paramset per HmIP device (one call each — there's no
+        // bulk equivalent) and merge into the same output shape: rssiDevice =
+        // measured by the device, rssiPeer = measured by the peer (AP/CCU), where
+        // present. Values are already dBm; a non-negative reading means "no value".
+        // Interface.getParamset returns raw string values; coerce, and treat
+        // only a negative dBm as a real reading (0/positive/non-numeric = none).
+        const dbm = (v: unknown): number | null => {
+          const n = typeof v === "string" ? Number(v) : v;
+          return typeof n === "number" && Number.isFinite(n) && n < 0 ? n : null;
+        };
+        for (const d of devices) {
+          if (!/hmip/i.test(d.interface)) continue;
+          const maint = d.channels.find((c) => c.address.endsWith(":0"));
+          if (!maint) continue;
+          if (needle && !`${d.address} ${d.name}`.toLowerCase().includes(needle)) continue;
+          try {
+            await rateLimiter.acquire();
+            const vals = await withRetry(
+              () => session.call("Interface.getParamset", { interface: d.interface, address: maint.address, paramsetKey: "VALUES" }),
+              "Interface.getParamset",
+              logger,
+            ) as Record<string, unknown>;
+            const rssiDevice = dbm(vals?.RSSI_DEVICE);
+            const rssiPeer = dbm(vals?.RSSI_PEER);
+            if (rssiDevice === null && rssiPeer === null) continue; // no usable RSSI
+            deviceEntries.push({
+              address: d.address,
+              name: d.name,
+              interface: d.interface,
+              links: [{ peer: d.interface, peerName: "", rssiDevice, rssiPeer }],
+            });
+          } catch {
+            // device unreachable / paramset unreadable — skip, don't fail the call
+            continue;
           }
         }
 

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -288,9 +288,11 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
     {
       title: "Get RSSI / Radio Quality",
       description:
-        "Report radio link quality (RSSI, in dBm) for every device, resolved to device names, " +
+        "Report radio link quality (RSSI, in dBm) from Interface.rssiInfo, resolved to device names, " +
         "plus BidCos interface health (duty cycle, connected state). Use to answer 'why is this " +
-        "sensor flaky?'. Higher (closer to 0) dBm is better; null means no measurement available.",
+        "sensor flaky?'. Higher (closer to 0) dBm is better; null means no measurement available. " +
+        "Note: rssiInfo covers BidCos-RF; HmIP-RF does not expose it, so pure-HmIP setups return no " +
+        "rssiInfo data (HmIP RSSI lives in per-device RSSI_DEVICE/RSSI_PEER datapoints — not yet read here).",
       inputSchema: {
         name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
       },
@@ -317,8 +319,12 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
           ifaceByAddress.set(d.address, d.interface);
         }
 
-        // Enumerate interfaces and pull rssiInfo per interface. rssiInfo maps
-        // device1 → device2 → [rssiAtDevice1, rssiAtDevice2] (dBm; 65536 = none).
+        // Enumerate interfaces and pull rssiInfo per interface. The JSON-RPC
+        // Interface.rssiInfo returns an ARRAY (see occu .../interface/rssiinfo.tcl):
+        //   [{ name: <deviceAddress>, partner: [{ name: <peerAddress>, rssiData: [a, b] }] }]
+        // The `name` fields are device/peer addresses; rssiData values are dBm
+        // (65536 = no measurement). atDevice = received by this device from peer,
+        // atPeer = received by the peer from this device.
         await rateLimiter.acquire();
         const interfaces = await withRetry(
           () => session.call("Interface.listInterfaces"),
@@ -329,30 +335,32 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
         const needle = args.name?.toLowerCase();
         const deviceEntries: Array<Record<string, unknown>> = [];
 
+        type RssiEntry = { name: string; partner?: Array<{ name: string; rssiData?: unknown }> };
         for (const iface of interfaces) {
-          let info: Record<string, Record<string, unknown>> | null = null;
+          let info: RssiEntry[] | null = null;
           try {
             await rateLimiter.acquire();
             info = await withRetry(
               () => session.call("Interface.rssiInfo", { interface: iface.name }),
               "Interface.rssiInfo",
               logger,
-            ) as Record<string, Record<string, unknown>>;
+            ) as RssiEntry[];
           } catch {
             // Interfaces without RF (e.g. VirtualDevices) don't support rssiInfo.
             continue;
           }
-          if (!info || typeof info !== "object") continue;
+          if (!Array.isArray(info)) continue;
 
-          for (const [address, peers] of Object.entries(info)) {
-            if (!peers || typeof peers !== "object") continue;
-            const links = Object.entries(peers).map(([peer, pair]) => {
-              const [atDevice, atPeer] = Array.isArray(pair) ? pair : [];
+          for (const dev of info) {
+            const address = dev?.name ?? "";
+            if (!address) continue;
+            const links = (Array.isArray(dev.partner) ? dev.partner : []).map((p) => {
+              const pair = Array.isArray(p?.rssiData) ? p.rssiData : [];
               return {
-                peer,
-                peerName: nameByAddress.get(peer) ?? "",
-                rssiDevice: normalizeRssi(atDevice), // dBm received by this device from peer
-                rssiPeer: normalizeRssi(atPeer),     // dBm received by the peer from this device
+                peer: p?.name ?? "",
+                peerName: nameByAddress.get(p?.name ?? "") ?? "",
+                rssiDevice: normalizeRssi(pair[0]), // dBm received by this device from peer
+                rssiPeer: normalizeRssi(pair[1]),   // dBm received by the peer from this device
               };
             });
             const entry = {

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -4,7 +4,7 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
-import { toolResult } from "../utils.js";
+import { toolResult, structuredResult } from "../utils.js";
 
 export function registerDiscoveryTools(server: McpServer, deps: ServerDeps): void {
   registerListDevices(server, deps);
@@ -32,6 +32,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
         type: z.string().optional().describe("Filter by device type (exact match, e.g. 'HmIP-eTRV-2')"),
         name: z.string().optional().describe("Filter by device/channel name (substring, case-insensitive)"),
       },
+      outputSchema: { devices: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -117,7 +118,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             }));
 
         logger.info("tool_call", { tool: "list_devices", duration_ms: Date.now() - start, status: "ok", deviceCount: devices.length });
-        return toolResult(output);
+        return structuredResult({ devices: Array.isArray(output) ? output : [] }, output);
       } catch (err) {
         logger.info("tool_call", { tool: "list_devices", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -133,6 +134,7 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Interfaces",
       description: "List available communication interfaces (BidCos-RF, HmIP-RF, VirtualDevices, etc.).",
+      outputSchema: { interfaces: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
@@ -142,7 +144,7 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
         await rateLimiter.acquire();
         const result = await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger);
         logger.info("tool_call", { tool: "list_interfaces", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(result);
+        return structuredResult({ interfaces: Array.isArray(result) ? result : [] }, result);
       } catch (err) {
         logger.info("tool_call", { tool: "list_interfaces", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -158,6 +160,7 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Rooms",
       description: "List all rooms with their assigned channel IDs. Use with list_devices to find devices by room.",
+      outputSchema: { rooms: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
@@ -167,7 +170,7 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
         await rateLimiter.acquire();
         const result = await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger);
         logger.info("tool_call", { tool: "list_rooms", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(result);
+        return structuredResult({ rooms: Array.isArray(result) ? result : [] }, result);
       } catch (err) {
         logger.info("tool_call", { tool: "list_rooms", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -183,6 +186,7 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Functions",
       description: "List all function groups (Heating, Lighting, etc.) with their assigned channel IDs.",
+      outputSchema: { functions: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
@@ -192,7 +196,7 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
         await rateLimiter.acquire();
         const result = await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger);
         logger.info("tool_call", { tool: "list_functions", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(result);
+        return structuredResult({ functions: Array.isArray(result) ? result : [] }, result);
       } catch (err) {
         logger.info("tool_call", { tool: "list_functions", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -211,6 +215,7 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         name: z.string().optional().describe("Filter by program name (substring, case-insensitive)"),
       },
+      outputSchema: { programs: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -226,7 +231,7 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
         }
 
         logger.info("tool_call", { tool: "list_programs", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(programs);
+        return structuredResult({ programs: Array.isArray(programs) ? programs : [] }, programs);
       } catch (err) {
         logger.info("tool_call", { tool: "list_programs", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -245,6 +250,7 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
       inputSchema: {
         name: z.string().optional().describe("Filter by variable name (substring, case-insensitive)"),
       },
+      outputSchema: { systemVariables: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -260,7 +266,7 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
         }
 
         logger.info("tool_call", { tool: "list_system_variables", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(sysvars);
+        return structuredResult({ systemVariables: Array.isArray(sysvars) ? sysvars : [] }, sysvars);
       } catch (err) {
         logger.info("tool_call", { tool: "list_system_variables", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -282,6 +288,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         deviceType: z.string().describe("Device type name (e.g. 'HmIP-eTRV-2', 'HmIP-SWDO-I'). Get from list_devices."),
       },
+      outputSchema: { deviceType: z.string().optional().describe("Echoed device type; other keys hold the channel/datapoint schema or a not-found hint") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -292,7 +299,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
 
       if (cached) {
         logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: true });
-        return toolResult({ deviceType: args.deviceType, ...cached });
+        return structuredResult({ deviceType: args.deviceType, ...cached });
       }
 
       // Cache miss — try live query if we can find a device instance
@@ -308,7 +315,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
             );
             if (cached) {
               logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: false });
-              return toolResult({ deviceType: args.deviceType, ...cached });
+              return structuredResult({ deviceType: args.deviceType, ...cached });
             }
           } catch {
             // Live query failed — fall through to cache-miss message
@@ -317,7 +324,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
       }
 
       logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: false });
-      return toolResult({
+      return structuredResult({
         deviceType: args.deviceType,
         message: "Device type not in cache. Cache may still be warming. Try again shortly or call list_devices first.",
         availableTypes: Object.keys(deviceTypeCache.getAll()),
@@ -338,6 +345,7 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         address: z.string().optional().describe("Device or channel address to filter by (e.g. '000A1BE9A71F15' or '000A1BE9A71F15:1')"),
       },
+      outputSchema: { links: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -407,7 +415,7 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
         }
 
         logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "ok", links: links.length });
-        return toolResult(links);
+        return structuredResult({ links }, links);
       } catch (err) {
         logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -14,6 +14,7 @@ export function registerDiscoveryTools(server: McpServer, deps: ServerDeps): voi
   registerListPrograms(server, deps);
   registerListSystemVariables(server, deps);
   registerDescribeDeviceType(server, deps);
+  registerListLinks(server, deps);
 }
 
 function registerListDevices(server: McpServer, deps: ServerDeps): void {
@@ -321,6 +322,95 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
         message: "Device type not in cache. Cache may still be warming. Try again shortly or call list_devices first.",
         availableTypes: Object.keys(deviceTypeCache.getAll()),
       });
+    },
+  );
+}
+
+function registerListLinks(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "list_links",
+    {
+      title: "List Direct Device Links",
+      description:
+        "List direct device links (Direktverknüpfungen) — sender→receiver channel pairings that operate " +
+        "independently of the CCU (e.g. a wall switch directly driving a lamp, or thermostats linked to a " +
+        "FALMOT). Read-only. Optionally filter to links involving a specific device or channel address.",
+      inputSchema: {
+        address: z.string().optional().describe("Device or channel address to filter by (e.g. '000A1BE9A71F15' or '000A1BE9A71F15:1')"),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) => {
+      const { session, rateLimiter, logger } = deps;
+      const start = Date.now();
+
+      try {
+        // Channel address → name map; SENDER/RECEIVER from getLinks are channel addresses.
+        await rateLimiter.acquire();
+        const devices = await withRetry(
+          () => session.call("Device.listAllDetail"),
+          "Device.listAllDetail",
+          logger,
+        ) as CcuDevice[];
+        deps.resolver.updateDeviceList(devices);
+        const channelName = new Map<string, string>();
+        for (const d of devices) for (const ch of d.channels) channelName.set(ch.address, ch.name);
+
+        // Auto-iterate all interfaces (BidCos-RF, HmIP-RF, …) like the cache warmer.
+        await rateLimiter.acquire();
+        const interfaces = await withRetry(
+          () => session.call("Interface.listInterfaces"),
+          "Interface.listInterfaces",
+          logger,
+        ) as Array<{ name: string }>;
+
+        // Match a channel address against the filter: exact channel, or any
+        // channel of the given device address (so a device-level filter works).
+        const matchesAddr = (chAddr: string): boolean => {
+          if (!args.address) return true;
+          return chAddr === args.address || chAddr.split(":")[0] === args.address;
+        };
+
+        const links: Array<Record<string, unknown>> = [];
+        for (const iface of interfaces) {
+          let raw: unknown;
+          try {
+            await rateLimiter.acquire();
+            raw = await withRetry(
+              () => session.call("Interface.getLinks", { interface: iface.name, address: args.address ?? "", flags: 0 }),
+              "Interface.getLinks",
+              logger,
+            );
+          } catch {
+            continue; // interface doesn't expose getLinks
+          }
+          if (!Array.isArray(raw)) continue;
+
+          for (const l of raw as Array<Record<string, unknown>>) {
+            const sender = String(l.SENDER ?? "");
+            const receiver = String(l.RECEIVER ?? "");
+            // Re-filter client-side in case the interface ignores the address arg.
+            if (!matchesAddr(sender) && !matchesAddr(receiver)) continue;
+            links.push({
+              sender,
+              senderName: channelName.get(sender) ?? "",
+              receiver,
+              receiverName: channelName.get(receiver) ?? "",
+              name: l.NAME ?? "",
+              description: l.DESCRIPTION ?? "",
+              flags: l.FLAGS ?? 0,
+              interface: iface.name,
+            });
+          }
+        }
+
+        logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "ok", links: links.length });
+        return toolResult(links);
+      } catch (err) {
+        logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "error" });
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
     },
   );
 }

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -387,8 +387,10 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
           if (!Array.isArray(raw)) continue;
 
           for (const l of raw as Array<Record<string, unknown>>) {
-            const sender = String(l.SENDER ?? "");
-            const receiver = String(l.RECEIVER ?? "");
+            // JSON-RPC getLinks returns lowercase fields (see occu
+            // .../interface/getlinks.tcl): sender, receiver, name, description, flags.
+            const sender = String(l.sender ?? "");
+            const receiver = String(l.receiver ?? "");
             // Re-filter client-side in case the interface ignores the address arg.
             if (!matchesAddr(sender) && !matchesAddr(receiver)) continue;
             links.push({
@@ -396,9 +398,9 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
               senderName: channelName.get(sender) ?? "",
               receiver,
               receiverName: channelName.get(receiver) ?? "",
-              name: l.NAME ?? "",
-              description: l.DESCRIPTION ?? "",
-              flags: l.FLAGS ?? 0,
+              name: l.name ?? "",
+              description: l.description ?? "",
+              flags: l.flags ?? 0,
               interface: iface.name,
             });
           }

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -31,6 +31,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
         type: z.string().optional().describe("Filter by device type (exact match, e.g. 'HmIP-eTRV-2')"),
         name: z.string().optional().describe("Filter by device/channel name (substring, case-insensitive)"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
@@ -131,6 +132,7 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Interfaces",
       description: "List available communication interfaces (BidCos-RF, HmIP-RF, VirtualDevices, etc.).",
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
       const { session, rateLimiter, logger } = deps;
@@ -155,6 +157,7 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Rooms",
       description: "List all rooms with their assigned channel IDs. Use with list_devices to find devices by room.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
       const { session, rateLimiter, logger } = deps;
@@ -179,6 +182,7 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Functions",
       description: "List all function groups (Heating, Lighting, etc.) with their assigned channel IDs.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () => {
       const { session, rateLimiter, logger } = deps;
@@ -206,6 +210,7 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         name: z.string().optional().describe("Filter by program name (substring, case-insensitive)"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
@@ -239,6 +244,7 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
       inputSchema: {
         name: z.string().optional().describe("Filter by variable name (substring, case-insensitive)"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
@@ -275,6 +281,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         deviceType: z.string().describe("Device type name (e.g. 'HmIP-eTRV-2', 'HmIP-SWDO-I'). Get from list_devices."),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger, deviceTypeCache } = deps;

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -146,6 +146,8 @@ function registerHelp(server: McpServer, deps: ServerDeps): void {
       inputSchema: {
         topic: z.string().optional().describe("Tool name, device type, or omit for general guide"),
       },
+      // Local-only: serves the static guide and the device-type cache; never reaches the CCU.
+      annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async (args) => {
       if (!args.topic) {
@@ -186,8 +188,8 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
         script: z.string().describe("HomeMatic Script to execute"),
       },
       annotations: {
-        title: "Run Script",
         destructiveHint: true,
+        openWorldHint: true,
       },
     },
     async (args) => {

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -47,7 +47,7 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 ## Available Tools
 **Discovery:** list_devices, list_interfaces, list_rooms, list_functions, list_programs, list_system_variables, list_links, describe_device_type
 **Read:** get_value, get_values, get_paramset
-**Control:** set_value, put_paramset, set_system_variable, execute_program
+**Control:** set_value, put_paramset, set_system_variable, create_system_variable, delete_system_variable, execute_program
 **Diagnostics:** get_service_messages, acknowledge_service_messages, get_rssi, get_system_info
 **Meta:** help, run_script
 `;
@@ -118,6 +118,17 @@ Idempotent: yes`,
 Args: name (string), value (string|number|boolean)
 Returns: {name, value, method}
 Idempotent: yes`,
+
+  create_system_variable: `Create a new system variable.
+Args: name (string), type ("bool"|"float"|"enum"|"string"), description? (string),
+  unit?/min?/max? (float only), values? (string[], required for enum)
+Returns: {name, type, created: true}
+INVALID_INPUT if the name already exists (or enum without values). Use set_system_variable to write it.`,
+
+  delete_system_variable: `Delete a system variable by name.
+Args: name (string, exact match)
+Returns: {name, deleted: true}
+NOT_FOUND if the name doesn't exist.`,
 
   execute_program: `Trigger an automation program. NOT idempotent — never auto-retried.
 Args: id (string)

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -48,7 +48,7 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 **Discovery:** list_devices, list_interfaces, list_rooms, list_functions, list_programs, list_system_variables, describe_device_type
 **Read:** get_value, get_values, get_paramset
 **Control:** set_value, put_paramset, set_system_variable, execute_program
-**Diagnostics:** get_service_messages, get_system_info
+**Diagnostics:** get_service_messages, acknowledge_service_messages, get_system_info
 **Meta:** help, run_script
 `;
 
@@ -121,6 +121,11 @@ Returns: {id, executed}`,
   get_service_messages: `Get active service messages (low battery, unreachable, etc.).
 Args: none
 Returns: Array of {id, name, address, channelName, timestamp}`,
+
+  acknowledge_service_messages: `Confirm/dismiss active service messages (e.g. clear a low-battery warning).
+Args: id (single alarm id from get_service_messages) OR address (all active messages on a channel) — at least one required
+Returns: {confirmed: Array of {id, type, address}, count}
+NOT_FOUND if no active message matches; the warning reappears if its condition persists.`,
 
   get_system_info: `Get CCU system info: firmware, serial, addresses, cache status.
 Args: none

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -47,7 +47,7 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 ## Available Tools
 **Discovery:** list_devices, list_interfaces, list_rooms, list_functions, list_programs, list_system_variables, list_links, describe_device_type
 **Read:** get_value, get_values, get_paramset
-**Control:** set_value, put_paramset, set_system_variable, create_system_variable, delete_system_variable, execute_program
+**Control:** set_value, put_paramset, set_system_variable, create_system_variable, delete_system_variable, assign_channel, unassign_channel, execute_program
 **Diagnostics:** get_service_messages, acknowledge_service_messages, get_rssi, get_system_info
 **Meta:** help, run_script
 `;
@@ -129,6 +129,16 @@ INVALID_INPUT if the name already exists (or enum without values). Use set_syste
 Args: name (string, exact match)
 Returns: {name, deleted: true}
 NOT_FOUND if the name doesn't exist.`,
+
+  assign_channel: `Assign a channel to a room and/or function group.
+Args: channel (address), room? (name), function? (name) — at least one of room/function
+Returns: {channel, assignedTo: [{kind, name}]}
+NOT_FOUND (with valid names) for unknown channel/room/function.`,
+
+  unassign_channel: `Remove a channel from a room and/or function group.
+Args: channel (address), room? (name), function? (name) — at least one of room/function
+Returns: {channel, removedFrom: [{kind, name}]}
+NOT_FOUND (with valid names) for unknown channel/room/function.`,
 
   execute_program: `Trigger an automation program. NOT idempotent — never auto-retried.
 Args: id (string)

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -45,7 +45,7 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 - \`run_script\` executes arbitrary HomeMatic Script for anything tools don't cover
 
 ## Available Tools
-**Discovery:** list_devices, list_interfaces, list_rooms, list_functions, list_programs, list_system_variables, describe_device_type
+**Discovery:** list_devices, list_interfaces, list_rooms, list_functions, list_programs, list_system_variables, list_links, describe_device_type
 **Read:** get_value, get_values, get_paramset
 **Control:** set_value, put_paramset, set_system_variable, execute_program
 **Diagnostics:** get_service_messages, acknowledge_service_messages, get_rssi, get_system_info
@@ -82,6 +82,11 @@ Returns: Array of variables with id, name, value, type, min, max`,
   describe_device_type: `Get channel/datapoint schema for a device type (from cache).
 Args: deviceType (string, e.g. "HmIP-eTRV-2")
 Returns: Channels with paramsets, datapoint types, ranges, operations`,
+
+  list_links: `List direct device links (Direktverknüpfungen) — sender→receiver channel pairings that work without the CCU.
+Args: address? (device or channel address filter, e.g. "000A1BE9A71F15" or "000A1BE9A71F15:1")
+Returns: Array of {sender, senderName, receiver, receiverName, name, description, flags, interface}
+Read-only; answers "what directly controls this?". Link creation/removal is out of scope.`,
 
   get_value: `Read a single datapoint value.
 Args: address (string), valueKey (string), interface? (auto-resolved)

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -48,7 +48,7 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 **Discovery:** list_devices, list_interfaces, list_rooms, list_functions, list_programs, list_system_variables, describe_device_type
 **Read:** get_value, get_values, get_paramset
 **Control:** set_value, put_paramset, set_system_variable, execute_program
-**Diagnostics:** get_service_messages, acknowledge_service_messages, get_system_info
+**Diagnostics:** get_service_messages, acknowledge_service_messages, get_rssi, get_system_info
 **Meta:** help, run_script
 `;
 
@@ -130,6 +130,11 @@ NOT_FOUND if no active message matches; the warning reappears if its condition p
   get_system_info: `Get CCU system info: firmware, serial, addresses, cache status.
 Args: none
 Returns: {version, serial, address, hmipAddress, cacheTypes, cacheWarming}`,
+
+  get_rssi: `Radio link quality (RSSI, dBm) per device, plus BidCos interface health.
+Args: name (optional substring filter on device name/address)
+Returns: {devices: [{address, name, interface, links: [{peer, peerName, rssiDevice, rssiPeer}]}], interfaces}
+rssiDevice/rssiPeer are dBm (higher = better); null means no measurement. Use to diagnose flaky devices.`,
 
   run_script: `Execute arbitrary HomeMatic Script. NOT idempotent — never auto-retried.
 Args: script (string)

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -25,6 +25,7 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
         valueKey: z.string().describe("Datapoint name (e.g. 'STATE', 'LEVEL', 'ACTUAL_TEMPERATURE')"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
@@ -68,6 +69,7 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         room: z.string().optional().describe("Room name — read all channels in this room"),
         function: z.string().optional().describe("Function name — read all channels in this function group"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
@@ -196,6 +198,7 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
         paramsetKey: z.enum(["VALUES", "MASTER", "LINK"]).describe("Paramset to read"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
       },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
-import { toolResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
+import { toolResult, structuredResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
 
 export function registerReadTools(server: McpServer, deps: ServerDeps): void {
   registerGetValue(server, deps);
@@ -24,6 +24,11 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
         address: z.string().describe("Channel address (e.g. '000A1BE9A71F15:1')"),
         valueKey: z.string().describe("Datapoint name (e.g. 'STATE', 'LEVEL', 'ACTUAL_TEMPERATURE')"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
+      },
+      outputSchema: {
+        address: z.string(),
+        valueKey: z.string(),
+        value: z.unknown().describe("Parsed datapoint value (bool/number/string/null)"),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
@@ -46,7 +51,7 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
         );
 
         logger.info("tool_call", { tool: "get_value", duration_ms: Date.now() - start, status: "ok", address: args.address });
-        return toolResult({ address: args.address, valueKey: args.valueKey, value: parseValue(value) });
+        return structuredResult({ address: args.address, valueKey: args.valueKey, value: parseValue(value) });
       } catch (err) {
         logger.info("tool_call", { tool: "get_value", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -68,6 +73,9 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         channels: z.array(z.string()).optional().describe("Array of channel addresses to read"),
         room: z.string().optional().describe("Room name — read all channels in this room"),
         function: z.string().optional().describe("Function name — read all channels in this function group"),
+      },
+      outputSchema: {
+        values: z.array(z.unknown()).describe("One entry per channel: {address, name, datapoints}"),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
@@ -106,7 +114,9 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         );
 
         logger.info("tool_call", { tool: "get_values", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(typeof result === "string" ? tryParseJson(result) : result);
+        const data = typeof result === "string" ? tryParseJson(result) : result;
+        // Wrap the array for structuredContent; keep the bare array as the text block.
+        return structuredResult({ values: Array.isArray(data) ? data : [] }, data);
       } catch (err) {
         logger.info("tool_call", { tool: "get_values", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();
@@ -198,6 +208,11 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
         paramsetKey: z.enum(["VALUES", "MASTER", "LINK"]).describe("Paramset to read"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
       },
+      outputSchema: {
+        address: z.string(),
+        paramsetKey: z.string(),
+        params: z.unknown().describe("Map of parameter name → value"),
+      },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
@@ -223,7 +238,7 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
         const params = (typeof result === "object" && result !== null && !Array.isArray(result))
           ? parseValues(result as Record<string, unknown>)
           : result;
-        return toolResult({ address: args.address, paramsetKey: args.paramsetKey, params });
+        return structuredResult({ address: args.address, paramsetKey: args.paramsetKey, params });
       } catch (err) {
         logger.info("tool_call", { tool: "get_paramset", duration_ms: Date.now() - start, status: "error" });
         if (err instanceof CcuError) return err.toMcpError();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,21 @@ export function escapeHmScript(input: string): string {
     .replace(/\r/g, "\\r");
 }
 
+/**
+ * Extract the token from an `Authorization: Bearer <token>` header (scheme is
+ * case-insensitive per RFC 7235). Returns "" when absent or not a well-formed
+ * bearer header.
+ *
+ * The capture is anchored to a non-space first char (`\S.*`) so the whitespace
+ * and token patterns can't overlap — `\s+(.+)` overlapped on whitespace and
+ * backtracked polynomially on a caller-controlled header, which is reachable
+ * pre-auth (CodeQL js/polynomial-redos). Bearer tokens contain no spaces, so
+ * anchoring is behaviour-preserving for valid input.
+ */
+export function extractBearerToken(authHeader: string): string {
+  return authHeader.match(/^Bearer\s+(\S.*)$/i)?.[1] ?? "";
+}
+
 /** Format a tool result as MCP text content. */
 export function toolResult(data: unknown) {
   return { content: [{ type: "text" as const, text: typeof data === "string" ? data : JSON.stringify(data, null, 2) }] };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,6 +37,24 @@ export function toolResult(data: unknown) {
   return { content: [{ type: "text" as const, text: typeof data === "string" ? data : JSON.stringify(data, null, 2) }] };
 }
 
+/**
+ * Tool result carrying BOTH a human-readable text block (backwards-compatible
+ * with pre-structuredContent clients) and machine-readable `structuredContent`
+ * that validates against the tool's `outputSchema` (MCP 2025-11-25).
+ *
+ * `structured` must be an object (structuredContent is always a JSON object).
+ * For list/array tools, pass the wrapper object as `structured` and the bare
+ * array as `text` so the text block stays byte-for-byte what older clients got.
+ * For object tools, omit `text` and the object is used for both.
+ */
+export function structuredResult(structured: Record<string, unknown>, text?: unknown) {
+  const body = text === undefined ? structured : text;
+  return {
+    content: [{ type: "text" as const, text: typeof body === "string" ? body : JSON.stringify(body, null, 2) }],
+    structuredContent: structured,
+  };
+}
+
 /** Try to parse JSON, return raw string on failure. */
 export function tryParseJson(text: string): unknown {
   try { return JSON.parse(text); } catch { return text; }

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createServer, request, type Server, type IncomingHttpHeaders } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { AddressInfo } from "node:net";
@@ -504,10 +504,13 @@ describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebin
 // the clear. Skipped if openssl isn't available to mint a throwaway cert.
 const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
 
-// Minimal HTTPS client that trusts the self-signed test cert.
+// Minimal HTTPS client. TLS validation stays ENABLED — we trust the specific
+// throwaway cert by passing it as the CA (the cert carries an IP:127.0.0.1 SAN
+// so identity verification against the loopback host succeeds), rather than
+// disabling certificate validation.
 function httpsJson(
   port: number,
-  opts: { method?: string; path?: string; headers?: Record<string, string>; body?: unknown } = {},
+  opts: { method?: string; path?: string; headers?: Record<string, string>; body?: unknown; ca?: Buffer } = {},
 ): Promise<{ status: number; headers: IncomingHttpHeaders; text: string }> {
   return new Promise((resolve, reject) => {
     const payload = opts.body === undefined ? undefined : JSON.stringify(opts.body);
@@ -517,7 +520,7 @@ function httpsJson(
         port,
         path: opts.path ?? "/",
         method: opts.method ?? "GET",
-        rejectUnauthorized: false, // self-signed test cert
+        ca: opts.ca,
         headers: {
           ...(payload ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } : {}),
           ...opts.headers,
@@ -540,21 +543,26 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   let child: ChildProcess;
   let mcpPort: number;
   let cacheDir: string;
+  let caCert: Buffer;
 
   beforeAll(async () => {
     ccu = await startCcuMock();
     cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-tls-"));
     mcpPort = 20000 + Math.floor(Math.random() * 20000);
 
-    // Mint a throwaway self-signed cert for localhost.
+    // Mint a throwaway self-signed cert. The SAN must include IP:127.0.0.1 —
+    // Node (>=17) no longer falls back to the subject CN for identity checks,
+    // so a CN-only cert would fail verification against the loopback host.
     const certPath = join(cacheDir, "cert.pem");
     const keyPath = join(cacheDir, "key.pem");
     const gen = spawnSync("openssl", [
       "req", "-x509", "-newkey", "rsa:2048", "-nodes",
       "-keyout", keyPath, "-out", certPath,
       "-days", "1", "-subj", "/CN=localhost",
+      "-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1",
     ], { stdio: "ignore" });
     if (gen.status !== 0) throw new Error("openssl failed to generate test cert");
+    caCert = readFileSync(certPath);
 
     child = spawn("node", [DIST], {
       env: {
@@ -578,7 +586,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
     const deadline = Date.now() + 15_000;
     for (;;) {
       try {
-        const r = await httpsJson(mcpPort, { path: "/health" });
+        const r = await httpsJson(mcpPort, { path: "/health", ca: caCert });
         if (r.status === 200 || r.status === 503) break;
       } catch { /* not up yet */ }
       if (Date.now() > deadline) throw new Error("HTTPS server did not start");
@@ -595,7 +603,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   });
 
   it("serves the health endpoint over HTTPS", async () => {
-    const res = await httpsJson(mcpPort, { path: "/health" });
+    const res = await httpsJson(mcpPort, { path: "/health", ca: caCert });
     expect(res.status).toBe(200);
     expect((JSON.parse(res.text) as { status: string }).status).toBe("healthy");
   });
@@ -610,6 +618,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   it("completes the MCP initialize handshake over TLS", async () => {
     const res = await httpsJson(mcpPort, {
       method: "POST",
+      ca: caCert,
       headers: {
         "Authorization": `Bearer ${AUTH_TOKEN}`,
         "Accept": "application/json, text/event-stream",
@@ -627,6 +636,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   it("still enforces the bearer token over TLS", async () => {
     const res = await httpsJson(mcpPort, {
       method: "POST",
+      ca: caCert,
       headers: { "Accept": "application/json, text/event-stream" },
       body: { jsonrpc: "2.0", id: 1, method: "ping" },
     });

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -130,7 +130,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, sid);
     expect(res.status).toBe(200);
     const msg = await parseSse(res);
-    expect(msg.result.tools.length).toBe(21);
+    expect(msg.result.tools.length).toBe(23);
   });
 
   it("returns a structured tool error (not a crash) when a tool needs the CCU", async () => {
@@ -220,7 +220,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
       const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: i, method: "tools/list", params: {} }, sid);
       expect(res.status).toBe(200);
       const msg = await parseSse(res);
-      expect(msg.result.tools.length).toBe(21);
+      expect(msg.result.tools.length).toBe(23);
     }
   });
 

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -13,6 +13,8 @@ import { AddressInfo } from "node:net";
 
 const DIST = join(__dirname, "../../dist/index.js");
 const AUTH_TOKEN = "e2e-test-token";
+// Origin on the allowlist for the CORS-enabled describe block below.
+const ALLOWED_ORIGIN = "http://localhost:6274";
 
 function startCcuMock(): Promise<{ server: Server; port: number }> {
   const server = createServer((req, res) => {
@@ -166,10 +168,10 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
         MCP_TRANSPORT: "http",
         MCP_PORT: String(mcpPort),
         MCP_AUTH_TOKEN: AUTH_TOKEN,
-        // This block exercises the dev/MCP-Inspector configuration: wildcard
-        // CORS is opt-in (issue #28). The secure-defaults block below covers
-        // the unset (default-deny) behavior.
-        MCP_CORS_ALLOW_ORIGIN: "*",
+        // This block exercises the browser-client configuration (issue #37):
+        // a single trusted origin is allowlisted. The secure-defaults block
+        // below covers the unset (default-deny) behavior.
+        MCP_ALLOWED_ORIGINS: ALLOWED_ORIGIN,
         CACHE_DIR: cacheDir,
         RESOURCE_POLL_INTERVAL: "3600",
         LOG_LEVEL: "error",
@@ -268,41 +270,82 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
     expect(res.status).toBeGreaterThanOrEqual(400);
   });
 
-  // CORS (issue #19, credit @marcinn2): browser clients need preflight + exposed session header
-  it("answers OPTIONS preflight with 204 and CORS headers, without auth", async () => {
+  // CORS (issue #37, building on #19/@marcinn2): an allowlisted browser origin
+  // gets preflight + the exact origin reflected back — never `*`.
+  it("answers OPTIONS preflight from an allowed origin with 204 and reflects the exact origin", async () => {
     const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
       method: "OPTIONS",
       headers: {
-        "Origin": "http://localhost:6274",
+        "Origin": ALLOWED_ORIGIN,
         "Access-Control-Request-Method": "POST",
         "Access-Control-Request-Headers": "content-type, authorization, mcp-session-id",
       },
     });
     expect(res.status).toBe(204);
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
+    expect(res.headers.get("vary")).toContain("Origin");
     expect(res.headers.get("access-control-allow-methods")).toContain("POST");
     expect(res.headers.get("access-control-allow-headers")?.toLowerCase()).toContain("mcp-session-id");
   });
 
-  it("sets CORS headers on MCP responses and exposes Mcp-Session-Id", async () => {
-    const res = await mcpPost(mcpPort, {
-      jsonrpc: "2.0", id: 0, method: "initialize",
-      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "cors", version: "1" } },
+  it("rejects an OPTIONS preflight from a disallowed origin (403, no CORS headers)", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "OPTIONS",
+      headers: {
+        "Origin": "http://evil.example",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+    expect(res.status).toBe(403);
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("reflects the allowed origin on MCP responses and exposes Mcp-Session-Id", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "POST",
+      headers: {
+        "Origin": ALLOWED_ORIGIN,
+        "Authorization": `Bearer ${AUTH_TOKEN}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "mcp-protocol-version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 0, method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "cors", version: "1" } },
+      }),
     });
     expect(res.status).toBe(200);
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
     expect(res.headers.get("access-control-expose-headers")?.toLowerCase()).toContain("mcp-session-id");
     await res.text();
   });
 
-  it("sets CORS headers on 401 responses too", async () => {
+  it("omits CORS headers for a disallowed origin even when another is allowlisted", async () => {
     const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "Accept": "application/json, text/event-stream" },
+      headers: {
+        "Origin": "http://evil.example",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("reflects the allowed origin on 401 responses too", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "POST",
+      headers: {
+        "Origin": ALLOWED_ORIGIN,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+      },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
     });
     expect(res.status).toBe(401);
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
   });
 
   // Must be last: terminates the server and asserts a clean exit
@@ -379,7 +422,7 @@ describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebin
         MCP_TRANSPORT: "http",
         MCP_PORT: String(mcpPort),
         MCP_AUTH_TOKEN: AUTH_TOKEN,
-        // MCP_CORS_ALLOW_ORIGIN deliberately unset → default-deny CORS.
+        // MCP_ALLOWED_ORIGINS deliberately unset → default-deny CORS.
         CACHE_DIR: cacheDir,
         RESOURCE_POLL_INTERVAL: "3600",
         LOG_LEVEL: "error",

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -305,6 +305,22 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
   });
 
+  // Issue #26: a successful tool call returns structuredContent AND passes the
+  // SDK's server-side outputSchema validation (a schema mismatch would come back
+  // as a JSON-RPC error instead). This is the end-to-end check unit tests can't do.
+  it("returns structuredContent that passes outputSchema validation", async () => {
+    const sid = await initialize(mcpPort);
+    const res = await mcpPost(mcpPort, {
+      jsonrpc: "2.0", id: 1, method: "tools/call",
+      params: { name: "get_system_info", arguments: {} },
+    }, sid);
+    expect(res.status).toBe(200);
+    const msg = await parseSse(res);
+    expect(msg.error).toBeUndefined();            // validation passed
+    expect(msg.result.isError).toBeFalsy();
+    expect(msg.result.structuredContent).toBeTypeOf("object");
+  });
+
   // Must be last: terminates the server and asserts a clean exit
   it("shuts down gracefully on SIGTERM with exit code 0", async () => {
     const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -213,6 +213,34 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
     expect(res.status).toBe(401);
   });
 
+  // Issue #29: 401 carries a WWW-Authenticate challenge (RFC 6750 / MCP auth spec)
+  it("challenges with WWW-Authenticate: Bearer and no error when no token is sent", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Accept": "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    expect(res.status).toBe(401);
+    const challenge = res.headers.get("www-authenticate") ?? "";
+    expect(challenge).toContain("Bearer");
+    expect(challenge).toContain('realm="debmatic-mcp"');
+    expect(challenge).not.toContain("error="); // no credentials presented
+  });
+
+  it("adds error=invalid_token to the challenge when a bad token is sent", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer wrong-token",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate") ?? "").toContain('error="invalid_token"');
+  });
+
   // Regression #17: with a reused stateless transport, request 2+ returned 500
   it("handles many sequential requests on one session", async () => {
     const sid = await initialize(mcpPort);

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createServer, request, type Server, type IncomingHttpHeaders } from "node:http";
-import { spawn, type ChildProcess } from "node:child_process";
+import { request as httpsRequest } from "node:https";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -484,6 +485,152 @@ describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebin
   it("rejects a forged Host header with 403 (DNS-rebinding protection)", async () => {
     const res = await rawPost(mcpPort, INIT_BODY, { token: AUTH_TOKEN, host: "evil.example" });
     expect(res.status).toBe(403);
+  });
+
+  // Must be last: clean shutdown
+  it("shuts down gracefully on SIGTERM with exit code 0", async () => {
+    const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
+    child.kill("SIGTERM");
+    const code = await Promise.race([
+      exited,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("shutdown timed out")), 12_000)),
+    ]);
+    expect(code).toBe(0);
+  }, 15_000);
+});
+
+// Issue #50: native TLS for the HTTP transport. When MCP_TLS_CERT/MCP_TLS_KEY
+// are set the server must listen over HTTPS so the bearer token isn't sent in
+// the clear. Skipped if openssl isn't available to mint a throwaway cert.
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+
+// Minimal HTTPS client that trusts the self-signed test cert.
+function httpsJson(
+  port: number,
+  opts: { method?: string; path?: string; headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; headers: IncomingHttpHeaders; text: string }> {
+  return new Promise((resolve, reject) => {
+    const payload = opts.body === undefined ? undefined : JSON.stringify(opts.body);
+    const req = httpsRequest(
+      {
+        host: "127.0.0.1",
+        port,
+        path: opts.path ?? "/",
+        method: opts.method ?? "GET",
+        rejectUnauthorized: false, // self-signed test cert
+        headers: {
+          ...(payload ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } : {}),
+          ...opts.headers,
+        },
+      },
+      (res) => {
+        let text = "";
+        res.on("data", (c) => (text += c));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers, text }));
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native TLS, mocked CCU)", () => {
+  let ccu: { server: Server; port: number };
+  let child: ChildProcess;
+  let mcpPort: number;
+  let cacheDir: string;
+
+  beforeAll(async () => {
+    ccu = await startCcuMock();
+    cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-tls-"));
+    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+
+    // Mint a throwaway self-signed cert for localhost.
+    const certPath = join(cacheDir, "cert.pem");
+    const keyPath = join(cacheDir, "key.pem");
+    const gen = spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=localhost",
+    ], { stdio: "ignore" });
+    if (gen.status !== 0) throw new Error("openssl failed to generate test cert");
+
+    child = spawn("node", [DIST], {
+      env: {
+        ...process.env,
+        CCU_HOST: "127.0.0.1",
+        CCU_PORT: String(ccu.port),
+        CCU_HTTPS: "false",
+        CCU_PASSWORD: "mock",
+        MCP_TRANSPORT: "http",
+        MCP_PORT: String(mcpPort),
+        MCP_AUTH_TOKEN: AUTH_TOKEN,
+        MCP_TLS_CERT: certPath,
+        MCP_TLS_KEY: keyPath,
+        CACHE_DIR: cacheDir,
+        RESOURCE_POLL_INTERVAL: "3600",
+        LOG_LEVEL: "error",
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+
+    const deadline = Date.now() + 15_000;
+    for (;;) {
+      try {
+        const r = await httpsJson(mcpPort, { path: "/health" });
+        if (r.status === 200 || r.status === 503) break;
+      } catch { /* not up yet */ }
+      if (Date.now() > deadline) throw new Error("HTTPS server did not start");
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    child?.kill("SIGTERM");
+    await new Promise((r) => setTimeout(r, 300));
+    child?.kill("SIGKILL");
+    ccu?.server.close();
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("serves the health endpoint over HTTPS", async () => {
+    const res = await httpsJson(mcpPort, { path: "/health" });
+    expect(res.status).toBe(200);
+    expect((JSON.parse(res.text) as { status: string }).status).toBe("healthy");
+  });
+
+  it("rejects a plaintext HTTP request to the TLS port (TLS is actually on)", async () => {
+    // A plain-HTTP GET to an HTTPS listener does not complete a normal response.
+    await expect(
+      fetch(`http://127.0.0.1:${mcpPort}/health`, { signal: AbortSignal.timeout(2000) }),
+    ).rejects.toThrow();
+  });
+
+  it("completes the MCP initialize handshake over TLS", async () => {
+    const res = await httpsJson(mcpPort, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${AUTH_TOKEN}`,
+        "Accept": "application/json, text/event-stream",
+        "mcp-protocol-version": "2025-06-18",
+      },
+      body: {
+        jsonrpc: "2.0", id: 0, method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "tls", version: "1" } },
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers["mcp-session-id"]).toBeTruthy();
+  });
+
+  it("still enforces the bearer token over TLS", async () => {
+    const res = await httpsJson(mcpPort, {
+      method: "POST",
+      headers: { "Accept": "application/json, text/event-stream" },
+      body: { jsonrpc: "2.0", id: 1, method: "ping" },
+    });
+    expect(res.status).toBe(401);
   });
 
   // Must be last: clean shutdown

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -130,7 +130,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, sid);
     expect(res.status).toBe(200);
     const msg = await parseSse(res);
-    expect(msg.result.tools.length).toBe(20);
+    expect(msg.result.tools.length).toBe(21);
   });
 
   it("returns a structured tool error (not a crash) when a tool needs the CCU", async () => {
@@ -220,7 +220,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
       const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: i, method: "tools/list", params: {} }, sid);
       expect(res.status).toBe(200);
       const msg = await parseSse(res);
-      expect(msg.result.tools.length).toBe(20);
+      expect(msg.result.tools.length).toBe(21);
     }
   });
 

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { createServer, type Server } from "node:http";
+import { createServer, request, type Server, type IncomingHttpHeaders } from "node:http";
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
@@ -166,6 +166,10 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
         MCP_TRANSPORT: "http",
         MCP_PORT: String(mcpPort),
         MCP_AUTH_TOKEN: AUTH_TOKEN,
+        // This block exercises the dev/MCP-Inspector configuration: wildcard
+        // CORS is opt-in (issue #28). The secure-defaults block below covers
+        // the unset (default-deny) behavior.
+        MCP_CORS_ALLOW_ORIGIN: "*",
         CACHE_DIR: cacheDir,
         RESOURCE_POLL_INTERVAL: "3600",
         LOG_LEVEL: "error",
@@ -274,6 +278,128 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
   });
 
   // Must be last: terminates the server and asserts a clean exit
+  it("shuts down gracefully on SIGTERM with exit code 0", async () => {
+    const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
+    child.kill("SIGTERM");
+    const code = await Promise.race([
+      exited,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("shutdown timed out")), 12_000)),
+    ]);
+    expect(code).toBe(0);
+  }, 15_000);
+});
+
+// Issue #28: secure HTTP defaults — no CORS env set, DNS-rebinding protection on.
+// `request` is used (not fetch) because undici forbids overriding the Host header,
+// and a forged Host is exactly the DNS-rebinding vector we need to exercise.
+function rawPost(
+  port: number,
+  body: unknown,
+  opts: { host?: string; token?: string } = {},
+): Promise<{ status: number; headers: IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const req = request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json, text/event-stream",
+          "mcp-protocol-version": "2025-06-18",
+          ...(opts.token ? { Authorization: `Bearer ${opts.token}` } : {}),
+          ...(opts.host ? { Host: opts.host } : {}),
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        res.on("data", () => {}); // drain
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers }));
+      },
+    );
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+const INIT_BODY = {
+  jsonrpc: "2.0", id: 0, method: "initialize",
+  params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "secure", version: "1" } },
+};
+
+describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebinding on)", () => {
+  let ccu: { server: Server; port: number };
+  let child: ChildProcess;
+  let mcpPort: number;
+  let cacheDir: string;
+
+  beforeAll(async () => {
+    ccu = await startCcuMock();
+    cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-secure-"));
+    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+
+    child = spawn("node", [DIST], {
+      env: {
+        ...process.env,
+        CCU_HOST: "127.0.0.1",
+        CCU_PORT: String(ccu.port),
+        CCU_HTTPS: "false",
+        CCU_PASSWORD: "mock",
+        MCP_TRANSPORT: "http",
+        MCP_PORT: String(mcpPort),
+        MCP_AUTH_TOKEN: AUTH_TOKEN,
+        // MCP_CORS_ALLOW_ORIGIN deliberately unset → default-deny CORS.
+        CACHE_DIR: cacheDir,
+        RESOURCE_POLL_INTERVAL: "3600",
+        LOG_LEVEL: "error",
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+
+    const deadline = Date.now() + 15_000;
+    for (;;) {
+      try {
+        const r = await fetch(`http://127.0.0.1:${mcpPort}/health`);
+        if (r.status === 200 || r.status === 503) break;
+      } catch { /* not up yet */ }
+      if (Date.now() > deadline) throw new Error("server did not start");
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }, 20_000);
+
+  afterAll(async () => {
+    child?.kill("SIGTERM");
+    await new Promise((r) => setTimeout(r, 300));
+    child?.kill("SIGKILL");
+    ccu?.server.close();
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("does not emit Access-Control-Allow-Origin when CORS is unconfigured (default-deny)", async () => {
+    const preflight = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "OPTIONS",
+      headers: { "Origin": "http://evil.example", "Access-Control-Request-Method": "POST" },
+    });
+    expect(preflight.headers.get("access-control-allow-origin")).toBeNull();
+
+    const init = await initialize(mcpPort);
+    expect(init).toBeTruthy(); // a non-browser client still works fine
+  });
+
+  it("accepts a request whose Host header is on the allowlist", async () => {
+    const res = await rawPost(mcpPort, INIT_BODY, { token: AUTH_TOKEN, host: `127.0.0.1:${mcpPort}` });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a forged Host header with 403 (DNS-rebinding protection)", async () => {
+    const res = await rawPost(mcpPort, INIT_BODY, { token: AUTH_TOKEN, host: "evil.example" });
+    expect(res.status).toBe(403);
+  });
+
+  // Must be last: clean shutdown
   it("shuts down gracefully on SIGTERM with exit code 0", async () => {
     const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
     child.kill("SIGTERM");

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -130,7 +130,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, sid);
     expect(res.status).toBe(200);
     const msg = await parseSse(res);
-    expect(msg.result.tools.length).toBe(18);
+    expect(msg.result.tools.length).toBe(19);
   });
 
   it("returns a structured tool error (not a crash) when a tool needs the CCU", async () => {
@@ -220,7 +220,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
       const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: i, method: "tools/list", params: {} }, sid);
       expect(res.status).toBe(200);
       const msg = await parseSse(res);
-      expect(msg.result.tools.length).toBe(18);
+      expect(msg.result.tools.length).toBe(19);
     }
   });
 

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -130,7 +130,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, sid);
     expect(res.status).toBe(200);
     const msg = await parseSse(res);
-    expect(msg.result.tools.length).toBe(23);
+    expect(msg.result.tools.length).toBe(25);
   });
 
   it("returns a structured tool error (not a crash) when a tool needs the CCU", async () => {
@@ -220,7 +220,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
       const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: i, method: "tools/list", params: {} }, sid);
       expect(res.status).toBe(200);
       const msg = await parseSse(res);
-      expect(msg.result.tools.length).toBe(23);
+      expect(msg.result.tools.length).toBe(25);
     }
   });
 

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -130,7 +130,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, sid);
     expect(res.status).toBe(200);
     const msg = await parseSse(res);
-    expect(msg.result.tools.length).toBe(19);
+    expect(msg.result.tools.length).toBe(20);
   });
 
   it("returns a structured tool error (not a crash) when a tool needs the CCU", async () => {
@@ -220,7 +220,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
       const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: i, method: "tools/list", params: {} }, sid);
       expect(res.status).toBe(200);
       const msg = await parseSse(res);
-      expect(msg.result.tools.length).toBe(19);
+      expect(msg.result.tools.length).toBe(20);
     }
   });
 

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -44,7 +44,7 @@ describeIf("MCP tools against live CCU", () => {
     deps = {
       config: {
         ccu: config,
-        mcp: { transport: "stdio", port: 3000 },
+        mcp: { transport: "stdio", port: 3000, allowedHosts: [] },
         cache: { dir: tempDir, ttl: 86400 },
         rateLimiter: { burst: 20, rate: 10 },
         resourcePollInterval: 3600,

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -172,10 +172,14 @@ describeIf("MCP tools against live CCU", () => {
   // Full lifecycle against real ReGa: create → set → read back → delete. Uses a
   // throwaway name and always deletes, so the CCU is left as it was found.
   it("system variable lifecycle: create → set → read → delete (live)", async () => {
-    const name = "debmatic_mcp_test_var";
+    // Unique per run: the CCU keeps hidden VARDP objects for a name even after
+    // deletion, so reusing a fixed name eventually makes create dedup it to
+    // "<name> N". A fresh name each run sidesteps that and keeps the test clean.
+    const name = `debmatic_mcp_test_${Date.now()}`;
     try {
       const created = parseToolResult(await callTool(server, "create_system_variable", { name, type: "float", unit: "°C", min: 0, max: 50 })) as any;
       expect(created.created).toBe(true);
+      expect(created.name).toBe(name); // got the exact requested name, not a deduped one
 
       // Duplicate create is rejected.
       const dup: any = await callTool(server, "create_system_variable", { name, type: "float" });
@@ -203,9 +207,12 @@ describeIf("MCP tools against live CCU", () => {
   // CCU as found. Skips gracefully if the CCU has no rooms/channels to work with.
   it("assign_channel → verify via list_rooms → unassign (live)", async () => {
     const rooms = parseToolResult(await callTool(server, "list_rooms")) as Array<{ id: string; name: string; channelIds: string[] }>;
-    const devices = parseToolResult(await callTool(server, "list_devices")) as Array<{ channels: Array<{ id: string; address: string }> }>;
-    const channel = devices.flatMap((d) => d.channels)[0];
     expect(rooms.length).toBeGreaterThan(0);
+    // Filtered list_devices returns FULL channel objects (with `id`); the
+    // unfiltered/compact form omits `id`, which we need to check room membership.
+    const populated = rooms.find((r) => r.channelIds.length > 0) ?? rooms[0]!;
+    const devices = parseToolResult(await callTool(server, "list_devices", { room: populated.name })) as Array<{ channels: Array<{ id: string; address: string }> }>;
+    const channel = devices.flatMap((d) => d.channels).find((c) => c.id && c.address);
     expect(channel).toBeDefined();
 
     // Pick a room the channel is NOT already in, so the revert is a true revert.

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -44,7 +44,7 @@ describeIf("MCP tools against live CCU", () => {
     deps = {
       config: {
         ccu: config,
-        mcp: { transport: "stdio", port: 3000, allowedHosts: [] },
+        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [] },
         cache: { dir: tempDir, ttl: 86400 },
         rateLimiter: { burst: 20, rate: 10 },
         resourcePollInterval: 3600,

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -198,4 +198,32 @@ describeIf("MCP tools against live CCU", () => {
     expect(second.isError).toBe(true);
     expect(JSON.parse(second.content[0].text).error).toBe("NOT_FOUND");
   }, 90_000);
+
+  // Assign a channel to a room, verify via list_rooms, then revert — leaving the
+  // CCU as found. Skips gracefully if the CCU has no rooms/channels to work with.
+  it("assign_channel → verify via list_rooms → unassign (live)", async () => {
+    const rooms = parseToolResult(await callTool(server, "list_rooms")) as Array<{ id: string; name: string; channelIds: string[] }>;
+    const devices = parseToolResult(await callTool(server, "list_devices")) as Array<{ channels: Array<{ id: string; address: string }> }>;
+    const channel = devices.flatMap((d) => d.channels)[0];
+    expect(rooms.length).toBeGreaterThan(0);
+    expect(channel).toBeDefined();
+
+    // Pick a room the channel is NOT already in, so the revert is a true revert.
+    const target = rooms.find((r) => !r.channelIds.includes(channel!.id)) ?? rooms[0]!;
+    const wasMember = target.channelIds.includes(channel!.id);
+
+    try {
+      const res = parseToolResult(await callTool(server, "assign_channel", { channel: channel!.address, room: target.name })) as any;
+      expect(res.assignedTo).toContainEqual({ kind: "room", name: target.name });
+
+      const after = parseToolResult(await callTool(server, "list_rooms")) as Array<{ name: string; channelIds: string[] }>;
+      const updated = after.find((r) => r.name === target.name)!;
+      expect(updated.channelIds).toContain(channel!.id);
+    } finally {
+      // Revert only if we added it (don't strip a pre-existing membership).
+      if (!wasMember) {
+        await callTool(server, "unassign_channel", { channel: channel!.address, room: target.name });
+      }
+    }
+  }, 90_000);
 });

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -125,4 +125,26 @@ describeIf("MCP tools against live CCU", () => {
     expect(result.isError).toBe(true);
     expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
   }, 30_000);
+
+  it("get_rssi returns devices with plausible dBm RSSI values (live)", async () => {
+    const result = parseToolResult(await callTool(server, "get_rssi")) as {
+      devices: Array<{ address: string; links: Array<{ rssiDevice: number | null; rssiPeer: number | null }> }>;
+      interfaces: unknown;
+    };
+    expect(Array.isArray(result.devices)).toBe(true);
+
+    for (const d of result.devices) {
+      expect(typeof d.address).toBe("string");
+      for (const link of d.links) {
+        for (const v of [link.rssiDevice, link.rssiPeer]) {
+          if (v !== null) {
+            // dBm: never the 65536 sentinel, within a physically plausible range
+            expect(v).not.toBe(65536);
+            expect(v).toBeGreaterThan(-130);
+            expect(v).toBeLessThan(0);
+          }
+        }
+      }
+    }
+  }, 60_000);
 });

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -109,4 +109,20 @@ describeIf("MCP tools against live CCU", () => {
     expect(result.isError).toBe(true);
     expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
   }, 30_000);
+
+  // Exercises the real ReGa enumeration + AlConfirm path without mutating the
+  // user's CCU: a bogus id matches no active alarm → empty confirmed → NOT_FOUND.
+  // We deliberately do NOT auto-confirm a real active alarm (it would silently
+  // dismiss the user's warnings during a test run).
+  it("acknowledge_service_messages returns NOT_FOUND for an unknown id (live ReGa)", async () => {
+    const result: any = await callTool(server, "acknowledge_service_messages", { id: "999999999" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
+  }, 30_000);
+
+  it("acknowledge_service_messages rejects an empty request with INVALID_INPUT", async () => {
+    const result: any = await callTool(server, "acknowledge_service_messages", {});
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+  }, 30_000);
 });

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -44,7 +44,7 @@ describeIf("MCP tools against live CCU", () => {
     deps = {
       config: {
         ccu: config,
-        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [] },
+        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
         cache: { dir: tempDir, ttl: 86400 },
         rateLimiter: { burst: 20, rate: 10 },
         resourcePollInterval: 3600,

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -168,4 +168,34 @@ describeIf("MCP tools against live CCU", () => {
       }
     }
   }, 60_000);
+
+  // Full lifecycle against real ReGa: create → set → read back → delete. Uses a
+  // throwaway name and always deletes, so the CCU is left as it was found.
+  it("system variable lifecycle: create → set → read → delete (live)", async () => {
+    const name = "debmatic_mcp_test_var";
+    try {
+      const created = parseToolResult(await callTool(server, "create_system_variable", { name, type: "float", unit: "°C", min: 0, max: 50 })) as any;
+      expect(created.created).toBe(true);
+
+      // Duplicate create is rejected.
+      const dup: any = await callTool(server, "create_system_variable", { name, type: "float" });
+      expect(dup.isError).toBe(true);
+      expect(JSON.parse(dup.content[0].text).error).toBe("INVALID_INPUT");
+
+      // Set and read back through the normal tools (cache must see the new var).
+      await callTool(server, "set_system_variable", { name, value: 21.5 });
+      const vars = parseToolResult(await callTool(server, "list_system_variables", { name })) as Array<{ name: string; value: unknown }>;
+      const mine = vars.find((v) => v.name === name);
+      expect(mine).toBeDefined();
+      expect(Number(mine!.value)).toBeCloseTo(21.5, 1);
+    } finally {
+      const del = parseToolResult(await callTool(server, "delete_system_variable", { name })) as any;
+      expect(del?.deleted ?? del?.isError === undefined).toBeTruthy();
+    }
+
+    // After deletion it's gone → NOT_FOUND on a second delete.
+    const second: any = await callTool(server, "delete_system_variable", { name });
+    expect(second.isError).toBe(true);
+    expect(JSON.parse(second.content[0].text).error).toBe("NOT_FOUND");
+  }, 90_000);
 });

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -147,4 +147,25 @@ describeIf("MCP tools against live CCU", () => {
       }
     }
   }, 60_000);
+
+  it("list_links returns well-formed links (live; production CCU has thermostat↔FALMOT links)", async () => {
+    const links = parseToolResult(await callTool(server, "list_links")) as Array<{
+      sender: string; receiver: string; senderName: string; receiverName: string; interface: string;
+    }>;
+    expect(Array.isArray(links)).toBe(true);
+    for (const l of links) {
+      expect(typeof l.sender).toBe("string");
+      expect(typeof l.receiver).toBe("string");
+      expect(l.sender).not.toBe("");
+      expect(l.receiver).not.toBe("");
+    }
+    // Filtering by a sender's device returns a subset that all involve that device.
+    if (links.length > 0) {
+      const dev = links[0]!.sender.split(":")[0]!;
+      const filtered = parseToolResult(await callTool(server, "list_links", { address: dev })) as Array<{ sender: string; receiver: string }>;
+      for (const l of filtered) {
+        expect(l.sender.split(":")[0] === dev || l.receiver.split(":")[0] === dev).toBe(true);
+      }
+    }
+  }, 60_000);
 });

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -44,7 +44,7 @@ describeIf("MCP tools against live CCU", () => {
     deps = {
       config: {
         ccu: config,
-        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
+        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
         cache: { dir: tempDir, ttl: 86400 },
         rateLimiter: { burst: 20, rate: 10 },
         resourcePollInterval: 3600,

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -13,7 +13,7 @@ export function createMockDeps(overrides?: {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -13,7 +13,7 @@ export function createMockDeps(overrides?: {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000 },
+      mcp: { transport: "stdio" as const, port: 3000, allowedHosts: [] },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -13,7 +13,7 @@ export function createMockDeps(overrides?: {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedHosts: [] },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [] },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -13,7 +13,7 @@ export function createMockDeps(overrides?: {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [] },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,

--- a/test/unit/auth-token.test.ts
+++ b/test/unit/auth-token.test.ts
@@ -1,96 +1,186 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { resolveAuthToken } from "../../src/auth/token.js";
+import { resolveAuthTokens } from "../../src/auth/token.js";
 import { Logger } from "../../src/logger.js";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 const logger = new Logger("error");
 
-describe("resolveAuthToken", () => {
-  let tempDir: string;
+const DAY = 86_400_000;
+const HOUR = 3_600_000;
+
+// Pull the persisted token straight out of the .env file the resolver wrote.
+async function fileToken(dir: string): Promise<string> {
+  const content = await readFile(join(dir, ".env"), "utf-8");
+  return content.match(/^MCP_AUTH_TOKEN=(.+)$/m)![1].trim();
+}
+
+describe("resolveAuthTokens", () => {
+  let dir: string;
 
   beforeEach(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "debmatic-auth-test-"));
+    dir = await mkdtemp(join(tmpdir(), "debmatic-auth-test-"));
     vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   });
 
   afterEach(async () => {
-    await rm(tempDir, { recursive: true, force: true });
+    await rm(dir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
 
-  it("returns explicit env token if provided", async () => {
-    const token = await resolveAuthToken("my-explicit-token", tempDir, logger);
-    expect(token).toBe("my-explicit-token");
+  it("accepts the explicit env token and rejects everything else", async () => {
+    const tokens = await resolveAuthTokens(
+      { envToken: "my-explicit-token", dataDir: dir, graceMs: 24 * HOUR },
+      logger,
+    );
+    expect(tokens.verify("my-explicit-token")).toBe(true);
+    expect(tokens.verify("nope")).toBe(false);
+    expect(tokens.verify("")).toBe(false);
   });
 
-  it("generates token and saves to .env if none exists", async () => {
-    const token = await resolveAuthToken(undefined, tempDir, logger);
+  it("env token takes priority and leaves the data dir untouched", async () => {
+    const tokens = await resolveAuthTokens(
+      { envToken: "override", dataDir: dir, graceMs: 24 * HOUR },
+      logger,
+    );
+    expect(tokens.verify("override")).toBe(true);
+    // No file should have been written for the explicit-token path.
+    await expect(readFile(join(dir, ".env"), "utf-8")).rejects.toThrow();
+  });
 
+  it("accepts both env current and previous during a rotation overlap", async () => {
+    const tokens = await resolveAuthTokens(
+      { envToken: "new", envPreviousToken: "old", dataDir: dir, graceMs: 24 * HOUR },
+      logger,
+    );
+    expect(tokens.verify("new")).toBe(true);
+    expect(tokens.verify("old")).toBe(true);
+    expect(tokens.verify("ancient")).toBe(false);
+  });
+
+  it("generates and persists a token when none exists", async () => {
+    const tokens = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    const token = await fileToken(dir);
     expect(token.length).toBeGreaterThan(20);
-
-    // Check file was created
-    const content = await readFile(join(tempDir, ".env"), "utf-8");
-    expect(content).toBe(`MCP_AUTH_TOKEN=${token}\n`);
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/); // base64url, no padding
+    expect(tokens.verify(token)).toBe(true);
   });
 
-  it("loads existing token from .env", async () => {
-    // First call generates
-    const token1 = await resolveAuthToken(undefined, tempDir, logger);
-
-    // Second call loads
-    const token2 = await resolveAuthToken(undefined, tempDir, logger);
-
-    expect(token2).toBe(token1);
+  it("loads the same token across runs", async () => {
+    await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    const token = await fileToken(dir);
+    const tokens2 = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    expect(tokens2.verify(token)).toBe(true);
   });
 
-  it("env token takes priority over .env file", async () => {
-    // Generate a file token first
-    await resolveAuthToken(undefined, tempDir, logger);
-
-    // Explicit env should win
-    const token = await resolveAuthToken("override-token", tempDir, logger);
-    expect(token).toBe("override-token");
+  it("trims a trailing CR from CRLF-edited files (issue #13)", async () => {
+    await writeFile(join(dir, ".env"), "MCP_AUTH_TOKEN=crlf-token\r\n", "utf-8");
+    const tokens = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    expect(tokens.verify("crlf-token")).toBe(true);
   });
 
-  // Regression: trailing \r from CRLF line endings was kept in the token (issue #13)
-  it("trims trailing CR when .env has CRLF line endings", async () => {
-    const { writeFile } = await import("node:fs/promises");
-    await writeFile(join(tempDir, ".env"), "MCP_AUTH_TOKEN=crlf-token\r\n", "utf-8");
-
-    const token = await resolveAuthToken(undefined, tempDir, logger);
-    expect(token).toBe("crlf-token");
+  it("generates a fresh token when .env lacks MCP_AUTH_TOKEN", async () => {
+    await writeFile(join(dir, ".env"), "OTHER_VAR=x\n", "utf-8");
+    const tokens = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    const token = await fileToken(dir);
+    expect(tokens.verify(token)).toBe(true);
   });
 
-  it("generates base64url token (no padding, URL-safe)", async () => {
-    const token = await resolveAuthToken(undefined, tempDir, logger);
-    // base64url uses only [A-Za-z0-9_-], no = padding
-    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
-  });
-});
+  describe("expiry (TTL)", () => {
+    it("a generated token is rejected once its TTL lapses", async () => {
+      const t0 = 1_000_000_000_000;
+      const tokens = await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR },
+        logger,
+        t0,
+      );
+      const token = await fileToken(dir);
+      // boundary: valid right up to the edge, rejected past it
+      expect(tokens.verify(token, t0)).toBe(true);
+      expect(tokens.verify(token, t0 + 30 * DAY)).toBe(true);
+      expect(tokens.verify(token, t0 + 30 * DAY + 1)).toBe(false);
+    });
 
-describe("save failure (coverage round)", () => {
-  it("still returns a usable token when the data dir is not writable", async () => {
-    // /dev/null is a file, so creating a directory beneath it fails fast (ENOTDIR)
-    const token = await resolveAuthToken(undefined, "/dev/null/not-writable", logger);
-    expect(token.length).toBeGreaterThan(20);
-  });
-});
+    it("without a TTL the generated token never expires", async () => {
+      const t0 = 1_000_000_000_000;
+      const tokens = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger, t0);
+      const token = await fileToken(dir);
+      expect(tokens.verify(token, t0 + 3650 * DAY)).toBe(true);
+    });
 
-describe("malformed .env (coverage round)", () => {
-  it("generates a new token when .env exists without MCP_AUTH_TOKEN", async () => {
-    const { writeFile, mkdtemp, rm } = await import("node:fs/promises");
-    const { tmpdir } = await import("node:os");
-    const dir = await mkdtemp(join(tmpdir(), "debmatic-auth-test2-"));
-    try {
-      await writeFile(join(dir, ".env"), "OTHER_VAR=x\n", "utf-8");
-      const token = await resolveAuthToken(undefined, dir, logger);
-      expect(token.length).toBeGreaterThan(20);
+    it("backfills issued-at for a legacy file so TTL starts from first sight", async () => {
+      await writeFile(join(dir, ".env"), "MCP_AUTH_TOKEN=legacy\n", "utf-8");
+      const t0 = 1_000_000_000_000;
+      const tokens = await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 10 * DAY, graceMs: 24 * HOUR },
+        logger,
+        t0,
+      );
+      // legacy token kept, now carrying an issued-at == t0
+      expect(tokens.verify("legacy", t0)).toBe(true);
+      expect(tokens.verify("legacy", t0 + 10 * DAY + 1)).toBe(false);
       const content = await readFile(join(dir, ".env"), "utf-8");
-      expect(content).toContain(`MCP_AUTH_TOKEN=${token}`);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
+      expect(content).toContain(`MCP_AUTH_TOKEN_ISSUED=${t0}`);
+    });
+  });
+
+  describe("rotation overlap", () => {
+    it("rotates an expired generated token but keeps the old one valid during grace", async () => {
+      const t0 = 1_000_000_000_000;
+      // First run mints token A.
+      await resolveAuthTokens({ dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR }, logger, t0);
+      const tokenA = await fileToken(dir);
+
+      // Second run, past A's TTL → rotate to token B, A stays valid for grace.
+      const tRotate = t0 + 31 * DAY;
+      const tokens = await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR },
+        logger,
+        tRotate,
+      );
+      const tokenB = await fileToken(dir);
+      expect(tokenB).not.toBe(tokenA);
+
+      // Both accepted inside the overlap (in-flight clients survive the swap).
+      expect(tokens.verify(tokenB, tRotate)).toBe(true);
+      expect(tokens.verify(tokenA, tRotate)).toBe(true);
+      // Old token lapses at the grace boundary; new one lives on.
+      expect(tokens.verify(tokenA, tRotate + 24 * HOUR + 1)).toBe(false);
+      expect(tokens.verify(tokenB, tRotate + 24 * HOUR + 1)).toBe(true);
+    });
+
+    it("drops a rotated-out token from the file once its grace fully elapses", async () => {
+      const t0 = 1_000_000_000_000;
+      await resolveAuthTokens({ dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR }, logger, t0);
+      const tokenA = await fileToken(dir);
+      // Rotate to B.
+      await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR },
+        logger,
+        t0 + 31 * DAY,
+      );
+      // A later run, well past the grace window: A should be pruned from the file.
+      const tokens = await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR },
+        logger,
+        t0 + 40 * DAY,
+      );
+      const content = await readFile(join(dir, ".env"), "utf-8");
+      expect(content).not.toContain("MCP_AUTH_TOKEN_PREVIOUS");
+      expect(tokens.verify(tokenA, t0 + 40 * DAY)).toBe(false);
+    });
+  });
+
+  it("still returns a usable verifier when the data dir is not writable", async () => {
+    // /dev/null is a file, so creating a dir beneath it fails fast (ENOTDIR).
+    const tokens = await resolveAuthTokens(
+      { dataDir: "/dev/null/nope", graceMs: 24 * HOUR },
+      logger,
+    );
+    // It minted an in-memory token even though persistence failed; the operator
+    // gets it on stderr. We can't read it from a file, but a bogus token fails.
+    expect(tokens.verify("definitely-not-it")).toBe(false);
+    expect(tokens.liveCount()).toBe(1);
   });
 });

--- a/test/unit/bearer-token.test.ts
+++ b/test/unit/bearer-token.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { extractBearerToken } from "../../src/utils.js";
+
+describe("extractBearerToken", () => {
+  it("extracts a well-formed bearer token", () => {
+    expect(extractBearerToken("Bearer abc123")).toBe("abc123");
+  });
+
+  it("is case-insensitive on the scheme (RFC 7235)", () => {
+    expect(extractBearerToken("bearer abc123")).toBe("abc123");
+    expect(extractBearerToken("BEARER abc123")).toBe("abc123");
+  });
+
+  it("tolerates multiple spaces after the scheme", () => {
+    expect(extractBearerToken("Bearer    abc123")).toBe("abc123");
+  });
+
+  it("returns '' for a missing or non-bearer header", () => {
+    expect(extractBearerToken("")).toBe("");
+    expect(extractBearerToken("Basic abc123")).toBe("");
+    expect(extractBearerToken("Bearer")).toBe("");
+    expect(extractBearerToken("Bearer ")).toBe("");
+  });
+
+  it("does not backtrack polynomially on a whitespace-only tail (ReDoS guard)", () => {
+    // The old /^Bearer\s+(.+)$/ overlapped \s+ and .+ on whitespace; a long
+    // all-space tail was the polynomial-ReDoS input. Anchoring to \S makes
+    // this linear: it must complete near-instantly and yield no token.
+    const malicious = "Bearer" + " ".repeat(100_000);
+    const start = performance.now();
+    const token = extractBearerToken(malicious);
+    const elapsed = performance.now() - start;
+    expect(token).toBe("");
+    expect(elapsed).toBeLessThan(50);
+  });
+});

--- a/test/unit/ccu-tls-verify.test.ts
+++ b/test/unit/ccu-tls-verify.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:https";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { X509Certificate } from "node:crypto";
+import { AddressInfo } from "node:net";
+import { Logger } from "../../src/logger.js";
+import { CcuClient } from "../../src/ccu/client.js";
+import { CcuError } from "../../src/middleware/error-mapper.js";
+
+// Issue #51: the CcuClient must actually verify the CCU's self-signed TLS cert
+// when CCU_TLS_FINGERPRINT or CCU_CA_CERT is configured. This drives a real
+// local HTTPS server (a self-signed cert minted with openssl) through the
+// client's connector. Skipped if openssl isn't available.
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+
+const logger = new Logger("error");
+
+describe.skipIf(!HAVE_OPENSSL)("CcuClient TLS verification (real HTTPS server)", () => {
+  let server: Server;
+  let port: number;
+  let certPem: string;
+  let fingerprint: string;
+  let tmpDir: string;
+
+  const base = {
+    host: "127.0.0.1",
+    https: true,
+    tlsVerify: false,
+    user: "Admin",
+    password: "pw",
+    timeout: 5000,
+    scriptTimeout: 30000,
+  };
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ccu-tls-"));
+    const certPath = join(tmpDir, "cert.pem");
+    const keyPath = join(tmpDir, "key.pem");
+    // SAN must carry IP:127.0.0.1 — Node (>=17) dropped subject-CN fallback, and
+    // CA-cert mode (rejectUnauthorized:true) checks identity against the host.
+    const gen = spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=ccu",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    if (gen.status !== 0) throw new Error("openssl failed to generate test cert");
+
+    certPem = readFileSync(certPath, "utf-8");
+    fingerprint = new X509Certificate(certPem).fingerprint256; // "AB:CD:.."
+
+    server = createServer(
+      { cert: certPem, key: readFileSync(keyPath) },
+      (_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ id: "1", version: "1.1", result: "ok", error: null }));
+      },
+    );
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", () => {
+        port = (server.address() as AddressInfo).port;
+        resolve();
+      }),
+    );
+  });
+
+  afterAll(() => {
+    server?.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("connects when the pinned fingerprint matches", async () => {
+    const client = new CcuClient({ ...base, port, tlsFingerprint: fingerprint }, logger);
+    await expect(client.call("Test", {})).resolves.toBe("ok");
+  });
+
+  it("accepts a fingerprint written without colons", async () => {
+    const client = new CcuClient(
+      { ...base, port, tlsFingerprint: fingerprint.replace(/:/g, "") },
+      logger,
+    );
+    await expect(client.call("Test", {})).resolves.toBe("ok");
+  });
+
+  it("refuses to connect when the pinned fingerprint does not match", async () => {
+    const wrong = "00:".repeat(31) + "00";
+    const client = new CcuClient({ ...base, port, tlsFingerprint: wrong }, logger);
+    try {
+      await client.call("Test", {});
+      expect.unreachable("should have rejected the cert");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CcuError);
+      expect((err as CcuError).structured.error).toBe("UNREACHABLE");
+    }
+  });
+
+  it("connects when the cert is trusted via caCert", async () => {
+    const client = new CcuClient({ ...base, port, caCert: certPem }, logger);
+    await expect(client.call("Test", {})).resolves.toBe("ok");
+  });
+
+  it("rejects an untrusted cert under caCert verification", async () => {
+    // A different (unrelated) CA must not validate the server's cert.
+    const otherDir = mkdtempSync(join(tmpdir(), "ccu-tls-other-"));
+    const otherCert = join(otherDir, "cert.pem");
+    spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", join(otherDir, "key.pem"), "-out", otherCert,
+      "-days", "1", "-subj", "/CN=other", "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    const client = new CcuClient(
+      { ...base, port, caCert: readFileSync(otherCert, "utf-8") },
+      logger,
+    );
+    try {
+      await client.call("Test", {});
+      expect.unreachable("should have rejected the untrusted cert");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CcuError);
+      expect((err as CcuError).structured.error).toBe("UNREACHABLE");
+    } finally {
+      rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/ccu-tls-verify.test.ts
+++ b/test/unit/ccu-tls-verify.test.ts
@@ -85,6 +85,18 @@ describe.skipIf(!HAVE_OPENSSL)("CcuClient TLS verification (real HTTPS server)",
     await expect(client.call("Test", {})).resolves.toBe("ok");
   });
 
+  // Regression: TLS session resumption returns an empty peer cert on a resumed
+  // connection, which made fingerprint pinning reject those requests. One
+  // awaited call caches the TLS session; the following concurrent burst then
+  // opens fresh connections that would resume it. The client disables session
+  // caching so every connection presents the cert and all calls verify.
+  it("verifies the fingerprint on connections that would resume the TLS session", async () => {
+    const client = new CcuClient({ ...base, port, tlsFingerprint: fingerprint }, logger);
+    await client.call("Test", {}); // full handshake, caches the session
+    const results = await Promise.all(Array.from({ length: 8 }, () => client.call("Test", {})));
+    expect(results).toEqual(Array(8).fill("ok"));
+  });
+
   it("refuses to connect when the pinned fingerprint does not match", async () => {
     const wrong = "00:".repeat(31) + "00";
     const client = new CcuClient({ ...base, port, tlsFingerprint: wrong }, logger);

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -17,7 +17,7 @@ describe("loadConfig", () => {
     delete process.env.MCP_TRANSPORT;
     delete process.env.MCP_PORT;
     delete process.env.MCP_AUTH_TOKEN;
-    delete process.env.MCP_CORS_ALLOW_ORIGIN;
+    delete process.env.MCP_ALLOWED_ORIGINS;
     delete process.env.MCP_ALLOWED_HOSTS;
     delete process.env.CACHE_DIR;
     delete process.env.CACHE_TTL;
@@ -152,17 +152,21 @@ describe("loadConfig", () => {
     expect(() => loadConfig()).toThrow(/RESOURCE_POLL_INTERVAL must be a positive number/);
   });
 
-  // Issue #28: HTTP transport hardening
-  it("CORS is default-deny: corsAllowOrigin is undefined unless configured", () => {
+  // Issue #28 / #37: HTTP transport hardening
+  it("origin allowlist is default-deny: allowedOrigins is empty unless configured", () => {
     process.env.CCU_HOST = "test";
     process.env.CCU_PASSWORD = "pw";
-    expect(loadConfig().mcp.corsAllowOrigin).toBeUndefined();
+    expect(loadConfig().mcp.allowedOrigins).toEqual([]);
+  });
 
-    process.env.MCP_CORS_ALLOW_ORIGIN = "*";
-    expect(loadConfig().mcp.corsAllowOrigin).toBe("*");
-
-    process.env.MCP_CORS_ALLOW_ORIGIN = "https://app.example";
-    expect(loadConfig().mcp.corsAllowOrigin).toBe("https://app.example");
+  it("MCP_ALLOWED_ORIGINS parses a comma-separated allowlist (trimmed, no blanks)", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_ALLOWED_ORIGINS = "https://app.example, , http://localhost:6274 ";
+    expect(loadConfig().mcp.allowedOrigins).toEqual([
+      "https://app.example",
+      "http://localhost:6274",
+    ]);
   });
 
   it("allowedHosts defaults to localhost/127.0.0.1 on the MCP port", () => {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { loadConfig } from "../../src/config.js";
 
 describe("loadConfig", () => {
@@ -27,6 +30,8 @@ describe("loadConfig", () => {
     delete process.env.CCU_TIMEOUT;
     delete process.env.CCU_SCRIPT_TIMEOUT;
     delete process.env.CCU_TLS_VERIFY;
+    delete process.env.CCU_TLS_FINGERPRINT;
+    delete process.env.CCU_CA_CERT;
     delete process.env.MCP_HOST;
     delete process.env.MCP_TLS_CERT;
     delete process.env.MCP_TLS_KEY;
@@ -200,6 +205,43 @@ describe("loadConfig", () => {
 
     process.env.CCU_TLS_VERIFY = "true";
     expect(loadConfig().ccu.tlsVerify).toBe(true);
+  });
+
+  // Issue #51: CCU TLS verification via fingerprint pin or CA cert
+  it("CCU TLS pinning is off by default", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    const config = loadConfig();
+    expect(config.ccu.tlsFingerprint).toBeUndefined();
+    expect(config.ccu.caCert).toBeUndefined();
+  });
+
+  it("parses CCU_TLS_FINGERPRINT", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.CCU_TLS_FINGERPRINT = "AB:CD:EF:01";
+    expect(loadConfig().ccu.tlsFingerprint).toBe("AB:CD:EF:01");
+  });
+
+  it("reads CCU_CA_CERT file contents", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ccu-ca-"));
+    const caPath = join(dir, "ca.pem");
+    writeFileSync(caPath, "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n");
+    try {
+      process.env.CCU_HOST = "test";
+      process.env.CCU_PASSWORD = "pw";
+      process.env.CCU_CA_CERT = caPath;
+      expect(loadConfig().ccu.caCert).toContain("BEGIN CERTIFICATE");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws if CCU_CA_CERT points at a missing file", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.CCU_CA_CERT = "/no/such/ca.pem";
+    expect(() => loadConfig()).toThrow(/CCU_CA_CERT could not be read/);
   });
 
   // Issue #50: native TLS for the HTTP transport (opt-in), bind host, plaintext ack

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -20,6 +20,9 @@ describe("loadConfig", () => {
     delete process.env.MCP_TRANSPORT;
     delete process.env.MCP_PORT;
     delete process.env.MCP_AUTH_TOKEN;
+    delete process.env.MCP_AUTH_TOKEN_PREVIOUS;
+    delete process.env.MCP_AUTH_TOKEN_TTL_DAYS;
+    delete process.env.MCP_AUTH_TOKEN_GRACE_HOURS;
     delete process.env.MCP_ALLOWED_ORIGINS;
     delete process.env.MCP_ALLOWED_HOSTS;
     delete process.env.CACHE_DIR;
@@ -285,5 +288,36 @@ describe("loadConfig", () => {
     const config = loadConfig();
     expect(config.mcp.host).toBe("127.0.0.1");
     expect(config.mcp.allowPlaintext).toBe(true);
+  });
+
+  // Issue #52: token rotation + expiry
+  it("token TTL/previous default to none; grace defaults to 24h", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    const config = loadConfig();
+    expect(config.mcp.authTokenPrevious).toBeUndefined();
+    expect(config.mcp.authTokenTtlMs).toBeUndefined();
+    expect(config.mcp.authTokenGraceMs).toBe(24 * 3_600_000);
+  });
+
+  it("parses MCP_AUTH_TOKEN_TTL_DAYS / _GRACE_HOURS / _PREVIOUS (fractional ok)", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_AUTH_TOKEN_PREVIOUS = "old-token";
+    process.env.MCP_AUTH_TOKEN_TTL_DAYS = "30";
+    process.env.MCP_AUTH_TOKEN_GRACE_HOURS = "0.5";
+    const config = loadConfig();
+    expect(config.mcp.authTokenPrevious).toBe("old-token");
+    expect(config.mcp.authTokenTtlMs).toBe(30 * 86_400_000);
+    expect(config.mcp.authTokenGraceMs).toBe(Math.round(0.5 * 3_600_000));
+  });
+
+  it("throws on a non-positive / garbage MCP_AUTH_TOKEN_TTL_DAYS", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_AUTH_TOKEN_TTL_DAYS = "0";
+    expect(() => loadConfig()).toThrow(/MCP_AUTH_TOKEN_TTL_DAYS must be a positive number/);
+    process.env.MCP_AUTH_TOKEN_TTL_DAYS = "soon";
+    expect(() => loadConfig()).toThrow(/MCP_AUTH_TOKEN_TTL_DAYS must be a positive number/);
   });
 });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -27,6 +27,10 @@ describe("loadConfig", () => {
     delete process.env.CCU_TIMEOUT;
     delete process.env.CCU_SCRIPT_TIMEOUT;
     delete process.env.CCU_TLS_VERIFY;
+    delete process.env.MCP_HOST;
+    delete process.env.MCP_TLS_CERT;
+    delete process.env.MCP_TLS_KEY;
+    delete process.env.MCP_ALLOW_PLAINTEXT;
     delete process.env.LOG_LEVEL;
   });
 
@@ -196,5 +200,48 @@ describe("loadConfig", () => {
 
     process.env.CCU_TLS_VERIFY = "true";
     expect(loadConfig().ccu.tlsVerify).toBe(true);
+  });
+
+  // Issue #50: native TLS for the HTTP transport (opt-in), bind host, plaintext ack
+  it("TLS is off by default: no cert/key paths, plain HTTP", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    const config = loadConfig();
+    expect(config.mcp.tlsCertPath).toBeUndefined();
+    expect(config.mcp.tlsKeyPath).toBeUndefined();
+    expect(config.mcp.host).toBeUndefined();
+    expect(config.mcp.allowPlaintext).toBe(false);
+  });
+
+  it("reads MCP_TLS_CERT/MCP_TLS_KEY when both are set", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_TLS_CERT = "/data/cert.pem";
+    process.env.MCP_TLS_KEY = "/data/key.pem";
+    const config = loadConfig();
+    expect(config.mcp.tlsCertPath).toBe("/data/cert.pem");
+    expect(config.mcp.tlsKeyPath).toBe("/data/key.pem");
+  });
+
+  it("throws if only one of MCP_TLS_CERT / MCP_TLS_KEY is set", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+
+    process.env.MCP_TLS_CERT = "/data/cert.pem";
+    expect(() => loadConfig()).toThrow(/MCP_TLS_CERT and MCP_TLS_KEY must both be set/);
+
+    delete process.env.MCP_TLS_CERT;
+    process.env.MCP_TLS_KEY = "/data/key.pem";
+    expect(() => loadConfig()).toThrow(/MCP_TLS_CERT and MCP_TLS_KEY must both be set/);
+  });
+
+  it("reads MCP_HOST and MCP_ALLOW_PLAINTEXT", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_HOST = "127.0.0.1";
+    process.env.MCP_ALLOW_PLAINTEXT = "true";
+    const config = loadConfig();
+    expect(config.mcp.host).toBe("127.0.0.1");
+    expect(config.mcp.allowPlaintext).toBe(true);
   });
 });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -17,6 +17,8 @@ describe("loadConfig", () => {
     delete process.env.MCP_TRANSPORT;
     delete process.env.MCP_PORT;
     delete process.env.MCP_AUTH_TOKEN;
+    delete process.env.MCP_CORS_ALLOW_ORIGIN;
+    delete process.env.MCP_ALLOWED_HOSTS;
     delete process.env.CACHE_DIR;
     delete process.env.CACHE_TTL;
     delete process.env.CCU_RATE_LIMIT_BURST;
@@ -148,6 +150,39 @@ describe("loadConfig", () => {
 
     process.env.RESOURCE_POLL_INTERVAL = "-60";
     expect(() => loadConfig()).toThrow(/RESOURCE_POLL_INTERVAL must be a positive number/);
+  });
+
+  // Issue #28: HTTP transport hardening
+  it("CORS is default-deny: corsAllowOrigin is undefined unless configured", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    expect(loadConfig().mcp.corsAllowOrigin).toBeUndefined();
+
+    process.env.MCP_CORS_ALLOW_ORIGIN = "*";
+    expect(loadConfig().mcp.corsAllowOrigin).toBe("*");
+
+    process.env.MCP_CORS_ALLOW_ORIGIN = "https://app.example";
+    expect(loadConfig().mcp.corsAllowOrigin).toBe("https://app.example");
+  });
+
+  it("allowedHosts defaults to localhost/127.0.0.1 on the MCP port", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_PORT = "4567";
+    expect(loadConfig().mcp.allowedHosts).toEqual(["127.0.0.1:4567", "localhost:4567"]);
+  });
+
+  it("MCP_ALLOWED_HOSTS extends the default host allowlist (trimmed, no blanks)", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.MCP_PORT = "3000";
+    process.env.MCP_ALLOWED_HOSTS = "mcp.lan:3000, , proxy.example ";
+    expect(loadConfig().mcp.allowedHosts).toEqual([
+      "127.0.0.1:3000",
+      "localhost:3000",
+      "mcp.lan:3000",
+      "proxy.example",
+    ]);
   });
 
   it("parses CCU_TLS_VERIFY (default off)", () => {

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -27,8 +27,8 @@ function envKeysReferencedInCode(): Set<string> {
     for (const m of text.matchAll(/process\.env(?:\.([A-Z][A-Z0-9_]*)|\["([A-Z][A-Z0-9_]*)"\])/g)) {
       keys.add(m[1] ?? m[2]);
     }
-    // parseIntEnv("FOO", ...) — indirect numeric reads
-    for (const m of text.matchAll(/parseIntEnv\("([A-Z][A-Z0-9_]*)"/g)) {
+    // parseIntEnv("FOO", ...) / parseDurationEnv("FOO", ...) — indirect reads
+    for (const m of text.matchAll(/parse(?:Int|Duration)Env\("([A-Z][A-Z0-9_]*)"/g)) {
       keys.add(m[1]);
     }
   }

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// Guard: .env.example must document every environment variable the code reads,
+// and must not list any that the code doesn't. Keeps the example exhaustive
+// (and honest) as env vars come and go.
+
+const SRC = join(__dirname, "../../src");
+const ENV_EXAMPLE = join(__dirname, "../../.env.example");
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectTsFiles(p));
+    else if (entry.name.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+
+function envKeysReferencedInCode(): Set<string> {
+  const keys = new Set<string>();
+  for (const file of collectTsFiles(SRC)) {
+    const text = readFileSync(file, "utf-8");
+    // process.env.FOO and process.env["FOO"]
+    for (const m of text.matchAll(/process\.env(?:\.([A-Z][A-Z0-9_]*)|\["([A-Z][A-Z0-9_]*)"\])/g)) {
+      keys.add(m[1] ?? m[2]);
+    }
+    // parseIntEnv("FOO", ...) — indirect numeric reads
+    for (const m of text.matchAll(/parseIntEnv\("([A-Z][A-Z0-9_]*)"/g)) {
+      keys.add(m[1]);
+    }
+  }
+  return keys;
+}
+
+function envKeysInExample(): Set<string> {
+  const keys = new Set<string>();
+  for (const line of readFileSync(ENV_EXAMPLE, "utf-8").split("\n")) {
+    const m = line.match(/^([A-Z][A-Z0-9_]*)=/);
+    if (m) keys.add(m[1]);
+  }
+  return keys;
+}
+
+describe(".env.example", () => {
+  it("documents every env var the code reads", () => {
+    const code = envKeysReferencedInCode();
+    const example = envKeysInExample();
+    const missing = [...code].filter((k) => !example.has(k)).sort();
+    expect(missing, `env vars read in code but missing from .env.example: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("does not list env vars the code never reads", () => {
+    const code = envKeysReferencedInCode();
+    const example = envKeysInExample();
+    const stale = [...example].filter((k) => !code.has(k)).sort();
+    expect(stale, `env vars in .env.example not read anywhere in code: ${stale.join(", ")}`).toEqual([]);
+  });
+});

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -48,6 +48,7 @@ describe("MCP Server Registration", () => {
 
     expect(toolNames).toEqual([
       "acknowledge_service_messages",
+      "assign_channel",
       "create_system_variable",
       "delete_system_variable",
       "describe_device_type",
@@ -70,9 +71,10 @@ describe("MCP Server Registration", () => {
       "run_script",
       "set_system_variable",
       "set_value",
+      "unassign_channel",
     ]);
 
-    expect(Object.keys(tools).length).toBe(23);
+    expect(Object.keys(tools).length).toBe(25);
     deps.rateLimiter.destroy();
   });
 
@@ -127,8 +129,8 @@ describe("Tool annotations", () => {
     "get_rssi", "get_value", "get_values", "help", "list_devices", "list_functions",
     "list_interfaces", "list_links", "list_programs", "list_rooms", "list_system_variables",
   ];
-  const WRITE_TOOLS = ["acknowledge_service_messages", "create_system_variable", "delete_system_variable", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
-  const IDEMPOTENT_WRITES = ["acknowledge_service_messages", "delete_system_variable", "put_paramset", "set_system_variable", "set_value"];
+  const WRITE_TOOLS = ["acknowledge_service_messages", "assign_channel", "create_system_variable", "delete_system_variable", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value", "unassign_channel"];
+  const IDEMPOTENT_WRITES = ["acknowledge_service_messages", "assign_channel", "delete_system_variable", "put_paramset", "set_system_variable", "set_value", "unassign_channel"];
   const LOCAL_TOOLS = ["help"]; // everything else reaches the external CCU
 
   type Ann = {

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -10,7 +10,7 @@ function createMockDeps() {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedHosts: [] },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [] },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 20, rate: 10 },
       resourcePollInterval: 60,

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -48,6 +48,8 @@ describe("MCP Server Registration", () => {
 
     expect(toolNames).toEqual([
       "acknowledge_service_messages",
+      "create_system_variable",
+      "delete_system_variable",
       "describe_device_type",
       "execute_program",
       "get_paramset",
@@ -70,7 +72,7 @@ describe("MCP Server Registration", () => {
       "set_value",
     ]);
 
-    expect(Object.keys(tools).length).toBe(21);
+    expect(Object.keys(tools).length).toBe(23);
     deps.rateLimiter.destroy();
   });
 
@@ -125,8 +127,8 @@ describe("Tool annotations", () => {
     "get_rssi", "get_value", "get_values", "help", "list_devices", "list_functions",
     "list_interfaces", "list_links", "list_programs", "list_rooms", "list_system_variables",
   ];
-  const WRITE_TOOLS = ["acknowledge_service_messages", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
-  const IDEMPOTENT_WRITES = ["acknowledge_service_messages", "put_paramset", "set_system_variable", "set_value"];
+  const WRITE_TOOLS = ["acknowledge_service_messages", "create_system_variable", "delete_system_variable", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
+  const IDEMPOTENT_WRITES = ["acknowledge_service_messages", "delete_system_variable", "put_paramset", "set_system_variable", "set_value"];
   const LOCAL_TOOLS = ["help"]; // everything else reaches the external CCU
 
   type Ann = {

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -60,6 +60,7 @@ describe("MCP Server Registration", () => {
       "list_devices",
       "list_functions",
       "list_interfaces",
+      "list_links",
       "list_programs",
       "list_rooms",
       "list_system_variables",
@@ -69,7 +70,7 @@ describe("MCP Server Registration", () => {
       "set_value",
     ]);
 
-    expect(Object.keys(tools).length).toBe(20);
+    expect(Object.keys(tools).length).toBe(21);
     deps.rateLimiter.destroy();
   });
 
@@ -122,7 +123,7 @@ describe("Tool annotations", () => {
   const READ_TOOLS = [
     "describe_device_type", "get_paramset", "get_service_messages", "get_system_info",
     "get_rssi", "get_value", "get_values", "help", "list_devices", "list_functions",
-    "list_interfaces", "list_programs", "list_rooms", "list_system_variables",
+    "list_interfaces", "list_links", "list_programs", "list_rooms", "list_system_variables",
   ];
   const WRITE_TOOLS = ["acknowledge_service_messages", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
   const IDEMPOTENT_WRITES = ["acknowledge_service_messages", "put_paramset", "set_system_variable", "set_value"];

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -47,6 +47,7 @@ describe("MCP Server Registration", () => {
     const toolNames = Object.keys(tools).sort();
 
     expect(toolNames).toEqual([
+      "acknowledge_service_messages",
       "describe_device_type",
       "execute_program",
       "get_paramset",
@@ -67,7 +68,7 @@ describe("MCP Server Registration", () => {
       "set_value",
     ]);
 
-    expect(Object.keys(tools).length).toBe(18);
+    expect(Object.keys(tools).length).toBe(19);
     deps.rateLimiter.destroy();
   });
 
@@ -122,8 +123,8 @@ describe("Tool annotations", () => {
     "get_value", "get_values", "help", "list_devices", "list_functions",
     "list_interfaces", "list_programs", "list_rooms", "list_system_variables",
   ];
-  const WRITE_TOOLS = ["execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
-  const IDEMPOTENT_WRITES = ["put_paramset", "set_system_variable", "set_value"];
+  const WRITE_TOOLS = ["acknowledge_service_messages", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
+  const IDEMPOTENT_WRITES = ["acknowledge_service_messages", "put_paramset", "set_system_variable", "set_value"];
   const LOCAL_TOOLS = ["help"]; // everything else reaches the external CCU
 
   type Ann = {

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -10,7 +10,7 @@ function createMockDeps() {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 20, rate: 10 },
       resourcePollInterval: 60,

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -10,7 +10,7 @@ function createMockDeps() {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [] },
+      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 20, rate: 10 },
       resourcePollInterval: 60,

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -10,7 +10,7 @@ function createMockDeps() {
   return {
     config: {
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000 },
+      mcp: { transport: "stdio" as const, port: 3000, allowedHosts: [] },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 20, rate: 10 },
       resourcePollInterval: 60,

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -51,6 +51,7 @@ describe("MCP Server Registration", () => {
       "describe_device_type",
       "execute_program",
       "get_paramset",
+      "get_rssi",
       "get_service_messages",
       "get_system_info",
       "get_value",
@@ -68,7 +69,7 @@ describe("MCP Server Registration", () => {
       "set_value",
     ]);
 
-    expect(Object.keys(tools).length).toBe(19);
+    expect(Object.keys(tools).length).toBe(20);
     deps.rateLimiter.destroy();
   });
 
@@ -120,7 +121,7 @@ describe("MCP Server Registration", () => {
 describe("Tool annotations", () => {
   const READ_TOOLS = [
     "describe_device_type", "get_paramset", "get_service_messages", "get_system_info",
-    "get_value", "get_values", "help", "list_devices", "list_functions",
+    "get_rssi", "get_value", "get_values", "help", "list_devices", "list_functions",
     "list_interfaces", "list_programs", "list_rooms", "list_system_variables",
   ];
   const WRITE_TOOLS = ["acknowledge_service_messages", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -113,3 +113,68 @@ describe("MCP Server Registration", () => {
     deps.rateLimiter.destroy();
   });
 });
+
+// Issue #27: tool annotation hints drive client UX (auto-approve safe reads,
+// reason about retries). These assert the invariants, not each tool by hand.
+describe("Tool annotations", () => {
+  const READ_TOOLS = [
+    "describe_device_type", "get_paramset", "get_service_messages", "get_system_info",
+    "get_value", "get_values", "help", "list_devices", "list_functions",
+    "list_interfaces", "list_programs", "list_rooms", "list_system_variables",
+  ];
+  const WRITE_TOOLS = ["execute_program", "put_paramset", "run_script", "set_system_variable", "set_value"];
+  const IDEMPOTENT_WRITES = ["put_paramset", "set_system_variable", "set_value"];
+  const LOCAL_TOOLS = ["help"]; // everything else reaches the external CCU
+
+  type Ann = {
+    title?: string; readOnlyHint?: boolean; destructiveHint?: boolean;
+    idempotentHint?: boolean; openWorldHint?: boolean;
+  };
+  function annotationsByTool(): Record<string, Ann> {
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+    const tools = (server as any)._registeredTools as Record<string, { annotations?: Ann }>;
+    const out: Record<string, Ann> = {};
+    for (const [name, t] of Object.entries(tools)) out[name] = t.annotations ?? {};
+    deps.rateLimiter.destroy();
+    return out;
+  }
+
+  it("read tools set readOnlyHint and carry no write hints", () => {
+    const ann = annotationsByTool();
+    for (const name of READ_TOOLS) {
+      expect(ann[name].readOnlyHint, name).toBe(true);
+      expect(ann[name].destructiveHint, name).toBeUndefined();
+      expect(ann[name].idempotentHint, name).toBeUndefined();
+    }
+  });
+
+  it("write tools set destructiveHint and never readOnlyHint", () => {
+    const ann = annotationsByTool();
+    for (const name of WRITE_TOOLS) {
+      expect(ann[name].destructiveHint, name).toBe(true);
+      expect(ann[name].readOnlyHint, name).not.toBe(true);
+    }
+  });
+
+  it("idempotentHint marks only the idempotent writes", () => {
+    const ann = annotationsByTool();
+    for (const name of WRITE_TOOLS) {
+      expect(ann[name].idempotentHint ?? false, name).toBe(IDEMPOTENT_WRITES.includes(name));
+    }
+  });
+
+  it("openWorldHint is true for CCU-reaching tools, false for local help", () => {
+    const ann = annotationsByTool();
+    for (const [name, a] of Object.entries(ann)) {
+      expect(a.openWorldHint, name).toBe(!LOCAL_TOOLS.includes(name));
+    }
+  });
+
+  it("drops the redundant annotations.title (it duplicates the top-level title)", () => {
+    const ann = annotationsByTool();
+    for (const [name, a] of Object.entries(ann)) {
+      expect(a.title, name).toBeUndefined();
+    }
+  });
+});

--- a/test/unit/tools-control.test.ts
+++ b/test/unit/tools-control.test.ts
@@ -199,6 +199,27 @@ describe("create_system_variable handler", () => {
     expect(script).toContain("ivtBinary");
     expect(script).toContain("istBool");
     expect(script).toContain('sv.Name("Urlaub")');
+    // ValueUnit/DPInfo (and the verifying WriteLine) come AFTER oSysVars.Add — a
+    // CCU naming quirk renames the variable if they're set before Add.
+    expect(script.indexOf("oSysVars.Add")).toBeLessThan(script.indexOf("WriteLine(sv.Name())"));
+    cleanupDeps(deps);
+  });
+
+  it("rejects a CCU name-dedup (script echoes a suffixed name) and cleans it up", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [];        // exact name looks free…
+      if (method === "ReGa.runScript") return "Urlaub 1"; // …but the CCU deduped it
+      return null;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result: any = await callTool(server, "create_system_variable", { name: "Urlaub", type: "bool" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    // the unintended, dedup'd variable is removed
+    expect(sessionCall.mock.calls.some(
+      (c: unknown[]) => c[0] === "SysVar.deleteSysVarByName" && (c[1] as any)?.name === "Urlaub 1",
+    )).toBe(true);
     cleanupDeps(deps);
   });
 

--- a/test/unit/tools-control.test.ts
+++ b/test/unit/tools-control.test.ts
@@ -180,6 +180,105 @@ describe("set_system_variable handler", () => {
   });
 });
 
+describe("create_system_variable handler", () => {
+  const reGaScriptOf = (sessionCall: any): string => {
+    const call = sessionCall.mock.calls.find((c: unknown[]) => c[0] === "ReGa.runScript");
+    return call?.[1]?.script ?? "";
+  };
+
+  it("creates a bool variable via ReGa and reports created:true", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return []; // no existing vars
+      return null;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result = parseToolResult(await callTool(server, "create_system_variable", { name: "Urlaub", type: "bool" })) as any;
+    expect(result).toEqual({ name: "Urlaub", type: "bool", created: true });
+    const script = reGaScriptOf(sessionCall);
+    expect(script).toContain("ivtBinary");
+    expect(script).toContain("istBool");
+    expect(script).toContain('sv.Name("Urlaub")');
+    cleanupDeps(deps);
+  });
+
+  it("creates a float variable with unit/min/max", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => (method === "SysVar.getAll" ? [] : null));
+    const { server, deps } = createTestServer({ sessionCall });
+
+    await callTool(server, "create_system_variable", { name: "Soll", type: "float", unit: "°C", min: 5, max: 30 });
+    const script = reGaScriptOf(sessionCall);
+    expect(script).toContain("ivtFloat");
+    expect(script).toContain('sv.ValueUnit("°C")');
+    expect(script).toContain("sv.ValueMin(5)");
+    expect(script).toContain("sv.ValueMax(30)");
+    cleanupDeps(deps);
+  });
+
+  it("rejects an enum without values (INVALID_INPUT, before any CCU call)", async () => {
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "create_system_variable", { name: "Modus", type: "enum" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    expect(sessionCall).not.toHaveBeenCalled();
+    cleanupDeps(deps);
+  });
+
+  it("rejects a duplicate name (INVALID_INPUT)", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) =>
+      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : null);
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "create_system_variable", { name: "Urlaub", type: "bool" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    cleanupDeps(deps);
+  });
+});
+
+describe("delete_system_variable handler", () => {
+  it("deletes an existing variable via deleteSysVarByName", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) =>
+      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : null);
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result = parseToolResult(await callTool(server, "delete_system_variable", { name: "Urlaub" })) as any;
+    expect(result).toEqual({ name: "Urlaub", deleted: true });
+    expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "SysVar.deleteSysVarByName")).toBe(true);
+    cleanupDeps(deps);
+  });
+
+  it("returns NOT_FOUND for an unknown name (and never calls delete)", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => (method === "SysVar.getAll" ? [] : null));
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "delete_system_variable", { name: "Ghost" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
+    expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "SysVar.deleteSysVarByName")).toBe(false);
+    cleanupDeps(deps);
+  });
+});
+
+describe("sysvar type cache invalidation (issue #24)", () => {
+  it("create_system_variable invalidates the shared type cache so the next set re-fetches", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [{ name: "Anwesenheit", type: "BOOL" }];
+      return null;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const getAllCount = () => sessionCall.mock.calls.filter((c: unknown[]) => c[0] === "SysVar.getAll").length;
+
+    await callTool(server, "set_system_variable", { name: "Anwesenheit", value: true });  // getAll #1 (cache fill)
+    await callTool(server, "set_system_variable", { name: "Anwesenheit", value: false }); // cached → no getAll
+    expect(getAllCount()).toBe(1);
+
+    await callTool(server, "create_system_variable", { name: "Neu", type: "bool" });        // getAll #2 (dup check) + invalidate
+    await callTool(server, "set_system_variable", { name: "Anwesenheit", value: true });    // cache invalidated → getAll #3
+    expect(getAllCount()).toBe(3);
+    cleanupDeps(deps);
+  });
+});
+
 describe("execute_program handler", () => {
   const programList = [{ id: "123", name: "Morgenroutine" }];
 

--- a/test/unit/tools-control.test.ts
+++ b/test/unit/tools-control.test.ts
@@ -279,6 +279,84 @@ describe("sysvar type cache invalidation (issue #24)", () => {
   });
 });
 
+describe("assign_channel / unassign_channel handlers", () => {
+  const membershipMock = () =>
+    vi.fn().mockImplementation(async (method: string) => {
+      switch (method) {
+        case "Device.listAllDetail":
+          return [{
+            id: "1", name: "Sensor", address: "AAA", interface: "HmIP-RF", type: "x",
+            operateGroupOnly: "false", isReady: "true",
+            channels: [{ id: "ch10", name: "Kanal", address: "AAA:1", deviceId: "1", index: 1 }],
+          }];
+        case "Room.getAll":
+          return [{ id: "room5", name: "Schlafzimmer", channelIds: [] }];
+        case "Subsection.getAll":
+          return [{ id: "fn3", name: "Licht", channelIds: [] }];
+        default:
+          return true; // add/removeChannel ack
+      }
+    });
+
+  it("assigns a channel to a room by resolving names→IDs", async () => {
+    const sessionCall = membershipMock();
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result = parseToolResult(await callTool(server, "assign_channel", { channel: "AAA:1", room: "Schlafzimmer" })) as any;
+    expect(result.assignedTo).toEqual([{ kind: "room", name: "Schlafzimmer" }]);
+    const call = sessionCall.mock.calls.find((c: unknown[]) => c[0] === "Room.addChannel");
+    expect(call?.[1]).toEqual({ id: "room5", channelId: "ch10" });
+    cleanupDeps(deps);
+  });
+
+  it("assigns a channel to a function (Subsection)", async () => {
+    const sessionCall = membershipMock();
+    const { server, deps } = createTestServer({ sessionCall });
+    await callTool(server, "assign_channel", { channel: "AAA:1", function: "Licht" });
+    const call = sessionCall.mock.calls.find((c: unknown[]) => c[0] === "Subsection.addChannel");
+    expect(call?.[1]).toEqual({ id: "fn3", channelId: "ch10" });
+    cleanupDeps(deps);
+  });
+
+  it("unassign_channel uses the remove APIs", async () => {
+    const sessionCall = membershipMock();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result = parseToolResult(await callTool(server, "unassign_channel", { channel: "AAA:1", room: "Schlafzimmer" })) as any;
+    expect(result.removedFrom).toEqual([{ kind: "room", name: "Schlafzimmer" }]);
+    expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "Room.removeChannel")).toBe(true);
+    cleanupDeps(deps);
+  });
+
+  it("INVALID_INPUT when neither room nor function is given", async () => {
+    const sessionCall = membershipMock();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "assign_channel", { channel: "AAA:1" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    cleanupDeps(deps);
+  });
+
+  it("NOT_FOUND for an unknown channel address", async () => {
+    const sessionCall = membershipMock();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "assign_channel", { channel: "ZZZ:9", room: "Schlafzimmer" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
+    cleanupDeps(deps);
+  });
+
+  it("NOT_FOUND for an unknown room, with valid names in the hint", async () => {
+    const sessionCall = membershipMock();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "assign_channel", { channel: "AAA:1", room: "Nirgendwo" });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error).toBe("NOT_FOUND");
+    expect(body.hint).toContain("Schlafzimmer");
+    cleanupDeps(deps);
+  });
+});
+
 describe("execute_program handler", () => {
   const programList = [{ id: "123", name: "Morgenroutine" }];
 

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -126,17 +126,22 @@ describe("get_rssi handler", () => {
       switch (method) {
         case "Device.listAllDetail":
           return [
-            { id: "1", name: "Thermostat Büro", address: "ABC123", interface: "HmIP-RF", type: "HmIP-eTRV", channels: [] },
+            { id: "1", name: "Thermostat Büro", address: "ABC123", interface: "HmIP-RF", type: "HmIP-eTRV",
+              channels: [{ id: "10", name: "M", address: "ABC123:0", deviceId: "1", index: 0 }] },
             { id: "2", name: "Fenster Küche", address: "DEF456", interface: "BidCos-RF", type: "HM-SWDO", channels: [] },
           ];
         case "Interface.listInterfaces":
           return [{ name: "HmIP-RF" }, { name: "BidCos-RF" }, { name: "VirtualDevices" }];
         case "Interface.rssiInfo":
-          // Real JSON-RPC shape: array of {name: <addr>, partner: [{name: <addr>, rssiData: [a,b]}]}
-          if (params?.interface === "VirtualDevices") throw new Error("rssiInfo not supported");
-          if (params?.interface === "HmIP-RF") return [{ name: "ABC123", partner: [{ name: "HmIP-RF", rssiData: [-65, -70] }] }];
+          // Real JSON-RPC shape: array of {name: <addr>, partner: [{name: <addr>, rssiData: [a,b]}]}.
+          // HmIP-RF and VirtualDevices don't implement rssiInfo on a real CCU → throw.
           if (params?.interface === "BidCos-RF") return [{ name: "DEF456", partner: [{ name: "BidCoS-RF", rssiData: [65536, -80] }] }];
-          return [];
+          throw new Error("rssiInfo not supported");
+        case "Interface.getParamset":
+          // HmIP :0 maintenance channel exposes RSSI_DEVICE (dBm, negative).
+          // Raw getParamset returns STRING values (the tool coerces them).
+          if (params?.address === "ABC123:0") return { RSSI_DEVICE: "-72", UNREACH: "0" };
+          return {};
         case "Interface.listBidcosInterfaces":
           return [{ ADDRESS: "OEQ0123456", DUTY_CYCLE: 12, CONNECTED: true }];
         default:
@@ -144,17 +149,18 @@ describe("get_rssi handler", () => {
       }
     });
 
-  it("reports per-device RSSI (dBm) resolved to names, normalizing 65536 → null", async () => {
+  it("reports BidCos RSSI via rssiInfo (65536 → null) and HmIP RSSI via maintenance datapoints", async () => {
     const { server, deps } = createTestServer({ sessionCall: rssiMock() });
     const result = parseToolResult(await callTool(server, "get_rssi")) as any;
 
     const byAddr = Object.fromEntries(result.devices.map((d: any) => [d.address, d]));
-    expect(byAddr.ABC123.name).toBe("Thermostat Büro");
-    expect(byAddr.ABC123.links[0].rssiDevice).toBe(-65);
-    expect(byAddr.ABC123.links[0].rssiPeer).toBe(-70);
-    // 65536 sentinel normalized to null; the other direction kept
+    // BidCos via rssiInfo: 65536 sentinel → null, other direction kept
     expect(byAddr.DEF456.links[0].rssiDevice).toBeNull();
     expect(byAddr.DEF456.links[0].rssiPeer).toBe(-80);
+    // HmIP via RSSI_DEVICE datapoint (rssiInfo threw for HmIP-RF)
+    expect(byAddr.ABC123.name).toBe("Thermostat Büro");
+    expect(byAddr.ABC123.links[0].rssiDevice).toBe(-72);
+    expect(byAddr.ABC123.links[0].rssiPeer).toBeNull(); // no RSSI_PEER datapoint
     cleanupDeps(deps);
   });
 

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -274,3 +274,25 @@ describe("merge fallbacks (coverage round)", () => {
     cleanupDeps(deps);
   });
 });
+
+// Issue #26: structuredContent on diagnostics tools.
+describe("structured output (diagnostics)", () => {
+  it("get_system_info returns structuredContent as an object", async () => {
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockImplementation(async (method: string) => (method === "CCU.getVersion" ? "3.85.7" : null)),
+    });
+    const res = await callTool(server, "get_system_info") as any;
+    expect(res.structuredContent).toBeTypeOf("object");
+    expect(res.structuredContent.version).toBe("3.85.7");
+    cleanupDeps(deps);
+  });
+
+  it("get_service_messages wraps alarms under structuredContent.messages", async () => {
+    const mock = JSON.stringify({ alarms: [{ id: "1", type: "LOWBAT", address: "ABC:0", timestamp: "t" }], channelNames: {} });
+    const { server, deps } = createTestServer({ sessionCall: vi.fn().mockResolvedValue(mock) });
+    const res = await callTool(server, "get_service_messages") as any;
+    expect(Array.isArray(res.structuredContent.messages)).toBe(true);
+    expect(res.structuredContent.messages[0].type).toBe("LOWBAT");
+    cleanupDeps(deps);
+  });
+});

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -120,6 +120,79 @@ describe("acknowledge_service_messages handler", () => {
   });
 });
 
+describe("get_rssi handler", () => {
+  const rssiMock = () =>
+    vi.fn().mockImplementation(async (method: string, params?: any) => {
+      switch (method) {
+        case "Device.listAllDetail":
+          return [
+            { id: "1", name: "Thermostat Büro", address: "ABC123", interface: "HmIP-RF", type: "HmIP-eTRV", channels: [] },
+            { id: "2", name: "Fenster Küche", address: "DEF456", interface: "BidCos-RF", type: "HM-SWDO", channels: [] },
+          ];
+        case "Interface.listInterfaces":
+          return [{ name: "HmIP-RF" }, { name: "BidCos-RF" }, { name: "VirtualDevices" }];
+        case "Interface.rssiInfo":
+          if (params?.interface === "VirtualDevices") throw new Error("rssiInfo not supported");
+          if (params?.interface === "HmIP-RF") return { ABC123: { "HmIP-RF": [-65, -70] } };
+          if (params?.interface === "BidCos-RF") return { DEF456: { "BidCoS-RF": [65536, -80] } };
+          return {};
+        case "Interface.listBidcosInterfaces":
+          return [{ ADDRESS: "OEQ0123456", DUTY_CYCLE: 12, CONNECTED: true }];
+        default:
+          return null;
+      }
+    });
+
+  it("reports per-device RSSI (dBm) resolved to names, normalizing 65536 → null", async () => {
+    const { server, deps } = createTestServer({ sessionCall: rssiMock() });
+    const result = parseToolResult(await callTool(server, "get_rssi")) as any;
+
+    const byAddr = Object.fromEntries(result.devices.map((d: any) => [d.address, d]));
+    expect(byAddr.ABC123.name).toBe("Thermostat Büro");
+    expect(byAddr.ABC123.links[0].rssiDevice).toBe(-65);
+    expect(byAddr.ABC123.links[0].rssiPeer).toBe(-70);
+    // 65536 sentinel normalized to null; the other direction kept
+    expect(byAddr.DEF456.links[0].rssiDevice).toBeNull();
+    expect(byAddr.DEF456.links[0].rssiPeer).toBe(-80);
+    cleanupDeps(deps);
+  });
+
+  it("includes BidCos interface health (duty cycle, connected)", async () => {
+    const { server, deps } = createTestServer({ sessionCall: rssiMock() });
+    const result = parseToolResult(await callTool(server, "get_rssi")) as any;
+    expect(result.interfaces[0].DUTY_CYCLE).toBe(12);
+    expect(result.interfaces[0].CONNECTED).toBe(true);
+    cleanupDeps(deps);
+  });
+
+  it("filters by device name/address substring", async () => {
+    const { server, deps } = createTestServer({ sessionCall: rssiMock() });
+    const result = parseToolResult(await callTool(server, "get_rssi", { name: "küche" })) as any;
+    expect(result.devices).toHaveLength(1);
+    expect(result.devices[0].address).toBe("DEF456");
+    cleanupDeps(deps);
+  });
+
+  it("tolerates interfaces that don't support rssiInfo (e.g. VirtualDevices)", async () => {
+    const { server, deps } = createTestServer({ sessionCall: rssiMock() });
+    const result = parseToolResult(await callTool(server, "get_rssi")) as any;
+    expect(result.devices).toHaveLength(2); // both RF devices present despite VirtualDevices throwing
+    cleanupDeps(deps);
+  });
+
+  it("tolerates listBidcosInterfaces failure (returns empty interfaces)", async () => {
+    const base = rssiMock().getMockImplementation()!;
+    const sessionCall = vi.fn().mockImplementation(async (method: string, params?: any) => {
+      if (method === "Interface.listBidcosInterfaces") throw new Error("unsupported");
+      return base(method, params);
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const result = parseToolResult(await callTool(server, "get_rssi")) as any;
+    expect(result.interfaces).toEqual([]);
+    cleanupDeps(deps);
+  });
+});
+
 describe("get_system_info handler", () => {
   it("returns all system info fields", async () => {
     const { server, deps } = createTestServer({

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -132,10 +132,11 @@ describe("get_rssi handler", () => {
         case "Interface.listInterfaces":
           return [{ name: "HmIP-RF" }, { name: "BidCos-RF" }, { name: "VirtualDevices" }];
         case "Interface.rssiInfo":
+          // Real JSON-RPC shape: array of {name: <addr>, partner: [{name: <addr>, rssiData: [a,b]}]}
           if (params?.interface === "VirtualDevices") throw new Error("rssiInfo not supported");
-          if (params?.interface === "HmIP-RF") return { ABC123: { "HmIP-RF": [-65, -70] } };
-          if (params?.interface === "BidCos-RF") return { DEF456: { "BidCoS-RF": [65536, -80] } };
-          return {};
+          if (params?.interface === "HmIP-RF") return [{ name: "ABC123", partner: [{ name: "HmIP-RF", rssiData: [-65, -70] }] }];
+          if (params?.interface === "BidCos-RF") return [{ name: "DEF456", partner: [{ name: "BidCoS-RF", rssiData: [65536, -80] }] }];
+          return [];
         case "Interface.listBidcosInterfaces":
           return [{ ADDRESS: "OEQ0123456", DUTY_CYCLE: 12, CONNECTED: true }];
         default:

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -58,6 +58,68 @@ describe("get_service_messages handler", () => {
   });
 });
 
+describe("acknowledge_service_messages handler", () => {
+  it("confirms a single alarm by id and reports what was confirmed", async () => {
+    const mock = JSON.stringify({ confirmed: [{ id: "4711", type: "LOWBAT", address: "ABC:0" }] });
+    const sessionCall = vi.fn().mockResolvedValue(mock);
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result = parseToolResult(await callTool(server, "acknowledge_service_messages", { id: "4711" })) as any;
+    expect(result.count).toBe(1);
+    expect(result.confirmed[0].id).toBe("4711");
+    cleanupDeps(deps);
+  });
+
+  it("confirms all active messages on a channel address", async () => {
+    const mock = JSON.stringify({
+      confirmed: [
+        { id: "1", type: "LOWBAT", address: "ABC:0" },
+        { id: "2", type: "UNREACH", address: "ABC:0" },
+      ],
+    });
+    const { server, deps } = createTestServer({ sessionCall: vi.fn().mockResolvedValue(mock) });
+
+    const result = parseToolResult(await callTool(server, "acknowledge_service_messages", { address: "ABC:0" })) as any;
+    expect(result.count).toBe(2);
+    cleanupDeps(deps);
+  });
+
+  it("returns INVALID_INPUT when neither id nor address is given", async () => {
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result: any = await callTool(server, "acknowledge_service_messages", {});
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    expect(sessionCall).not.toHaveBeenCalled(); // validated before touching the CCU
+    cleanupDeps(deps);
+  });
+
+  it("returns NOT_FOUND when nothing matched (no active alarm for that id/address)", async () => {
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockResolvedValue(JSON.stringify({ confirmed: [] })),
+    });
+
+    const result: any = await callTool(server, "acknowledge_service_messages", { id: "9999" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
+    cleanupDeps(deps);
+  });
+
+  it("generates a script that confirms (AlConfirm) and escapes the requested id/address", async () => {
+    const sessionCall = vi.fn().mockResolvedValue(JSON.stringify({ confirmed: [{ id: "1", type: "x", address: 'A":0' }] }));
+    const { server, deps } = createTestServer({ sessionCall });
+
+    await callTool(server, "acknowledge_service_messages", { address: 'A":0' });
+    const script = sessionCall.mock.calls[0][1].script as string;
+    expect(script).toContain("AlConfirm()");
+    expect(script).toContain("OT_ALARMDP");
+    // the embedded address literal is escaped (quote -> \")
+    expect(script).toContain('string wantAddr = "A\\":0";');
+    cleanupDeps(deps);
+  });
+});
+
 describe("get_system_info handler", () => {
   it("returns all system info fields", async () => {
     const { server, deps } = createTestServer({

--- a/test/unit/tools-discovery.test.ts
+++ b/test/unit/tools-discovery.test.ts
@@ -230,8 +230,9 @@ describe("list_links handler", () => {
         case "Interface.listInterfaces":
           return [{ name: "HmIP-RF" }, { name: "VirtualDevices" }];
         case "Interface.getLinks":
+          // Real JSON-RPC shape: lowercase fields (occu .../interface/getlinks.tcl)
           if (params?.interface === "VirtualDevices") throw new Error("getLinks not supported");
-          return [{ SENDER: "AAA:1", RECEIVER: "BBB:3", NAME: "Taster→Licht", DESCRIPTION: "", FLAGS: 0 }];
+          return [{ sender: "AAA:1", receiver: "BBB:3", name: "Taster→Licht", description: "", flags: 0 }];
         default:
           return null;
       }

--- a/test/unit/tools-discovery.test.ts
+++ b/test/unit/tools-discovery.test.ts
@@ -269,3 +269,18 @@ describe("list_links handler", () => {
     cleanupDeps(deps);
   });
 });
+
+// Issue #26: list tools wrap their array under a named structuredContent key,
+// while the text block stays the bare array (backwards-compatible).
+describe("structured output (discovery)", () => {
+  it("list_devices exposes structuredContent.devices and a bare-array text block", async () => {
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockImplementation(async (method: string) => (method === "Device.listAllDetail" ? mockDevices : [])),
+    });
+    const res = await callTool(server, "list_devices") as any;
+    expect(Array.isArray(res.structuredContent.devices)).toBe(true);
+    expect(res.structuredContent.devices.length).toBeGreaterThan(0);
+    expect(Array.isArray(parseToolResult(res))).toBe(true); // text remains the bare array
+    cleanupDeps(deps);
+  });
+});

--- a/test/unit/tools-discovery.test.ts
+++ b/test/unit/tools-discovery.test.ts
@@ -215,3 +215,56 @@ describe("list_devices error path (coverage round)", () => {
     cleanupDeps(deps);
   });
 });
+
+describe("list_links handler", () => {
+  const linksMock = () =>
+    vi.fn().mockImplementation(async (method: string, params?: any) => {
+      switch (method) {
+        case "Device.listAllDetail":
+          return [
+            { id: "1", name: "Wandtaster", address: "AAA", interface: "HmIP-RF", type: "x", operateGroupOnly: "false", isReady: "true",
+              channels: [{ id: "11", name: "Taste Oben", address: "AAA:1", deviceId: "1", index: 1 }] },
+            { id: "2", name: "Deckenlampe", address: "BBB", interface: "HmIP-RF", type: "y", operateGroupOnly: "false", isReady: "true",
+              channels: [{ id: "21", name: "Licht", address: "BBB:3", deviceId: "2", index: 3 }] },
+          ];
+        case "Interface.listInterfaces":
+          return [{ name: "HmIP-RF" }, { name: "VirtualDevices" }];
+        case "Interface.getLinks":
+          if (params?.interface === "VirtualDevices") throw new Error("getLinks not supported");
+          return [{ SENDER: "AAA:1", RECEIVER: "BBB:3", NAME: "Taster→Licht", DESCRIPTION: "", FLAGS: 0 }];
+        default:
+          return null;
+      }
+    });
+
+  it("lists links with sender/receiver channel names resolved", async () => {
+    const { server, deps } = createTestServer({ sessionCall: linksMock() });
+    const result = parseToolResult(await callTool(server, "list_links")) as any[];
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sender).toBe("AAA:1");
+    expect(result[0].senderName).toBe("Taste Oben");
+    expect(result[0].receiver).toBe("BBB:3");
+    expect(result[0].receiverName).toBe("Licht");
+    expect(result[0].interface).toBe("HmIP-RF");
+    cleanupDeps(deps);
+  });
+
+  it("filters by device address (matches either endpoint)", async () => {
+    const { server, deps } = createTestServer({ sessionCall: linksMock() });
+    const hit = parseToolResult(await callTool(server, "list_links", { address: "BBB" })) as any[];
+    expect(hit).toHaveLength(1);
+
+    const miss = parseToolResult(await callTool(server, "list_links", { address: "ZZZ" })) as any[];
+    expect(miss).toHaveLength(0);
+    cleanupDeps(deps);
+  });
+
+  it("tolerates interfaces that don't support getLinks", async () => {
+    const { server, deps } = createTestServer({ sessionCall: linksMock() });
+    // VirtualDevices.getLinks throws; the HmIP-RF link still comes back
+    const result = parseToolResult(await callTool(server, "list_links")) as any[];
+    expect(result).toHaveLength(1);
+    cleanupDeps(deps);
+  });
+});

--- a/test/unit/tools-read.test.ts
+++ b/test/unit/tools-read.test.ts
@@ -176,3 +176,34 @@ describe("error and edge paths (coverage round)", () => {
     cleanupDeps(deps);
   });
 });
+
+// Issue #26: tools expose structuredContent alongside the text block.
+describe("structured output (read tools)", () => {
+  it("get_value returns structuredContent matching the object", async () => {
+    const { server, deps } = createTestServer({ sessionCall: vi.fn().mockResolvedValue(21.5) });
+    deps.resolver.updateDeviceList([{ id: "1", name: "Dev", address: "AAA", interface: "HmIP-RF", type: "T", operateGroupOnly: "false", isReady: "true", channels: [] }] as any);
+    const res = await callTool(server, "get_value", { address: "AAA:1", valueKey: "ACTUAL_TEMPERATURE" }) as any;
+    expect(res.structuredContent).toEqual({ address: "AAA:1", valueKey: "ACTUAL_TEMPERATURE", value: 21.5 });
+    cleanupDeps(deps);
+  });
+
+  it("get_values wraps the array under structuredContent.values (text stays the bare array)", async () => {
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockResolvedValue([{ address: "AAA:1", datapoints: {} }]),
+    });
+    const res = await callTool(server, "get_values", { channels: ["AAA:1"] }) as any;
+    expect(res.structuredContent).toEqual({ values: [{ address: "AAA:1", datapoints: {} }] });
+    expect(parseToolResult(res)).toEqual([{ address: "AAA:1", datapoints: {} }]); // backwards-compatible text
+    cleanupDeps(deps);
+  });
+
+  it("get_paramset returns structuredContent with address/paramsetKey/params", async () => {
+    const { server, deps } = createTestServer({ sessionCall: vi.fn().mockResolvedValue({ TEMP: "21" }) });
+    deps.resolver.updateDeviceList([{ id: "1", name: "Dev", address: "AAA", interface: "HmIP-RF", type: "T", operateGroupOnly: "false", isReady: "true", channels: [] }] as any);
+    const res = await callTool(server, "get_paramset", { address: "AAA:1", paramsetKey: "VALUES" }) as any;
+    expect(res.structuredContent.address).toBe("AAA:1");
+    expect(res.structuredContent.paramsetKey).toBe("VALUES");
+    expect(res.structuredContent.params).toBeDefined();
+    cleanupDeps(deps);
+  });
+});

--- a/test/unit/version-sync.test.ts
+++ b/test/unit/version-sync.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+const CHECK = join(root, "scripts/check-version-sync.mjs");
+const SYNC = join(root, "scripts/sync-server-version.mjs");
+
+const PKG = (version: string, mcpName = "io.github.x/y") =>
+  JSON.stringify({ name: "y", version, mcpName });
+
+const SERVER = (version: string, pkgVersion = version, name = "io.github.x/y") =>
+  JSON.stringify({
+    $schema: "https://example/server.schema.json",
+    name,
+    version,
+    packages: [{ registryType: "npm", identifier: "y", version: pkgVersion }],
+  });
+
+describe("check-version-sync gate", () => {
+  let dir: string;
+  let pkgFile: string;
+  let serverFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vsync-"));
+    pkgFile = join(dir, "package.json");
+    serverFile = join(dir, "server.json");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const run = (script: string) =>
+    execFileSync("node", [script], {
+      env: { ...process.env, PKG_FILE: pkgFile, SERVER_FILE: serverFile },
+      encoding: "utf8",
+    });
+
+  const runCheck = (): { code: number; out: string } => {
+    try {
+      return { code: 0, out: run(CHECK) };
+    } catch (e: any) {
+      return { code: e.status ?? 1, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+    }
+  };
+
+  it("passes (exit 0) when all three versions and identity agree", () => {
+    writeFileSync(pkgFile, PKG("1.3.0"));
+    writeFileSync(serverFile, SERVER("1.3.0"));
+    const { code, out } = runCheck();
+    expect(code).toBe(0);
+    expect(out).toContain("Versions in sync.");
+  });
+
+  it("fails (exit 1) when server.json root version drifts", () => {
+    writeFileSync(pkgFile, PKG("1.3.0"));
+    writeFileSync(serverFile, SERVER("1.2.0", "1.3.0"));
+    const { code, out } = runCheck();
+    expect(code).toBe(1);
+    expect(out).toContain("drift");
+  });
+
+  it("fails (exit 1) when packages[].version drifts", () => {
+    writeFileSync(pkgFile, PKG("1.3.0"));
+    writeFileSync(serverFile, SERVER("1.3.0", "1.2.0"));
+    const { code } = runCheck();
+    expect(code).toBe(1);
+  });
+
+  it("fails (exit 1) when mcpName != server name", () => {
+    writeFileSync(pkgFile, PKG("1.3.0", "io.github.x/wrong"));
+    writeFileSync(serverFile, SERVER("1.3.0"));
+    const { code } = runCheck();
+    expect(code).toBe(1);
+  });
+
+  it("sync-server-version brings a drifted server.json back into sync", () => {
+    writeFileSync(pkgFile, PKG("1.3.0"));
+    writeFileSync(serverFile, SERVER("1.2.0", "1.2.0"));
+    run(SYNC);
+    const synced = JSON.parse(readFileSync(serverFile, "utf8"));
+    expect(synced.version).toBe("1.3.0");
+    expect(synced.packages[0].version).toBe("1.3.0");
+    expect(runCheck().code).toBe(0);
+  });
+});
+
+describe("live repo manifest", () => {
+  it("package.json and server.json are in sync (the gate, live)", () => {
+    // Belt-and-suspenders: `npm test` itself goes red if the real files drift,
+    // not just the dedicated CI step.
+    const code = (() => {
+      try {
+        execFileSync("node", [CHECK], { cwd: root, encoding: "utf8" });
+        return 0;
+      } catch (e: any) {
+        return e.status ?? 1;
+      }
+    })();
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
Release **v1.3.0** — promotes `dev` to `main`.

This is the first release using the `release-title` gate and the required `build-and-test` check on `main`.

## Highlights since v1.2.0
- **Structured tool output** (`outputSchema` + `structuredContent`) (#26)
- **MCP transport over TLS** — opt-in native HTTPS, plaintext stays the zero-config default (#50)
- **CCU TLS certificate verification** — fingerprint pin or CA PEM (#51), plus the session-resumption fix (#56)
- **Auth token expiry & rotation** — TTL + grace overlap, timing-safe across the rotation set (#52)
- **Node 24** runtime/CI/Docker bump (#54)
- **Exhaustive `.env.example`** with a drift-guard test (#57)
- **CI/process hardening** — `main` now requires `build-and-test` + a `Release vX.Y.Z` title gate

## Merged PRs in this release
- #60
- #59
- #58
- #57
- #56
- #55
- #54
- #53
- #48
- #47
- #45
- #44
- #43
- #41
- #40
- #38
- #39
- #35
- #32

## Post-merge
- Tag `v1.3.0` on `main` and push it.
- Fast-forward `dev` back to `main`.

Versions synced to 1.3.0 (`package.json`, `package-lock.json`, `server.json`); `check:versions` green.