### PR TITLE
feat(auth): structured auth-failure log + fail2ban config (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ The HTTP transport also has **DNS-rebinding protection** on by default: it rejec
 - *Auto-generated token* — set `MCP_AUTH_TOKEN_TTL_DAYS` (fractional days allowed) to give the generated token a lifetime. Once it lapses, the server mints a fresh one **on the next startup** and prints it on stderr, while the just-replaced token keeps validating for `MCP_AUTH_TOKEN_GRACE_HOURS` (default 24) so in-flight clients survive the swap. Expiry is also enforced live: a lapsed token is rejected mid-run with a `401` + `WWW-Authenticate: Bearer … error="invalid_token"`. To force a rotation sooner, delete `$CACHE_DIR/.env` (or just its `MCP_AUTH_TOKEN` line) and restart.
 - *Explicit token* — when you set `MCP_AUTH_TOKEN` yourself, you own its lifetime (TTL doesn't apply). To rotate, put the new token in `MCP_AUTH_TOKEN`, move the old one to `MCP_AUTH_TOKEN_PREVIOUS`, and restart; both are accepted during the overlap. Drop `MCP_AUTH_TOKEN_PREVIOUS` and restart once every client is on the new token. Comparison stays timing-safe across every currently-valid token.
 
+**Brute-force protection (fail2ban).** The auto-generated token is 256 bits of randomness, so guessing it is infeasible. If you set `MCP_AUTH_TOKEN` yourself, **make it long and random** (e.g. `openssl rand -base64 32`) — a short or guessable token is the one case brute force matters. The server does **not** rate-limit or lock out failed logins in-process; that job belongs to a firewall-level tool like [fail2ban](https://www.fail2ban.org/), which bans the source IP before the request ever reaches the server. To make that easy, every rejected request logs a structured line to stderr:
+
+```json
+{"ts":"2026-06-18T17:28:00.370Z","level":"warn","msg":"auth_failed","client":"203.0.113.7","hadToken":true}
+```
+
+Ready-to-use fail2ban config ships in [`fail2ban/`](fail2ban/): copy `filter.d/debmatic-mcp.conf` to `/etc/fail2ban/filter.d/` and the jail in `jail.d/debmatic-mcp.local` to `/etc/fail2ban/jail.d/` (it defaults to 5 failures in 10 minutes → 1-hour ban). The server logs to stderr, so point fail2ban at wherever you collect it — the journal (`backend = systemd`) when run as a unit, or a file when you redirect stderr/`docker logs`; both are spelled out in the jail file. Requires `LOG_LEVEL=warn` or lower (`info`, the default, is fine; `error` suppresses the line). Behind a reverse proxy the logged IP is the proxy's, so run fail2ban against the proxy's access log instead.
+
 CORS support was first implemented by [@marcinn2](https://github.com/marcinn2) in his fork [marcinn2/debmatic-mcp](https://github.com/marcinn2/debmatic-mcp) — thanks!
 
 ### HTTPS

--- a/fail2ban/filter.d/debmatic-mcp.conf
+++ b/fail2ban/filter.d/debmatic-mcp.conf
@@ -1,0 +1,23 @@
+# Fail2Ban filter for debmatic-mcp HTTP-transport bearer-auth failures.
+#
+# The server logs one structured JSON line to stderr on every rejected MCP
+# request, e.g.:
+#   {"ts":"2026-06-18T17:28:00.370Z","level":"warn","msg":"auth_failed","client":"203.0.113.7","hadToken":true}
+#
+# The ISO-8601 "ts" field is recognized by Fail2Ban's built-in date detection,
+# so no explicit datepattern is needed. (Requires LOG_LEVEL=warn or lower —
+# "info", the default, is fine; "error" suppresses the line.)
+#
+# Install: copy to /etc/fail2ban/filter.d/debmatic-mcp.conf
+
+[Definition]
+
+# Bans any rejected request (bad token OR no credentials at all).
+failregex = "msg":"auth_failed","client":"<HOST>"
+
+# Stricter alternative — ban only attempts that presented a (wrong) token,
+# ignoring unauthenticated probes that send no credentials. Comment out the
+# line above and uncomment this one to use it:
+#failregex = "msg":"auth_failed","client":"<HOST>","hadToken":true
+
+ignoreregex =

--- a/fail2ban/jail.d/debmatic-mcp.local
+++ b/fail2ban/jail.d/debmatic-mcp.local
@@ -1,0 +1,32 @@
+# Example Fail2Ban jail for debmatic-mcp. Copy to
+# /etc/fail2ban/jail.d/debmatic-mcp.local, adjust to your deployment, then
+# `systemctl reload fail2ban`. Check it with `fail2ban-client status debmatic-mcp`.
+#
+# The server writes its JSON logs to STDERR, so point Fail2Ban at wherever you
+# collect them. Pick ONE of the two backends below.
+
+[debmatic-mcp]
+enabled  = true
+filter   = debmatic-mcp
+
+# Ban the IP on the MCP port (match your MCP_PORT). Use a single number, or
+# drop this line to ban on all ports.
+port     = 3000
+
+maxretry = 5
+findtime = 10m
+bantime  = 1h
+
+# ── Backend A: systemd/journald ─────────────────────────────────────────────
+# Use when the server runs as a systemd unit (stderr → the journal). Set
+# journalmatch to your unit name.
+backend      = systemd
+journalmatch = _SYSTEMD_UNIT=debmatic-mcp.service
+
+# ── Backend B: a log file ───────────────────────────────────────────────────
+# Use instead of the two systemd lines above when you redirect the server's
+# stderr to a file (systemd `StandardError=append:`, a Docker logging driver,
+# or `docker logs debmatic-mcp >> /var/log/debmatic-mcp.log`). Comment out
+# `backend`/`journalmatch` above and uncomment:
+#backend = auto
+#logpath = /var/log/debmatic-mcp.log

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { ResourcePoller } from "./resources/poller.js";
 import { resolveAuthTokens } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
 import { createMcpServer } from "./server.js";
-import { extractBearerToken } from "./utils.js";
+import { extractBearerToken, normalizeClientIp } from "./utils.js";
 
 async function main(): Promise<void> {
   const logger = createLogger();
@@ -147,6 +147,16 @@ async function main(): Promise<void> {
         const presented = extractBearerToken(req.headers.authorization ?? "");
         const headerValid = authTokens.verify(presented);
         if (!headerValid) {
+          // Structured, greppable failure line so an external tool (fail2ban et
+          // al.) can ban brute-force sources at the firewall — the server
+          // deliberately does NOT throttle in-process (that belongs upstream;
+          // see README "Brute-force protection"). `client` is the peer IP
+          // (fail2ban's <HOST>); `hadToken` lets a filter ignore credential-less
+          // probes and ban only actual bad-token guesses.
+          logger.warn("auth_failed", {
+            client: normalizeClientIp(req.socket.remoteAddress),
+            hadToken: Boolean(presented),
+          });
           // Challenge header so clients can discover the scheme (RFC 6750 /
           // MCP auth spec). Add error=invalid_token only when a (bad) token was
           // actually presented; RFC 6750 §3 omits the error param when no

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,18 @@ export function extractBearerToken(authHeader: string): string {
   return authHeader.match(/^Bearer\s+(\S.*)$/i)?.[1] ?? "";
 }
 
+/**
+ * Normalize a socket's remote address into a plain client IP for logging.
+ * Strips the IPv6-mapped-IPv4 prefix (`::ffff:127.0.0.1` → `127.0.0.1`) so the
+ * value matches what fail2ban's `<HOST>` expects, and never returns undefined —
+ * an unknown peer logs as the literal "unknown" (which no IP-based fail2ban
+ * rule matches, so it's safely ignored).
+ */
+export function normalizeClientIp(remoteAddress: string | undefined): string {
+  if (!remoteAddress) return "unknown";
+  return remoteAddress.startsWith("::ffff:") ? remoteAddress.slice("::ffff:".length) : remoteAddress;
+}
+
 /** Format a tool result as MCP text content. */
 export function toolResult(data: unknown) {
   return { content: [{ type: "text" as const, text: typeof data === "string" ? data : JSON.stringify(data, null, 2) }] };

--- a/test/unit/fail2ban-filter.test.ts
+++ b/test/unit/fail2ban-filter.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Logger } from "../../src/logger.js";
+import { normalizeClientIp } from "../../src/utils.js";
+
+// Locks the contract between the auth-failure log line the server emits and the
+// committed fail2ban filter. If either the log shape (src/index.ts) or the
+// filter regex (fail2ban/filter.d/debmatic-mcp.conf) drifts, this fails — so a
+// shipped filter can't silently stop matching real log lines.
+
+const FILTER = join(__dirname, "../../fail2ban/filter.d/debmatic-mcp.conf");
+
+/** The exact line the server writes on a rejected request (mirrors src/index.ts). */
+function authFailedLine(client: string, hadToken: boolean): string {
+  const logger = new Logger("warn");
+  const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  try {
+    logger.warn("auth_failed", { client: normalizeClientIp(client), hadToken });
+    return (spy.mock.calls[0]![0] as string).trim();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+/** Read a `failregex`/`#failregex` value from the filter and make it a JS RegExp. */
+function failRegex(commented: boolean): RegExp {
+  const text = readFileSync(FILTER, "utf-8");
+  const re = commented ? /^#failregex\s*=\s*(.+)$/m : /^failregex\s*=\s*(.+)$/m;
+  const pattern = text.match(re)?.[1];
+  expect(pattern, "filter must define a failregex").toBeTruthy();
+  // fail2ban's <HOST> placeholder → a capturing IPv4/IPv6 group for the test.
+  return new RegExp(pattern!.replace("<HOST>", "([0-9a-fA-F:.]+)"));
+}
+
+describe("fail2ban filter", () => {
+  it("defines exactly one active (uncommented) failregex", () => {
+    const active = readFileSync(FILTER, "utf-8")
+      .split("\n")
+      .filter((l) => /^failregex\s*=/.test(l));
+    expect(active).toHaveLength(1);
+  });
+
+  it("matches the real auth_failed line and captures the client IP", () => {
+    const line = authFailedLine("203.0.113.7", true);
+    const m = line.match(failRegex(false));
+    expect(m, `filter did not match: ${line}`).not.toBeNull();
+    expect(m![1]).toBe("203.0.113.7");
+  });
+
+  it("captures the bare IPv4 from an IPv6-mapped peer address", () => {
+    const line = authFailedLine("::ffff:198.51.100.9", false);
+    const m = line.match(failRegex(false));
+    expect(m).not.toBeNull();
+    expect(m![1]).toBe("198.51.100.9");
+  });
+
+  it("active rule bans both bad-token and no-credential attempts", () => {
+    const re = failRegex(false);
+    expect(authFailedLine("203.0.113.7", true)).toMatch(re);
+    expect(authFailedLine("203.0.113.7", false)).toMatch(re);
+  });
+
+  it("the stricter (commented) rule matches a bad token but not a credential-less probe", () => {
+    const strict = failRegex(true);
+    expect(authFailedLine("203.0.113.7", true)).toMatch(strict);
+    expect(authFailedLine("203.0.113.7", false)).not.toMatch(strict);
+  });
+});

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { escapeHmScript, parseValue, parseValues } from "../../src/utils.js";
+import { escapeHmScript, parseValue, parseValues, normalizeClientIp } from "../../src/utils.js";
+
+describe("normalizeClientIp", () => {
+  it("passes through a plain IPv4 / IPv6 address", () => {
+    expect(normalizeClientIp("203.0.113.7")).toBe("203.0.113.7");
+    expect(normalizeClientIp("2001:db8::1")).toBe("2001:db8::1");
+  });
+
+  it("strips the IPv6-mapped-IPv4 prefix so fail2ban sees the bare IPv4", () => {
+    expect(normalizeClientIp("::ffff:127.0.0.1")).toBe("127.0.0.1");
+    expect(normalizeClientIp("::ffff:203.0.113.7")).toBe("203.0.113.7");
+  });
+
+  it("returns 'unknown' for a missing address (no IP-based rule will match it)", () => {
+    expect(normalizeClientIp(undefined)).toBe("unknown");
+    expect(normalizeClientIp("")).toBe("unknown");
+  });
+});
 
 describe("escapeHmScript", () => {
   // Escape semantics verified against a live CCU (issue #16):


### PR DESCRIPTION
Closes #63.

## Approach
After discussion, #63 is resolved at the **firewall level (fail2ban)** rather than with in-process throttling. fail2ban bans the source IP *before* the request reaches Node and avoids the baggage of an app-level limiter — unbounded per-IP state, `X-Forwarded-For` spoofing, and shared-proxy self-lockout. The app's job is just to give fail2ban something to match.

## Changes
- **`src/index.ts`** — every rejected HTTP request now logs a structured warn line:
  ```json
  {"ts":"…","level":"warn","msg":"auth_failed","client":"203.0.113.7","hadToken":true}
  ```
  `client` is the peer IP (fail2ban's `<HOST>`); `hadToken` lets a filter ban only bad-token guesses vs. credential-less probes.
- **`src/utils.ts`** — `normalizeClientIp()` strips the `::ffff:` IPv6-mapped prefix so the logged IP matches `<HOST>`.
- **`fail2ban/`** — ready-to-use `filter.d/debmatic-mcp.conf` + `jail.d/debmatic-mcp.local` (systemd **and** logfile backends; default 5 fails / 10 min → 1 h ban).
- **README** — brute-force section + minimum-entropy guidance for operator-set `MCP_AUTH_TOKEN`.
- **Tests** — `normalizeClientIp` unit tests, plus a contract test that pins the committed filter regex to the *real* logger output so the log shape and filter can't silently drift.

No new env vars (env-example-sync test stays green). No in-process throttle.

## Verification
- `npm run lint` clean
- `npm test` → 318 passed, 25 skipped (+8 new)
- Live-checked the built server: bad-token and no-token requests both emit the line with the correct `hadToken`.

## Note
CI's `npm audit --audit-level=high` will fail on this branch until #62 (undici bump) lands in `dev` — same base, unrelated to this change.