### PR TITLE
Release v1.5.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,9 @@
 # Only CCU_HOST and CCU_PASSWORD are required; everything else is optional.
 
 # ─── CCU connection (required) ──────────────────────────────────────────────
-# Hostname or IP of your CCU / debmatic box.
-CCU_HOST=debmatic
+# Hostname or IP of your CCU — set this to your own box (e.g. a hostname like
+# homematic-ccu3 or an IP like 192.168.1.50). Required; there is no default.
+CCU_HOST=your-ccu-hostname-or-ip
 # CCU admin password.
 CCU_PASSWORD=
 

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# debmatic-mcp configuration — copy to .env and adjust.
+# ccu-mcp configuration — copy to .env and adjust.
 # All settings are environment variables; values shown are the defaults.
 # Only CCU_HOST and CCU_PASSWORD are required; everything else is optional.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# debmatic-mcp
+# ccu-mcp
 
 Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
 
-<a href="https://glama.ai/mcp/servers/claymore666/debmatic-mcp">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/claymore666/debmatic-mcp/badge" alt="debmatic-mcp MCP server" />
+<a href="https://glama.ai/mcp/servers/claymore666/ccu-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/claymore666/ccu-mcp/badge" alt="ccu-mcp MCP server" />
 </a>
 
-debmatic-mcp connects to the CCU's built-in JSON-RPC API and exposes your devices, rooms, programs, and system variables as MCP tools. No addons, no XML-API, no cloud — just a direct connection to the CCU on your local network.
+ccu-mcp connects to the CCU's built-in JSON-RPC API and exposes your devices, rooms, programs, and system variables as MCP tools. No addons, no XML-API, no cloud — just a direct connection to the CCU on your local network.
 
