### PR TITLE
fix(deps): bump undici to ^8.5.0 (high-severity advisory)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "undici": "^8.4.1",
+        "undici": "^8.5.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -23,7 +23,7 @@
         "vitest": "^4.1.8"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2419,9 +2419,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.4.1.tgz",
-      "integrity": "sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "homepage": "https://github.com/claymore666/debmatic-mcp#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "undici": "^8.4.1",
+    "undici": "^8.5.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## What
Bump `undici` from 8.4.1 → ^8.5.0.

## Why
`undici@8.4.1` is flagged **high** by `npm audit`:
- [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g) — TLS certificate validation bypass via dropped `requestTls` in SOCKS5 ProxyAgent
- [GHSA-pr7r-676h-xcf6](https://github.com/advisories/GHSA-pr7r-676h-xcf6) — cross-user info disclosure via shared-cache whitespace bypass
- [GHSA-38rv-x7px-6hhq](https://github.com/advisories/GHSA-38rv-x7px-6hhq) — WebSocket DoS via cumulative fragment bypass

`undici` is the CCU HTTP client. CI runs `npm audit --audit-level=high`, so this also unblocks CI.

## Verification
- `npm audit --audit-level=high` → 0 vulnerabilities
- `npm run lint` clean
- `npm test` → 310 passed, 25 skipped (live-CCU gated)