### PR TITLE
chore(release): v1.5.0 version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.4.0",
+  "version": "1.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Bumps version `1.4.0 → 1.5.0` for the **ccu-mcp** rename release (package.json + server.json ×2, in sync). No code changes beyond the version.

Pre-flight on this branch:
- `npm run lint` clean
- `npm test` → 318 passed / 25 skipped
- `npm publish --dry-run` → `ccu-mcp@1.5.0` (80 kB, dist+README+LICENSE)
- `mcp-publisher validate` → ✅

Part of the v1.5.0 release; the `dev → main` "Release v1.5.0" PR follows once this lands.