-Built for [debmatic](https://github.com/alexreinert/debmatic) (HomeMatic on Debian) but works with any CCU3 or RaspberryMatic installation that exposes the standard `/api/homematic.cgi` endpoint.
+Works with any HomeMatic CCU: [debmatic](https://github.com/alexreinert/debmatic) (HomeMatic on Debian), a CCU3, or RaspberryMatic/OpenCCU — anything that exposes the standard `/api/homematic.cgi` endpoint.
 
 ## What can it do?
 
@@ -37,7 +37,7 @@ The MCP server handles device discovery, type resolution, session management, an
 ```bash
 export CCU_HOST=your-ccu-hostname-or-ip
 export CCU_PASSWORD=your-ccu-admin-password
-npx debmatic-mcp --stdio
+npx ccu-mcp --stdio
 ```
 
 If it prints `server_ready` to stderr, it's working. Press Ctrl+C to stop. Now set it up in your MCP client — see below.
@@ -57,7 +57,7 @@ For Claude Code, create a `.mcp.json` file in your project directory (or any dir
   "mcpServers": {
     "debmatic": {
       "command": "npx",
-      "args": ["debmatic-mcp", "--stdio"],
+      "args": ["ccu-mcp", "--stdio"],
       "env": {
         "CCU_HOST": "your-ccu-hostname-or-ip",
         "CCU_PASSWORD": "your-ccu-admin-password"
@@ -74,7 +74,7 @@ Restart Claude Code. Run `/mcp` to check it connected. You should see `debmatic`
 Alternatively, use the Claude Code CLI:
 
 ```bash
-claude mcp add debmatic -- npx debmatic-mcp --stdio
+claude mcp add debmatic -- npx ccu-mcp --stdio
 ```
 
 ### Option B: Docker (standalone HTTP server)
@@ -85,18 +85,18 @@ Use this if you want the server running independently — for example on a home 
 
 ```bash
 docker run -d \
-  --name debmatic-mcp \
+  --name ccu-mcp \
   -e CCU_HOST=your-ccu-hostname-or-ip \
   -e CCU_PASSWORD=your-ccu-admin-password \
-  -v debmatic-data:/data \
+  -v ccu-data:/data \
   -p 3000:3000 \
-  debmatic-mcp
+  ccu-mcp
 ```
 
 **2. Get the auth token.** The server generates a random bearer token on first startup and saves it inside the container's data volume. You need this token to authenticate your MCP client. Grab it with:
 
 ```bash
-docker exec debmatic-mcp grep MCP_AUTH_TOKEN /data/.env
+docker exec ccu-mcp grep MCP_AUTH_TOKEN /data/.env
 ```
 
 This prints something like `MCP_AUTH_TOKEN=e96suzi1iG0H-GPif6K2...`. The part after `=` is your token.
@@ -119,7 +119,7 @@ This prints something like `MCP_AUTH_TOKEN=e96suzi1iG0H-GPif6K2...`. The part af
 To inject the token automatically (requires `jq`):
 
 ```bash
-TOKEN=$(docker exec debmatic-mcp grep MCP_AUTH_TOKEN /data/.env | cut -d= -f2)
+TOKEN=$(docker exec ccu-mcp grep MCP_AUTH_TOKEN /data/.env | cut -d= -f2)
 jq --arg t "$TOKEN" '.mcpServers.debmatic.headers.Authorization = "Bearer " + $t' .mcp.json > .mcp.json.tmp && mv .mcp.json.tmp .mcp.json
 ```
 
@@ -150,7 +150,7 @@ The HTTP transport also has **DNS-rebinding protection** on by default: it rejec
 {"ts":"2026-06-18T17:28:00.370Z","level":"warn","msg":"auth_failed","client":"203.0.113.7","hadToken":true}
 ```
 
-Ready-to-use fail2ban config ships in [`fail2ban/`](fail2ban/): copy `filter.d/debmatic-mcp.conf` to `/etc/fail2ban/filter.d/` and the jail in `jail.d/debmatic-mcp.local` to `/etc/fail2ban/jail.d/` (it defaults to 5 failures in 10 minutes → 1-hour ban). The server logs to stderr, so point fail2ban at wherever you collect it — the journal (`backend = systemd`) when run as a unit, or a file when you redirect stderr/`docker logs`; both are spelled out in the jail file. Requires `LOG_LEVEL=warn` or lower (`info`, the default, is fine; `error` suppresses the line). Behind a reverse proxy the logged IP is the proxy's, so run fail2ban against the proxy's access log instead.
+Ready-to-use fail2ban config ships in [`fail2ban/`](fail2ban/): copy `filter.d/ccu-mcp.conf` to `/etc/fail2ban/filter.d/` and the jail in `jail.d/ccu-mcp.local` to `/etc/fail2ban/jail.d/` (it defaults to 5 failures in 10 minutes → 1-hour ban). The server logs to stderr, so point fail2ban at wherever you collect it — the journal (`backend = systemd`) when run as a unit, or a file when you redirect stderr/`docker logs`; both are spelled out in the jail file. Requires `LOG_LEVEL=warn` or lower (`info`, the default, is fine; `error` suppresses the line). Behind a reverse proxy the logged IP is the proxy's, so run fail2ban against the proxy's access log instead.
 
 CORS support was first implemented by [@marcinn2](https://github.com/marcinn2) in his fork [marcinn2/debmatic-mcp](https://github.com/marcinn2/debmatic-mcp) — thanks!
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
 
 ccu-mcp connects to the CCU's built-in JSON-RPC API and exposes your devices, rooms, programs, and system variables as MCP tools. No addons, no XML-API, no cloud — just a direct connection to the CCU on your local network.
 
-Works with any HomeMatic CCU: [debmatic](https://github.com/alexreinert/debmatic) (HomeMatic on Debian), a CCU3, or RaspberryMatic/OpenCCU — anything that exposes the standard `/api/homematic.cgi` endpoint.
+Works with any HomeMatic CCU: [debmatic](https://github.com/alexreinert/debmatic) (HomeMatic on Debian), a CCU3, or [OpenCCU](https://github.com/OpenCCU/OpenCCU) (formerly RaspberryMatic) — anything that exposes the standard `/api/homematic.cgi` endpoint.
 
 ## What can it do?
 
@@ -28,7 +28,7 @@ The MCP server handles device discovery, type resolution, session management, an
 
 ## Prerequisites
 
-- A running HomeMatic CCU (debmatic, CCU3, or RaspberryMatic) reachable on your network
+- A running HomeMatic CCU (debmatic, CCU3, or OpenCCU — formerly RaspberryMatic) reachable on your network
 - The CCU's admin username and password (the same credentials you use to log into the WebUI)
 - Node.js 22+ (for running from source or stdio mode) or Docker
 
@@ -273,9 +273,9 @@ Other device types should work too — the server queries the CCU for parameter 
 
 ## Related projects
 
+- [OpenCCU](https://github.com/OpenCCU/OpenCCU) — community-maintained, cloud-free CCU firmware for Raspberry Pi, x86/ARM, and CCU3/ELV-Charly hardware (formerly **RaspberryMatic**; built on the OCCU framework)
 - [debmatic](https://github.com/alexreinert/debmatic) — Run HomeMatic on Debian, Ubuntu, Raspberry Pi OS, Armbian
-- [OCCU](https://github.com/eq-3/occu) — Open CCU SDK by eQ-3 (the upstream HomeMatic software)
-- [RaspberryMatic](https://github.com/jens-maus/RaspberryMatic) — HomeMatic on Raspberry Pi
+- [OCCU](https://github.com/eq-3/occu) — eQ-3's original Open CCU SDK (the upstream HomeMatic software); now being superseded by the community-maintained [OpenCCU](https://github.com/OpenCCU/OpenCCU)
 - [MCP](https://modelcontextprotocol.io/) — Model Context Protocol specification
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
-  debmatic-mcp:
+  ccu-mcp:
     build: .
     restart: unless-stopped
     volumes:
-      - debmatic-data:/data
+      - ccu-data:/data
     ports:
       - "3000:3000"
     environment:
@@ -42,4 +42,4 @@ services:
       # - LOG_LEVEL=info
 
 volumes:
-  debmatic-data:
+  ccu-data:

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,8 +1,8 @@
 # Release runbook
 
-How to publish a `vX.Y.Z` of `debmatic-mcp`. The release is **manual** —
+How to publish a `vX.Y.Z` of `ccu-mcp`. The release is **manual** —
 there is no release workflow (CI only builds and tests). The publish
-targets are **npm** (`npx debmatic-mcp`, the primary install path) and the
+targets are **npm** (`npx ccu-mcp`, the primary install path) and the
 **official MCP registry** (`registry.modelcontextprotocol.io`). The Docker
 image is build-your-own (`docker-compose` builds from source); nothing is
 pushed to a container registry, so there is no image-publish step.
@@ -17,6 +17,36 @@ default/integration branch; `main` is protected and holds released code;
 each release is a tag `vX.Y.Z` on `main`. Branch off `dev`, never `main`.
 This runbook expands the release half of that model.
 
+## One-time: the v1.5.0 rename (`debmatic-mcp` → `ccu-mcp`)
+
+The project was renamed from `debmatic-mcp` to `ccu-mcp` for v1.5.0 (the name
+is CCU-platform-generic; the tool was never debmatic-specific). The in-repo
+code/docs change shipped in the rename PR. The out-of-repo moves below are
+**one-time owner actions**, done around the v1.5.0 release — *not* every
+release:
+
+1. **GitHub repo rename** — Settings → rename `claymore666/debmatic-mcp` →
+   `claymore666/ccu-mcp`. GitHub keeps redirects from the old URL and git
+   remote indefinitely. Update the local clone: `git remote set-url origin
+   https://github.com/claymore666/ccu-mcp.git`. Do this **before** the
+   `mcp-publisher publish` so the `io.github.claymore666/ccu-mcp` namespace
+   resolves.
+2. **npm** — there is no rename. Publish the new `ccu-mcp` package via the
+   normal per-release flow below, then tombstone the old name:
+   `npm deprecate debmatic-mcp "renamed to ccu-mcp — install ccu-mcp instead"`.
+   The old package stays published forever; the deprecation warning points
+   users across.
+3. **MCP registry** — `mcp-publisher publish` creates the new
+   `io.github.claymore666/ccu-mcp` entry. The old
+   `io.github.claymore666/debmatic-mcp` entry remains; leave it.
+4. **Smithery** — re-list as `ccu-mcp` (was `christian-kamien/debmatic-mcp`,
+   MCPB bundle).
+5. **glama.ai badge** — auto-derives from the repo path, so it follows the
+   GitHub rename; the README badge URL was already updated to `…/ccu-mcp`.
+
+After v1.5.0 ships, this section is historical — the steady-state procedure
+below is all that applies to subsequent releases.
+
 ## One-time prerequisites
 
 Per-account setup, **not** per-release. Done once when the publishing chain
@@ -24,7 +54,7 @@ is first wired up.
 
 ### npm — publish auth
 
-`debmatic-mcp` is published to npm under the unscoped name `debmatic-mcp`
+`ccu-mcp` is published to npm under the unscoped name `ccu-mcp`
 (`package.json` `name`). Publishing needs an authenticated npm session with
 publish rights on that package.
 
@@ -93,9 +123,9 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    ```
    This gate also runs in CI on every push and in `prepublishOnly`, so a
    drifted manifest can't merge or publish even if the bump is done by hand.
-   The README install snippets use unversioned `npx debmatic-mcp` /
+   The README install snippets use unversioned `npx ccu-mcp` /
    `claude mcp add` — there are **no pinned version strings to bump there**.
-   Keep it that way; don't add versioned `npx debmatic-mcp@X.Y.Z` snippets to
+   Keep it that way; don't add versioned `npx ccu-mcp@X.Y.Z` snippets to
    the README, or this list grows.
 
 3. **Documentation review — against the milestone, not from memory.** List
@@ -175,11 +205,11 @@ milestone — it's the source of the `Closes #N` list in the release PR.
 
 After publishing:
 
-- `npm view debmatic-mcp version` returns `vX.Y.Z` (allow a minute for the
-  registry to update). `npx -y debmatic-mcp@X.Y.Z --help` from a clean
+- `npm view ccu-mcp version` returns `vX.Y.Z` (allow a minute for the
+  registry to update). `npx -y ccu-mcp@X.Y.Z --help` from a clean
   machine pulls and runs it.
 - The MCP registry shows the new version:
-  `curl -s 'https://registry.modelcontextprotocol.io/v0/servers?search=io.github.claymore666/debmatic-mcp' | jq '.servers[].version'`.
+  `curl -s 'https://registry.modelcontextprotocol.io/v0/servers?search=io.github.claymore666/ccu-mcp' | jq '.servers[].version'`.
 - `gh release view vX.Y.Z` shows the notes body.
 - The milestone is closed:
   `gh issue list --milestone vX.Y.Z --state open` — should be empty.

--- a/fail2ban/filter.d/ccu-mcp.conf
+++ b/fail2ban/filter.d/ccu-mcp.conf
@@ -1,4 +1,4 @@
-# Fail2Ban filter for debmatic-mcp HTTP-transport bearer-auth failures.
+# Fail2Ban filter for ccu-mcp HTTP-transport bearer-auth failures.
 #
 # The server logs one structured JSON line to stderr on every rejected MCP
 # request, e.g.:
@@ -8,7 +8,7 @@
 # so no explicit datepattern is needed. (Requires LOG_LEVEL=warn or lower —
 # "info", the default, is fine; "error" suppresses the line.)
 #
-# Install: copy to /etc/fail2ban/filter.d/debmatic-mcp.conf
+# Install: copy to /etc/fail2ban/filter.d/ccu-mcp.conf
 
 [Definition]
 

--- a/fail2ban/jail.d/ccu-mcp.local
+++ b/fail2ban/jail.d/ccu-mcp.local
@@ -1,13 +1,13 @@
-# Example Fail2Ban jail for debmatic-mcp. Copy to
-# /etc/fail2ban/jail.d/debmatic-mcp.local, adjust to your deployment, then
-# `systemctl reload fail2ban`. Check it with `fail2ban-client status debmatic-mcp`.
+# Example Fail2Ban jail for ccu-mcp. Copy to
+# /etc/fail2ban/jail.d/ccu-mcp.local, adjust to your deployment, then
+# `systemctl reload fail2ban`. Check it with `fail2ban-client status ccu-mcp`.
 #
 # The server writes its JSON logs to STDERR, so point Fail2Ban at wherever you
 # collect them. Pick ONE of the two backends below.
 
-[debmatic-mcp]
+[ccu-mcp]
 enabled  = true
-filter   = debmatic-mcp
+filter   = ccu-mcp
 
 # Ban the IP on the MCP port (match your MCP_PORT). Use a single number, or
 # drop this line to ban on all ports.
@@ -21,12 +21,12 @@ bantime  = 1h
 # Use when the server runs as a systemd unit (stderr → the journal). Set
 # journalmatch to your unit name.
 backend      = systemd
-journalmatch = _SYSTEMD_UNIT=debmatic-mcp.service
+journalmatch = _SYSTEMD_UNIT=ccu-mcp.service
 
 # ── Backend B: a log file ───────────────────────────────────────────────────
 # Use instead of the two systemd lines above when you redirect the server's
 # stderr to a file (systemd `StandardError=append:`, a Docker logging driver,
-# or `docker logs debmatic-mcp >> /var/log/debmatic-mcp.log`). Comment out
+# or `docker logs ccu-mcp >> /var/log/ccu-mcp.log`). Comment out
 # `backend`/`journalmatch` above and uncomment:
 #backend = auto
-#logpath = /var/log/debmatic-mcp.log
+#logpath = /var/log/ccu-mcp.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "debmatic-mcp",
+  "name": "ccu-mcp",
   "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "debmatic-mcp",
+      "name": "ccu-mcp",
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
@@ -14,7 +14,7 @@
         "zod": "^4.4.3"
       },
       "bin": {
-        "debmatic-mcp": "dist/index.js"
+        "ccu-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^25.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "debmatic-mcp",
+  "name": "ccu-mcp",
   "version": "1.4.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
-  "mcpName": "io.github.claymore666/debmatic-mcp",
+  "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "debmatic-mcp": "dist/index.js"
+    "ccu-mcp": "dist/index.js"
   },
   "files": [
     "dist",
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/claymore666/debmatic-mcp.git"
+    "url": "git+https://github.com/claymore666/ccu-mcp.git"
   },
   "keywords": [
     "mcp",
@@ -49,9 +49,9 @@
   "author": "claymore666",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/claymore666/debmatic-mcp/issues"
+    "url": "https://github.com/claymore666/ccu-mcp/issues"
   },
-  "homepage": "https://github.com/claymore666/debmatic-mcp#readme",
+  "homepage": "https://github.com/claymore666/ccu-mcp#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "undici": "^8.5.0",

--- a/server.json
+++ b/server.json
@@ -1,16 +1,16 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.claymore666/debmatic-mcp",
+  "name": "io.github.claymore666/ccu-mcp",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "repository": {
-    "url": "https://github.com/claymore666/debmatic-mcp",
+    "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
   "version": "1.4.0",
   "packages": [
     {
       "registryType": "npm",
-      "identifier": "debmatic-mcp",
+      "identifier": "ccu-mcp",
       "version": "1.4.0",
       "runtimeHint": "npx",
       "transport": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.4.0",
+  "version": "1.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -25,7 +25,7 @@
       "environmentVariables": [
         {
           "name": "CCU_HOST",
-          "description": "Hostname or IP of your HomeMatic CCU (debmatic, CCU3, or RaspberryMatic)",
+          "description": "Hostname or IP of your HomeMatic CCU (debmatic, CCU3, or OpenCCU/RaspberryMatic)",
           "isRequired": true,
           "format": "string"
         },

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -121,9 +121,9 @@ function announce(token: string, dataDir: string, rotated: boolean): void {
   const envPath = join(dataDir, ENV_FILENAME);
   const what = rotated ? "Rotated auth token" : "Generated auth token";
   // stderr so the operator can copy it; never goes through the structured logger.
-  process.stderr.write(`\n[debmatic-mcp] ${what}: ${token}\n`);
-  process.stderr.write(`[debmatic-mcp] Token saved to ${envPath}\n`);
-  process.stderr.write(`[debmatic-mcp] Use this token in your MCP client configuration.\n\n`);
+  process.stderr.write(`\n[ccu-mcp] ${what}: ${token}\n`);
+  process.stderr.write(`[ccu-mcp] Token saved to ${envPath}\n`);
+  process.stderr.write(`[ccu-mcp] Use this token in your MCP client configuration.\n\n`);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,8 +162,8 @@ async function main(): Promise<void> {
           // actually presented; RFC 6750 §3 omits the error param when no
           // credentials were sent.
           const challenge = presented
-            ? 'Bearer realm="debmatic-mcp", error="invalid_token"'
-            : 'Bearer realm="debmatic-mcp"';
+            ? 'Bearer realm="ccu-mcp", error="invalid_token"'
+            : 'Bearer realm="ccu-mcp"';
           res.writeHead(401, {
             "Content-Type": "application/json",
             "WWW-Authenticate": challenge,

--- a/src/middleware/error-mapper.ts
+++ b/src/middleware/error-mapper.ts
@@ -3,8 +3,8 @@ import type { CcuRpcError, ErrorCategory, StructuredError } from "../ccu/types.j
 // Map CCU error codes to our error categories
 const CCU_ERROR_MAP: Record<number, { category: ErrorCategory; hint: string }> = {
   400: { category: "AUTH", hint: "Session expired. Will re-login automatically." },
-  401: { category: "INTERNAL", hint: "Invalid CCU method called — this is a bug in debmatic-mcp." },
-  402: { category: "INTERNAL", hint: "Missing required argument — this is a bug in debmatic-mcp." },
+  401: { category: "INTERNAL", hint: "Invalid CCU method called — this is a bug in ccu-mcp." },
+  402: { category: "INTERNAL", hint: "Missing required argument — this is a bug in ccu-mcp." },
   501: { category: "CCU_ERROR", hint: "CCU internal error. Try again or check CCU logs." },
   502: { category: "NOT_FOUND", hint: "Device or channel not found. Call list_devices to discover valid addresses." },
   503: { category: "NOT_FOUND", hint: "Invalid paramset key. Valid keys are: VALUES, MASTER, LINK." },

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,7 +26,7 @@ export interface ServerDeps {
 export function createMcpServer(deps: ServerDeps): McpServer {
   const server = new McpServer(
     {
-      name: "debmatic-mcp",
+      name: "ccu-mcp",
       version: VERSION,
     },
     {

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -9,7 +9,7 @@ export function registerMetaTools(server: McpServer, deps: ServerDeps): void {
   registerRunScript(server, deps);
 }
 
-const CONCEPTUAL_GUIDE = `# HomeMatic via debmatic-mcp
+const CONCEPTUAL_GUIDE = `# HomeMatic via ccu-mcp
 
 ## Object Hierarchy
 CCU → Interfaces → Devices → Channels → Datapoints (paramsets)

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -226,7 +226,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
     expect(res.status).toBe(401);
     const challenge = res.headers.get("www-authenticate") ?? "";
     expect(challenge).toContain("Bearer");
-    expect(challenge).toContain('realm="debmatic-mcp"');
+    expect(challenge).toContain('realm="ccu-mcp"');
     expect(challenge).not.toContain("error="); // no credentials presented
   });
 

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -175,7 +175,7 @@ describeIf("MCP tools against live CCU", () => {
     // Unique per run: the CCU keeps hidden VARDP objects for a name even after
     // deletion, so reusing a fixed name eventually makes create dedup it to
     // "<name> N". A fresh name each run sidesteps that and keeps the test clean.
-    const name = `debmatic_mcp_test_${Date.now()}`;
+    const name = `ccu_mcp_test_${Date.now()}`;
     try {
       const created = parseToolResult(await callTool(server, "create_system_variable", { name, type: "float", unit: "°C", min: 0, max: 50 })) as any;
       expect(created.created).toBe(true);

--- a/test/unit/fail2ban-filter.test.ts
+++ b/test/unit/fail2ban-filter.test.ts
@@ -6,10 +6,10 @@ import { normalizeClientIp } from "../../src/utils.js";
 
 // Locks the contract between the auth-failure log line the server emits and the
 // committed fail2ban filter. If either the log shape (src/index.ts) or the
-// filter regex (fail2ban/filter.d/debmatic-mcp.conf) drifts, this fails — so a
+// filter regex (fail2ban/filter.d/ccu-mcp.conf) drifts, this fails — so a
 // shipped filter can't silently stop matching real log lines.
 
-const FILTER = join(__dirname, "../../fail2ban/filter.d/debmatic-mcp.conf");
+const FILTER = join(__dirname, "../../fail2ban/filter.d/ccu-mcp.conf");
 
 /** The exact line the server writes on a rejected request (mirrors src/index.ts). */
 function authFailedLine(client: string, hadToken: boolean): string {

--- a/test/unit/tools-meta.test.ts
+++ b/test/unit/tools-meta.test.ts
@@ -6,7 +6,7 @@ describe("help handler", () => {
     const { server, deps } = createTestServer();
     const result = parseToolResult(await callTool(server, "help", {}));
     expect(typeof result).toBe("string");
-    expect((result as string)).toContain("HomeMatic via debmatic-mcp");
+    expect((result as string)).toContain("HomeMatic via ccu-mcp");
     expect((result as string)).toContain("Object Hierarchy");
     cleanupDeps(deps);
   });


### PR DESCRIPTION
## ccu-mcp v1.5.0 — project renamed `debmatic-mcp` → `ccu-mcp`

Renames the project from `debmatic-mcp` to **`ccu-mcp`**. The tool speaks the standard CCU JSON-RPC API and works with any HomeMatic CCU, so the name is now platform-generic. Thanks to **Jens Maus** for the suggestion ([homematic-forum thread](https://homematic-forum.de/forum/viewtopic.php?f=81&t=88230)).

**No functional changes** — every tool, environment variable, and behavior is identical to v1.4.0. This is a name-and-docs release.

### ⚠️ Action required: update your install command
The npm package is now **`ccu-mcp`**:
- `npx debmatic-mcp --stdio` → `npx ccu-mcp --stdio`
- `.mcp.json` args `["debmatic-mcp", …]` → `["ccu-mcp", …]`
- Environment variables are unchanged (`CCU_HOST`, `CCU_PASSWORD`, …).
- The old `debmatic-mcp` npm package is **deprecated** but still works; please switch to `ccu-mcp`.
- Docker: service/volume are now `ccu-mcp` / `ccu-data`. fail2ban: `filter.d/ccu-mcp.conf`, `jail.d/ccu-mcp.local`, jail `[ccu-mcp]`.

### Also in this release
- Docs: RaspberryMatic → [OpenCCU](https://github.com/OpenCCU/OpenCCU) terminology; OCCU noted as superseded by community-maintained OpenCCU.
- Docs: `.env.example` uses a `CCU_HOST` placeholder with explicit guidance.

### Included PRs
- #66 — Rename project debmatic-mcp → ccu-mcp (+ OpenCCU terminology, env placeholder)
- #67 — chore(release): bump version to 1.5.0