### PR TITLE
Multi-CCU targets: switch between prod/dev in one MCP server (#69)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,39 @@ CCU_CA_CERT=
 # Verify against the system trust store (only if the CCU has a publicly-trusted cert).
 CCU_TLS_VERIFY=false
 
+# ─── Multiple CCU targets / profiles (optional, issue #69) ──────────────────
+# By default the flat CCU_* vars above define a single target. To reach several
+# CCUs from ONE server (e.g. prod + dev), list profile names here and define
+# CCU_<NAME>_* vars for each. The active target is switched at runtime with the
+# use_ccu tool; read tools also take an optional `target` arg. When CCU_PROFILES
+# is unset, the flat CCU_* vars are used as a single "default" profile.
+CCU_PROFILES=
+# Which profile is active at startup (defaults to the first one listed).
+CCU_DEFAULT_PROFILE=
+#
+# Per-profile vars follow the pattern CCU_<PROFILE>_<SETTING> (profile name
+# upper-cased, non-alphanumerics → "_"). Each profile supports the same settings
+# as the flat ones: HOST (required), PASSWORD (may be empty — OpenCCU dev boxes
+# default to it), USER, PORT, HTTPS, TIMEOUT, SCRIPT_TIMEOUT, TLS_FINGERPRINT,
+# CA_CERT, TLS_VERIFY, plus two policy flags:
+#   CCU_<NAME>_PROTECTED=true  → write tools refuse unless called with confirm:true
+#   CCU_<NAME>_READONLY=true   → write tools are refused outright
+# These per-profile vars are read dynamically, so they are NOT listed as keys
+# here. Example (prod = the real box, protected; dev = a local OpenCCU VM):
+#   CCU_PROFILES=prod,dev
+#   CCU_DEFAULT_PROFILE=prod
+#   CCU_PROD_HOST=debmatic
+#   CCU_PROD_USER=claude
+#   CCU_PROD_PASSWORD=...
+#   CCU_PROD_HTTPS=true
+#   CCU_PROD_PORT=443
+#   CCU_PROD_TLS_FINGERPRINT=...
+#   CCU_PROD_PROTECTED=true
+#   CCU_DEV_HOST=127.0.0.1
+#   CCU_DEV_PORT=18080
+#   CCU_DEV_USER=Admin
+#   CCU_DEV_PASSWORD=
+
 # ─── CCU rate limiting (optional) ───────────────────────────────────────────
 # Max burst of requests sent to the CCU.
 CCU_RATE_LIMIT_BURST=20

--- a/src/cache/device-type-cache.ts
+++ b/src/cache/device-type-cache.ts
@@ -6,7 +6,7 @@ import type { Logger } from "../logger.js";
 import type { CachedDeviceType, CachedParamDescription, DeviceTypeCacheFile } from "./types.js";
 import { CACHE_VERSION } from "./types.js";
 
-const CACHE_FILENAME = "device-type-cache.json";
+const DEFAULT_CACHE_FILENAME = "device-type-cache.json";
 
 // Device types warmed in parallel; per-request pacing stays with the rate limiter
 const WARM_CONCURRENCY = 3;
@@ -37,13 +37,17 @@ export class DeviceTypeCache {
   private readonly cacheDir: string;
   private readonly ttl: number;
   private readonly logger: Logger;
+  private readonly fileName: string;
   private warming = false;
   private inflightQueries = new Map<string, Promise<CachedDeviceType | undefined>>();
 
-  constructor(cacheDir: string, ttl: number, logger: Logger) {
+  constructor(cacheDir: string, ttl: number, logger: Logger, fileName?: string) {
     this.cacheDir = cacheDir;
     this.ttl = ttl;
     this.logger = logger;
+    // Per-target cache file so different CCUs don't pollute each other's schema
+    // cache (default keeps the historical single-file name for back-compat).
+    this.fileName = fileName || DEFAULT_CACHE_FILENAME;
   }
 
   get(deviceType: string): CachedDeviceType | undefined {
@@ -64,7 +68,7 @@ export class DeviceTypeCache {
 
   /** Load cache from disk. Returns true if valid cache was loaded. */
   async loadFromDisk(): Promise<boolean> {
-    const filePath = join(this.cacheDir, CACHE_FILENAME);
+    const filePath = join(this.cacheDir, this.fileName);
     try {
       const data = await readFile(filePath, "utf-8");
       const parsed = JSON.parse(data) as DeviceTypeCacheFile;
@@ -89,7 +93,7 @@ export class DeviceTypeCache {
 
   /** Atomic write: serialize → tmp file → rename */
   async saveToDisk(): Promise<void> {
-    const filePath = join(this.cacheDir, CACHE_FILENAME);
+    const filePath = join(this.cacheDir, this.fileName);
     const tmpPath = filePath + ".tmp";
 
     const data: DeviceTypeCacheFile = {

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -6,7 +6,7 @@ import { CcuError } from "../middleware/error-mapper.js";
 import type { Logger } from "../logger.js";
 
 const SESSION_RENEW_INTERVAL = 60_000; // Renew every 60s
-const SESSION_FILE = "session.json";
+const DEFAULT_SESSION_FILE = "session.json";
 const LOGIN_RETRY_DELAY = 3_000;
 const LOGIN_MAX_RETRIES = 3;
 
@@ -15,15 +15,19 @@ export class SessionManager {
   private readonly config: CcuConfig;
   private readonly logger: Logger;
   private readonly cacheDir: string;
+  private readonly sessionFile: string;
   private sessionId: string | null = null;
   private renewTimer: ReturnType<typeof setInterval> | null = null;
   private loginPromise: Promise<void> | null = null;
 
-  constructor(config: CcuConfig, logger: Logger, cacheDir?: string) {
+  constructor(config: CcuConfig, logger: Logger, cacheDir?: string, sessionFile?: string) {
     this.config = config;
     this.client = new CcuClient(config, logger);
     this.logger = logger;
     this.cacheDir = cacheDir || "/tmp";
+    // Per-target session file so multiple SessionManagers don't fight over one
+    // session.json (each target's session is keyed by host/port/user too).
+    this.sessionFile = sessionFile || DEFAULT_SESSION_FILE;
   }
 
   /**
@@ -127,7 +131,7 @@ export class SessionManager {
 
   private async tryRestoreSession(): Promise<boolean> {
     try {
-      const filePath = join(this.cacheDir, SESSION_FILE);
+      const filePath = join(this.cacheDir, this.sessionFile);
       const data = JSON.parse(await readFile(filePath, "utf-8"));
 
       if (data.sessionId && data.host === this.config.host && data.port === this.config.port
@@ -153,7 +157,7 @@ export class SessionManager {
     if (!this.sessionId) return;
     try {
       await mkdir(this.cacheDir, { recursive: true });
-      const filePath = join(this.cacheDir, SESSION_FILE);
+      const filePath = join(this.cacheDir, this.sessionFile);
       const tmpPath = filePath + ".tmp";
       const data = JSON.stringify({
         sessionId: this.sessionId,
@@ -173,7 +177,7 @@ export class SessionManager {
   private async clearPersistedSession(): Promise<void> {
     try {
       const { unlink } = await import("node:fs/promises");
-      await unlink(join(this.cacheDir, SESSION_FILE));
+      await unlink(join(this.cacheDir, this.sessionFile));
     } catch {
       // Ignore
     }

--- a/src/ccu/target-registry.ts
+++ b/src/ccu/target-registry.ts
@@ -1,0 +1,172 @@
+import type { AppConfig } from "../config.js";
+import type { CcuProfile } from "./types.js";
+import type { Logger } from "../logger.js";
+import type { RateLimiter } from "../middleware/rate-limiter.js";
+import { SessionManager } from "./session.js";
+import { Resolver } from "../middleware/resolver.js";
+import { DeviceTypeCache } from "../cache/device-type-cache.js";
+import { CcuError } from "../middleware/error-mapper.js";
+
+/** Short-lived sysvar name→type cache (issue #9), now scoped per target. */
+export interface SysVarTypeCacheHolder {
+  entry: { ts: number; types: Map<string, string> } | null;
+}
+
+/**
+ * One connected CCU target: its profile (connection + policy), its own session,
+ * resolver, device-type cache, and sysvar-type cache. Caches are per-target so
+ * a dev and prod CCU never pollute each other.
+ */
+export interface Target {
+  profile: CcuProfile;
+  session: SessionManager;
+  resolver: Resolver;
+  deviceTypeCache: DeviceTypeCache;
+  sysVarTypeCache: SysVarTypeCacheHolder;
+  /**
+   * Writes to a `protected` target are unlocked for the rest of the session
+   * once the caller confirms once (the "ask once per session" model). Always
+   * false → no effect for non-protected targets.
+   */
+  unlocked: boolean;
+}
+
+// Filesystem-safe per-target suffix for cache/session filenames.
+function fileSuffix(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Holds every configured CCU target and which one is active. Tools reach the
+ * active target via ServerDeps getters; an optional per-call `target` arg routes
+ * a single call elsewhere via resolveTarget().
+ */
+export class TargetRegistry {
+  private readonly targets = new Map<string, Target>(); // keyed by lowercased name
+  private readonly order: string[] = []; // actual names, config order
+  private activeKey: string;
+
+  constructor(config: AppConfig, logger: Logger, cacheDir: string) {
+    for (const profile of config.profiles) {
+      // The back-compat single "default" profile keeps the historical filenames
+      // so existing on-disk session/cache still load; named profiles get a suffix.
+      const suffix = profile.name === "default" ? "" : `.${fileSuffix(profile.name)}`;
+      const target: Target = {
+        profile,
+        session: new SessionManager(profile.ccu, logger, cacheDir, `session${suffix}.json`),
+        resolver: new Resolver(),
+        deviceTypeCache: new DeviceTypeCache(cacheDir, config.cache.ttl, logger, `device-type-cache${suffix}.json`),
+        sysVarTypeCache: { entry: null },
+        unlocked: false,
+      };
+      this.targets.set(profile.name.toLowerCase(), target);
+      this.order.push(profile.name);
+    }
+    this.activeKey = config.defaultProfile.toLowerCase();
+  }
+
+  get active(): Target {
+    return this.targets.get(this.activeKey)!;
+  }
+
+  getByName(name: string): Target | undefined {
+    return this.targets.get(name.toLowerCase());
+  }
+
+  has(name: string): boolean {
+    return this.targets.has(name.toLowerCase());
+  }
+
+  /** All targets in configured order. */
+  list(): Target[] {
+    return this.order.map((n) => this.targets.get(n.toLowerCase())!);
+  }
+
+  /** Switch the active target; throws NOT_FOUND on an unknown name. */
+  use(name: string): Target {
+    const t = this.getByName(name);
+    if (!t) {
+      throw new CcuError({
+        error: "NOT_FOUND",
+        code: 0,
+        message: `Unknown CCU target: ${name}`,
+        hint: `Configured targets: ${this.order.join(", ")}. Call list_ccu_targets.`,
+      });
+    }
+    this.activeKey = t.profile.name.toLowerCase();
+    return t;
+  }
+
+  /** Log in the active target (other targets log in lazily on first use). */
+  async loginActive(): Promise<void> {
+    await this.active.session.login();
+  }
+
+  /** Load each target's device-type cache from disk. */
+  async loadCaches(): Promise<void> {
+    await Promise.all(this.list().map((t) => t.deviceTypeCache.loadFromDisk()));
+  }
+
+  /** Warm only the active target's cache (others warm lazily on first query). */
+  warmActive(rateLimiter: RateLimiter): Promise<void> {
+    const t = this.active;
+    return t.deviceTypeCache.warm(t.session, rateLimiter);
+  }
+
+  async saveCaches(): Promise<void> {
+    await Promise.allSettled(this.list().map((t) => t.deviceTypeCache.saveToDisk()));
+  }
+
+  async logoutAll(): Promise<void> {
+    await Promise.allSettled(this.list().map((t) => t.session.logout()));
+  }
+
+  destroyAll(): void {
+    for (const t of this.list()) t.session.destroy();
+  }
+}
+
+/**
+ * Resolve the target for a tool call: the optional per-call `target` name, or
+ * the active target when omitted. Throws NOT_FOUND for an unknown name.
+ */
+export function resolveTarget(targets: TargetRegistry, name?: string): Target {
+  if (!name) return targets.active;
+  const t = targets.getByName(name);
+  if (!t) {
+    throw new CcuError({
+      error: "NOT_FOUND",
+      code: 0,
+      message: `Unknown CCU target: ${name}`,
+      hint: "Call list_ccu_targets to see configured targets.",
+    });
+  }
+  return t;
+}
+
+/**
+ * Gate a write against a target's policy. `readonly` targets always refuse;
+ * `protected` targets refuse until the caller passes confirm:true once, which
+ * unlocks writes to that target for the rest of the session.
+ */
+export function assertWritable(target: Target, confirm: boolean | undefined): void {
+  if (target.profile.readonly) {
+    throw new CcuError({
+      error: "INVALID_INPUT",
+      code: 0,
+      message: `CCU target "${target.profile.name}" is read-only; writes are refused.`,
+      hint: "Switch to a writable target with use_ccu, or clear its readonly flag in config.",
+    });
+  }
+  if (target.profile.protected && !target.unlocked) {
+    if (confirm !== true) {
+      throw new CcuError({
+        error: "INVALID_INPUT",
+        code: 0,
+        message: `CCU target "${target.profile.name}" is protected. Re-issue with confirm:true to authorize writes for this session.`,
+        hint: "Safety gate on a production CCU. Pass confirm:true to proceed; later writes this session won't need it.",
+      });
+    }
+    target.unlocked = true;
+  }
+}

--- a/src/ccu/types.ts
+++ b/src/ccu/types.ts
@@ -143,6 +143,26 @@ export interface ParamDescription {
 }
 
 // Config
+/**
+ * A named CCU target (e.g. `prod`, `dev`). Profiles let one server reach
+ * several CCUs; the connection details live in `ccu`, and the two policy flags
+ * gate writes. Built from env in config.ts.
+ */
+export interface CcuProfile {
+  /** Profile name as used by use_ccu / the optional per-call `target` arg. */
+  name: string;
+  /**
+   * Production seatbelt: when true, write tools refuse unless the caller passes
+   * `confirm:true` (which unlocks writes to this target for the rest of the
+   * session). Declared explicitly per profile — never inferred from the name.
+   */
+  protected: boolean;
+  /** When true, write tools are refused outright (even with confirm). */
+  readonly: boolean;
+  /** Connection details for this target. */
+  ccu: CcuConfig;
+}
+
 export interface CcuConfig {
   host: string;
   port: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,17 @@
 import { readFileSync } from "node:fs";
-import type { CcuConfig } from "./ccu/types.js";
+import type { CcuConfig, CcuProfile } from "./ccu/types.js";
 
 export interface AppConfig {
+  /**
+   * Connection details for the DEFAULT target. Kept as an alias of
+   * `profiles[defaultProfile].ccu` for back-compat with code/tests that read
+   * `config.ccu.*` (e.g. `scriptTimeout`). Prefer `profiles` for new code.
+   */
   ccu: CcuConfig;
+  /** All configured CCU targets (always ≥1; a flat config yields one `default`). */
+  profiles: CcuProfile[];
+  /** Name of the target active at startup. */
+  defaultProfile: string;
   mcp: {
     transport: "http" | "stdio";
     port: number;
@@ -76,16 +85,6 @@ export interface AppConfig {
 }
 
 export function loadConfig(): AppConfig {
-  const host = process.env.CCU_HOST;
-  if (!host) {
-    throw new Error("CCU_HOST environment variable is required");
-  }
-
-  const password = process.env.CCU_PASSWORD;
-  if (!password) {
-    throw new Error("CCU_PASSWORD environment variable is required");
-  }
-
   // CLI flags override env vars for transport
   const args = process.argv.slice(2);
   let transport: "http" | "stdio" = (process.env.MCP_TRANSPORT as "http" | "stdio") || "http";
@@ -145,36 +144,102 @@ export function loadConfig(): AppConfig {
   }
 
   // CCU TLS verification (issue #51). A CCU ships a self-signed cert, so verify
-  // it either by pinning the leaf fingerprint (CCU_TLS_FINGERPRINT) or by
-  // trusting a CA/self-signed PEM (CCU_CA_CERT). Fingerprint takes precedence.
-  const tlsFingerprint = process.env.CCU_TLS_FINGERPRINT?.trim() || undefined;
-  const caCertPath = process.env.CCU_CA_CERT?.trim() || undefined;
-  let caCert: string | undefined;
-  if (caCertPath) {
+  // it either by pinning the leaf fingerprint or by trusting a CA/self-signed
+  // PEM. Read the PEM here; the env var name is only for the error message
+  // (don't interpolate the env-derived PATH into logs — js/clear-text-logging).
+  const readCaCert = (envName: string, path: string | undefined): string | undefined => {
+    if (!path) return undefined;
     try {
-      caCert = readFileSync(caCertPath, "utf-8");
+      return readFileSync(path, "utf-8");
     } catch (err) {
-      // Don't interpolate the env-derived path here: a fatal config error is
-      // logged at the top level, and echoing raw env values into logs is a
-      // leak vector (js/clear-text-logging). The fs error already names the
-      // path for the operator.
-      throw new Error(`CCU_CA_CERT could not be read: ${(err as Error).message}`);
+      throw new Error(`${envName} could not be read: ${(err as Error).message}`);
     }
+  };
+
+  // Build one named profile from CCU_<PREFIX>_* env vars (issue #69). These are
+  // read DYNAMICALLY (template-literal keys), so the env-example-sync test's
+  // literal scan doesn't see them — intentional; they're documented as comments
+  // in .env.example. Password may be empty (OpenCCU dev boxes default to it).
+  const buildProfile = (name: string): CcuProfile => {
+    const p = name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+    const get = (suffix: string): string | undefined => process.env[`CCU_${p}_${suffix}`]?.trim() || undefined;
+    const host = get("HOST");
+    if (!host) throw new Error(`profile "${name}" is missing CCU_${p}_HOST`);
+    const https = process.env[`CCU_${p}_HTTPS`] === "true";
+    return {
+      name,
+      protected: process.env[`CCU_${p}_PROTECTED`] === "true",
+      readonly: process.env[`CCU_${p}_READONLY`] === "true",
+      ccu: {
+        host,
+        port: parseIntEnv(`CCU_${p}_PORT`, https ? "443" : "80"),
+        https,
+        tlsVerify: process.env[`CCU_${p}_TLS_VERIFY`] === "true",
+        tlsFingerprint: get("TLS_FINGERPRINT"),
+        caCert: readCaCert(`CCU_${p}_CA_CERT`, get("CA_CERT")),
+        user: get("USER") || "Admin",
+        password: process.env[`CCU_${p}_PASSWORD`] ?? "",
+        timeout: parseIntEnv(`CCU_${p}_TIMEOUT`, "10000"),
+        scriptTimeout: parseIntEnv(`CCU_${p}_SCRIPT_TIMEOUT`, "30000"),
+      },
+    };
+  };
+
+  const profilesEnv = process.env.CCU_PROFILES?.trim();
+  let profiles: CcuProfile[];
+  let defaultProfile: string;
+
+  if (!profilesEnv) {
+    // Back-compat: no CCU_PROFILES ⇒ one "default" profile from the flat
+    // CCU_HOST/CCU_PASSWORD/... vars, with the exact validation as before.
+    const host = process.env.CCU_HOST;
+    if (!host) throw new Error("CCU_HOST environment variable is required");
+    const password = process.env.CCU_PASSWORD;
+    if (!password) throw new Error("CCU_PASSWORD environment variable is required");
+    profiles = [{
+      name: "default",
+      protected: false,
+      readonly: false,
+      ccu: {
+        host,
+        port: parseIntEnv("CCU_PORT", process.env.CCU_HTTPS === "true" ? "443" : "80"),
+        https: process.env.CCU_HTTPS === "true",
+        tlsVerify: process.env.CCU_TLS_VERIFY === "true",
+        tlsFingerprint: process.env.CCU_TLS_FINGERPRINT?.trim() || undefined,
+        caCert: readCaCert("CCU_CA_CERT", process.env.CCU_CA_CERT?.trim() || undefined),
+        user: process.env.CCU_USER || "Admin",
+        password,
+        timeout: parseIntEnv("CCU_TIMEOUT", "10000"),
+        scriptTimeout: parseIntEnv("CCU_SCRIPT_TIMEOUT", "30000"),
+      },
+    }];
+    defaultProfile = "default";
+  } else {
+    const names = profilesEnv.split(",").map((s) => s.trim()).filter(Boolean);
+    if (names.length === 0) throw new Error("CCU_PROFILES is set but lists no profile names");
+    const seen = new Set<string>();
+    for (const n of names) {
+      const key = n.toLowerCase();
+      if (seen.has(key)) throw new Error(`CCU_PROFILES lists "${n}" more than once`);
+      seen.add(key);
+    }
+    profiles = names.map(buildProfile);
+    const requested = process.env.CCU_DEFAULT_PROFILE?.trim();
+    const match = requested
+      ? profiles.find((p) => p.name.toLowerCase() === requested.toLowerCase())
+      : profiles[0];
+    if (!match) {
+      throw new Error(`CCU_DEFAULT_PROFILE="${requested}" is not one of CCU_PROFILES (${names.join(", ")})`);
+    }
+    defaultProfile = match.name;
   }
 
+  const defaultCcu = profiles.find((p) => p.name === defaultProfile)!.ccu;
+
   return {
-    ccu: {
-      host,
-      port: parseIntEnv("CCU_PORT", process.env.CCU_HTTPS === "true" ? "443" : "80"),
-      https: process.env.CCU_HTTPS === "true",
-      tlsVerify: process.env.CCU_TLS_VERIFY === "true",
-      tlsFingerprint,
-      caCert,
-      user: process.env.CCU_USER || "Admin",
-      password,
-      timeout: parseIntEnv("CCU_TIMEOUT", "10000"),
-      scriptTimeout: parseIntEnv("CCU_SCRIPT_TIMEOUT", "30000"),
-    },
+    ccu: defaultCcu,
+    profiles,
+    defaultProfile,
     mcp: {
       transport,
       port: mcpPort,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,14 +14,12 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { loadConfig } from "./config.js";
 import { createLogger } from "./logger.js";
-import { SessionManager } from "./ccu/session.js";
 import { RateLimiter } from "./middleware/rate-limiter.js";
-import { DeviceTypeCache } from "./cache/device-type-cache.js";
-import { Resolver } from "./middleware/resolver.js";
+import { TargetRegistry } from "./ccu/target-registry.js";
 import { ResourcePoller } from "./resources/poller.js";
 import { resolveAuthTokens } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
-import { createMcpServer } from "./server.js";
+import { createMcpServer, type ServerDeps } from "./server.js";
 import { extractBearerToken, normalizeClientIp } from "./utils.js";
 
 async function main(): Promise<void> {
@@ -30,21 +28,25 @@ async function main(): Promise<void> {
 
   logger.info("starting", {
     transport: config.mcp.transport,
+    profiles: config.profiles.map((p) => p.name),
+    activeProfile: config.defaultProfile,
     ccuHost: config.ccu.host,
     ccuPort: config.ccu.port,
     https: config.ccu.https,
   });
 
-  // Initialize CCU session
-  const session = new SessionManager(config.ccu, logger, config.cache.dir);
+  // Initialize all configured CCU targets (issue #69). Each has its own session,
+  // resolver, and per-target caches; `active` is the startup default.
   const rateLimiter = new RateLimiter(config.rateLimiter.burst, config.rateLimiter.rate);
+  const targets = new TargetRegistry(config, logger, config.cache.dir);
 
   // A failed login must not kill the server: the MCP transport starts anyway
   // (tool registration needs no CCU) and the session retries lazily on the
   // first CCU call. This keeps the server alive through CCU outages and lets
-  // it start before the CCU is reachable.
+  // it start before the CCU is reachable. Only the active target logs in eagerly;
+  // others log in lazily on first use / switch.
   try {
-    await session.login();
+    await targets.loginActive();
   } catch (err) {
     logger.warn("startup_degraded", {
       error: (err as Error).message,
@@ -52,16 +54,24 @@ async function main(): Promise<void> {
     });
   }
 
-  // Initialize device type cache
-  const deviceTypeCache = new DeviceTypeCache(config.cache.dir, config.cache.ttl, logger);
-  await deviceTypeCache.loadFromDisk();
-  deviceTypeCache.warm(session, rateLimiter).catch((err) => {
+  // Load each target's device-type cache; warm only the active one in background.
+  await targets.loadCaches();
+  targets.warmActive(rateLimiter).catch((err) => {
     logger.error("cache_warm_background_error", { error: (err as Error).message });
   });
 
-  // Create resolver and shared tool dependencies
-  const resolver = new Resolver();
-  const deps = { config, session, rateLimiter, logger, deviceTypeCache, resolver };
+  // Shared tool dependencies. session/resolver/deviceTypeCache are getters that
+  // resolve to the ACTIVE target each access, so a use_ccu() switch is picked up
+  // by the next tool call without touching tools that read deps.session etc.
+  const deps: ServerDeps = {
+    config,
+    targets,
+    get session() { return targets.active.session; },
+    get resolver() { return targets.active.resolver; },
+    get deviceTypeCache() { return targets.active.deviceTypeCache; },
+    rateLimiter,
+    logger,
+  };
 
   let poller: ResourcePoller;
   let closeTransports: () => Promise<void>;
@@ -73,7 +83,7 @@ async function main(): Promise<void> {
     await mcpServer.connect(transport);
     poller = new ResourcePoller(
       () => mcpServer.server.sendResourceListChanged(),
-      session, rateLimiter, logger, config.resourcePollInterval,
+      targets.active.session, rateLimiter, logger, config.resourcePollInterval,
     );
     poller.start();
     closeTransports = () => mcpServer.close();
@@ -136,7 +146,7 @@ async function main(): Promise<void> {
 
         // Health check endpoint
         if (req.url === "/health" && req.method === "GET") {
-          handleHealthRequest(req, res, { session, deviceTypeCache });
+          handleHealthRequest(req, res, { session: targets.active.session, deviceTypeCache: targets.active.deviceTypeCache });
           return;
         }
 
@@ -253,7 +263,7 @@ async function main(): Promise<void> {
           [...sessions.values()].map((s) => s.server.server.sendResourceListChanged()),
         );
       },
-      session, rateLimiter, logger, config.resourcePollInterval,
+      targets.active.session, rateLimiter, logger, config.resourcePollInterval,
     );
     poller.start();
     closeTransports = async () => {
@@ -287,9 +297,9 @@ async function main(): Promise<void> {
       poller.stop();
       rateLimiter.destroy();
       httpServer?.close();
-      await deviceTypeCache.saveToDisk();
-      await session.logout();
-      session.destroy();
+      await targets.saveCaches();
+      await targets.logoutAll();
+      targets.destroyAll();
       await closeTransports();
     } catch (err) {
       logger.error("shutdown_error", { error: (err as Error).message });

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -4,11 +4,14 @@ import { withRetry } from "../middleware/retry.js";
 import { VERSION } from "../utils.js";
 
 export function registerResources(server: McpServer, deps: ServerDeps): void {
-  const { session, rateLimiter, logger, deviceTypeCache } = deps;
+  const { rateLimiter, logger } = deps;
 
+  // Read deps.session / deps.deviceTypeCache per-call (they're getters for the
+  // ACTIVE target) so resources follow a use_ccu() switch instead of capturing
+  // the startup target at registration time.
   const ccuRead = async (method: string) => {
     await rateLimiter.acquire();
-    return withRetry(() => session.call(method), method, logger);
+    return withRetry(() => deps.session.call(method), method, logger);
   };
 
   server.registerResource("devices", "homematic://devices", { description: "All devices with channels" }, async () => ({
@@ -36,7 +39,7 @@ export function registerResources(server: McpServer, deps: ServerDeps): void {
   }));
 
   server.registerResource("device-types", "homematic://device-types", { description: "Cached device type schemas" }, async () => ({
-    contents: [{ uri: "homematic://device-types", text: JSON.stringify(deviceTypeCache.getAll(), null, 2), mimeType: "application/json" }],
+    contents: [{ uri: "homematic://device-types", text: JSON.stringify(deps.deviceTypeCache.getAll(), null, 2), mimeType: "application/json" }],
   }));
 
   server.registerResource("system", "homematic://system", { description: "CCU system info" }, async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,22 +5,32 @@ import type { RateLimiter } from "./middleware/rate-limiter.js";
 import type { Logger } from "./logger.js";
 import type { DeviceTypeCache } from "./cache/device-type-cache.js";
 import type { Resolver } from "./middleware/resolver.js";
+import type { TargetRegistry } from "./ccu/target-registry.js";
 import { registerDiscoveryTools } from "./tools/discovery.js";
 import { registerReadTools } from "./tools/read.js";
 import { registerControlTools } from "./tools/control.js";
 import { registerDiagnosticsTools } from "./tools/diagnostics.js";
 import { registerMetaTools } from "./tools/meta.js";
+import { registerTargetTools } from "./tools/targets.js";
 import { registerResources } from "./resources/registry.js";
 import { registerPrompts } from "./prompts/registry.js";
 import { VERSION } from "./utils.js";
 
 export interface ServerDeps {
   config: AppConfig;
-  session: SessionManager;
+  /** All configured CCU targets and the active pointer. */
+  targets: TargetRegistry;
+  /**
+   * The ACTIVE target's session/resolver/device-type cache. These are getters
+   * (see index.ts / _helpers.ts) that resolve to `targets.active.*` on each
+   * access, so a use_ccu() switch is picked up by the next tool call without
+   * touching any tool that reads `deps.session` etc.
+   */
+  readonly session: SessionManager;
+  readonly resolver: Resolver;
+  readonly deviceTypeCache: DeviceTypeCache;
   rateLimiter: RateLimiter;
   logger: Logger;
-  deviceTypeCache: DeviceTypeCache;
-  resolver: Resolver;
 }
 
 export function createMcpServer(deps: ServerDeps): McpServer {
@@ -44,6 +54,7 @@ export function createMcpServer(deps: ServerDeps): McpServer {
   registerControlTools(server, deps);
   registerDiagnosticsTools(server, deps);
   registerMetaTools(server, deps);
+  registerTargetTools(server, deps);
   registerResources(server, deps);
   registerPrompts(server);
 

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -4,21 +4,20 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult, parseValue, escapeHmScript } from "../utils.js";
 
-// Short-lived name→type cache (#9), shared so create/delete can invalidate it
-// and a freshly created/removed variable is reflected on the next set.
-interface SysVarTypeCacheHolder {
-  entry: { ts: number; types: Map<string, string> } | null;
-}
+// Optional `confirm` field for write tools: required (true) to authorize a write
+// against a `protected` CCU target (e.g. prod). Harmless on unprotected targets.
+const confirmField = z.boolean().optional()
+  .describe("Set true to authorize this write against a protected CCU target (e.g. prod). Unlocks writes to that target for the rest of the session.");
 
 export function registerControlTools(server: McpServer, deps: ServerDeps): void {
-  const sysVarTypeCache: SysVarTypeCacheHolder = { entry: null };
   registerSetValue(server, deps);
   registerPutParamset(server, deps);
-  registerSetSystemVariable(server, deps, sysVarTypeCache);
-  registerCreateSystemVariable(server, deps, sysVarTypeCache);
-  registerDeleteSystemVariable(server, deps, sysVarTypeCache);
+  registerSetSystemVariable(server, deps);
+  registerCreateSystemVariable(server, deps);
+  registerDeleteSystemVariable(server, deps);
   registerExecuteProgram(server, deps);
   registerAssignChannel(server, deps, "add");
   registerAssignChannel(server, deps, "remove");
@@ -39,6 +38,7 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
         value: z.union([z.string(), z.number(), z.boolean()]).describe("Value to set"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
         type: z.enum(["bool", "int", "double", "string"]).optional().describe("Value type override (auto-resolved if omitted)"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -51,6 +51,7 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
         const valueType = args.type ?? deps.resolver.resolveType(args.address, args.valueKey, deviceTypeCache) ?? inferType(args.value);
 
@@ -113,6 +114,7 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
         set: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
           .describe("Key-value pairs to write (e.g. {TEMPERATURE_WINDOW_OPEN: 5.0})"),
         interface: z.string().optional().describe("Interface name override"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -125,6 +127,7 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
         // CCU expects set as array of {name, type, value} objects
@@ -160,10 +163,10 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
 
 const SYSVAR_TYPE_TTL_MS = 30_000;
 
-function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCacheHolder: SysVarTypeCacheHolder): void {
-  // Short-lived name→type cache (shared via the holder): avoids fetching the
-  // full sysvar list on every write. create/delete clear it so new/removed
-  // variables are reflected immediately.
+function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
+  // Short-lived name→type cache (per active target): avoids fetching the full
+  // sysvar list on every write. create/delete clear it so new/removed variables
+  // are reflected immediately.
 
   server.registerTool(
     "set_system_variable",
@@ -174,6 +177,7 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCach
       inputSchema: {
         name: z.string().describe("Variable name (exact match)"),
         value: z.union([z.string(), z.number(), z.boolean()]).describe("Value to set"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -183,9 +187,11 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCach
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
+      const typeCacheHolder = deps.targets.active.sysVarTypeCache;
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         // Look up variable type (cached) to choose correct setter
         let method: string;
         let sysVarType: string | undefined;
@@ -219,7 +225,7 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCach
             await withRetry(
               () => session.call("ReGa.runScript", {
                 script: `var sv = dom.GetObject("${escapedName}"); if (sv) { sv.State("${escapedValue}"); }`,
-              }, deps.config.ccu.scriptTimeout),
+              }, deps.targets.active.profile.ccu.scriptTimeout),
               "ReGa.runScript",
               logger,
             );
@@ -262,7 +268,7 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCach
   );
 }
 
-function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeCacheHolder: SysVarTypeCacheHolder): void {
+function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void {
   server.registerTool(
     "create_system_variable",
     {
@@ -279,6 +285,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
         min: z.number().optional().describe("Minimum value (float only)"),
         max: z.number().optional().describe("Maximum value (float only)"),
         values: z.array(z.string()).optional().describe("Enum value labels in order (enum only, e.g. ['off','low','high'])"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -287,9 +294,11 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
+      const typeCacheHolder = deps.targets.active.sysVarTypeCache;
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         if (args.type === "enum" && (!args.values || args.values.length === 0)) {
           throw new CcuError({
             error: "INVALID_INPUT",
@@ -383,7 +392,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
 
         await rateLimiter.acquire();
         const createResult = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
@@ -421,7 +430,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
   );
 }
 
-function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps, typeCacheHolder: SysVarTypeCacheHolder): void {
+function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void {
   server.registerTool(
     "delete_system_variable",
     {
@@ -429,6 +438,7 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps, typeC
       description: "Delete a system variable by name. Use list_system_variables to see existing names.",
       inputSchema: {
         name: z.string().describe("Variable name (exact match)"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -438,9 +448,11 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps, typeC
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
+      const typeCacheHolder = deps.targets.active.sysVarTypeCache;
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         // Validate existence so an unknown name is a clean NOT_FOUND rather than
         // a silent no-op (deleteSysVarByName doesn't report a missing name).
         await rateLimiter.acquire();
@@ -494,6 +506,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
         channel: z.string().describe("Channel address (e.g. '000A1BE9A71F15:1')"),
         room: z.string().optional().describe("Room name (exact match)"),
         function: z.string().optional().describe("Function group name (exact match)"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -506,6 +519,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         if (!args.room && !args.function) {
           throw new CcuError({
             error: "INVALID_INPUT",
@@ -613,6 +627,7 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
         "Use list_programs to find program IDs.",
       inputSchema: {
         id: z.string().describe("Program ID. Get from list_programs."),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -624,6 +639,7 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         // The CCU's Program.execute reports success even for nonexistent IDs
         // (issue #18) — validate against the program list first.
         await rateLimiter.acquire();

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -4,6 +4,7 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
@@ -95,7 +96,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
 
         await rateLimiter.acquire();
         const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
@@ -136,6 +137,7 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
       inputSchema: {
         id: z.string().optional().describe("Alarm id from get_service_messages (confirm a single message)"),
         address: z.string().optional().describe("Channel address — confirm all active messages on this channel (e.g. '000A1BE9A71F15:0')"),
+        confirm: z.boolean().optional().describe("Set true to authorize this write against a protected CCU target (e.g. prod)."),
       },
       annotations: {
         destructiveHint: true,
@@ -148,6 +150,7 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         if (!args.id && !args.address) {
           throw new CcuError({
             error: "INVALID_INPUT",
@@ -205,7 +208,7 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
 
         await rateLimiter.acquire();
         const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
@@ -246,6 +249,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       description: "Get CCU system information: firmware version, serial number, addresses.",
       outputSchema: {
         serverVersion: z.string().optional(),
+        target: z.string().optional().describe("Active CCU target name"),
         version: z.unknown().optional(),
         serial: z.unknown().optional(),
         address: z.unknown().optional(),
@@ -260,7 +264,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
-        const results: Record<string, unknown> = { serverVersion: VERSION };
+        const results: Record<string, unknown> = { serverVersion: VERSION, target: deps.targets.active.profile.name };
 
         const calls: Array<{ key: string; method: string }> = [
           { key: "version", method: "CCU.getVersion" },

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -4,7 +4,12 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { resolveTarget } from "../ccu/target-registry.js";
 import { toolResult, structuredResult } from "../utils.js";
+
+// Optional per-call target override (route one read to a named CCU).
+const targetField = z.string().optional()
+  .describe("CCU target to read from (default: active). See list_ccu_targets.");
 
 export function registerDiscoveryTools(server: McpServer, deps: ServerDeps): void {
   registerListDevices(server, deps);
@@ -31,15 +36,17 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
         function: z.string().optional().describe("Filter by function group name (exact match)"),
         type: z.string().optional().describe("Filter by device type (exact match, e.g. 'HmIP-eTRV-2')"),
         name: z.string().optional().describe("Filter by device/channel name (substring, case-insensitive)"),
+        target: targetField,
       },
       outputSchema: { devices: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
       const start = Date.now();
 
       try {
+        const { session, resolver } = resolveTarget(deps.targets, args.target);
         await rateLimiter.acquire();
         const result = await withRetry(
           () => session.call("Device.listAllDetail"),
@@ -50,7 +57,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
         let devices = result as CcuDevice[];
 
         // Update resolver's device list
-        deps.resolver.updateDeviceList(devices);
+        resolver.updateDeviceList(devices);
 
         if (args.room || args.function) {
           const channelIds = new Set<string>();
@@ -287,13 +294,23 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
         "Served from cache (instant). Use list_devices first to find device types.",
       inputSchema: {
         deviceType: z.string().describe("Device type name (e.g. 'HmIP-eTRV-2', 'HmIP-SWDO-I'). Get from list_devices."),
+        target: targetField,
       },
       outputSchema: { deviceType: z.string().optional().describe("Echoed device type; other keys hold the channel/datapoint schema or a not-found hint") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
-      const { session, rateLimiter, logger, deviceTypeCache } = deps;
+      const { rateLimiter, logger } = deps;
       const start = Date.now();
+
+      let target;
+      try {
+        target = resolveTarget(deps.targets, args.target);
+      } catch (err) {
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+      const { session, resolver, deviceTypeCache } = target;
 
       let cached = deviceTypeCache.get(args.deviceType);
 
@@ -303,7 +320,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
       }
 
       // Cache miss — try live query if we can find a device instance
-      const devices = deps.resolver.getDeviceList();
+      const devices = resolver.getDeviceList();
       if (devices) {
         const device = devices.find((d) => d.type === args.deviceType);
         if (device) {

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { CcuError } from "../middleware/error-mapper.js";
+import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult } from "../utils.js";
 
 export function registerMetaTools(server: McpServer, deps: ServerDeps): void {
@@ -36,6 +37,17 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 3. \`get_value\` / \`get_values\` / \`get_paramset\` → read current state
 4. \`set_value\` / \`put_paramset\` → change state (returns previous value)
 
+## CCU Targets (prod / dev)
+This server can be configured with several named CCU targets (profiles). One is
+"active" at a time; tools run against it.
+- \`list_ccu_targets\` — see configured targets (name, host, user, protected/active)
+- \`get_connection_info\` — confirm which target is active (do this before a write!)
+- \`use_ccu\` — switch the active target
+- Read tools accept an optional \`target\` arg to read from another target for one
+  call without switching (e.g. compare prod vs dev).
+- A \`protected\` target (e.g. prod) refuses writes unless you pass \`confirm: true\`
+  once — that unlocks writes to it for the rest of the session.
+
 ## Tips
 - Use \`list_devices\` with room/function filters to reduce output
 - Use \`get_values\` with room filter instead of multiple \`get_value\` calls
@@ -49,6 +61,7 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 **Read:** get_value, get_values, get_paramset
 **Control:** set_value, put_paramset, set_system_variable, create_system_variable, delete_system_variable, assign_channel, unassign_channel, execute_program
 **Diagnostics:** get_service_messages, acknowledge_service_messages, get_rssi, get_system_info
+**Targets:** list_ccu_targets, get_connection_info, use_ccu
 **Meta:** help, run_script
 `;
 
@@ -163,8 +176,23 @@ Returns: {devices: [{address, name, interface, links: [{peer, peerName, rssiDevi
 rssiDevice/rssiPeer are dBm (higher = better); null means no measurement. Use to diagnose flaky devices.`,
 
   run_script: `Execute arbitrary HomeMatic Script. NOT idempotent — never auto-retried.
-Args: script (string)
+Args: script (string), confirm? (true to write to a protected target)
 Returns: Script output`,
+
+  list_ccu_targets: `List configured CCU targets (profiles) you can switch between.
+Args: none
+Returns: {targets: [{name, host, port, user, https, protected, readonly, active, loggedIn}], active}
+Never exposes passwords.`,
+
+  get_connection_info: `Report the active CCU target (host, user, https, protected/readonly, login state).
+Args: none
+Returns: {name, host, port, user, https, protected, readonly, active, loggedIn, writesUnlocked}
+Use before a write to confirm WHERE it will run.`,
+
+  use_ccu: `Switch the active CCU target. Subsequent calls run against it.
+Args: profile (string — see list_ccu_targets)
+Returns: the new active connection info
+For a one-off read elsewhere, prefer the per-call \`target\` arg on read tools instead.`,
 
   help: `Context-aware help. No args = guide, tool name = tool docs, device type = schema.
 Args: topic? (string)`,
@@ -222,6 +250,7 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
         "Use for anything the other tools don't cover.",
       inputSchema: {
         script: z.string().describe("HomeMatic Script to execute"),
+        confirm: z.boolean().optional().describe("Set true to authorize this script against a protected CCU target (e.g. prod)."),
       },
       annotations: {
         destructiveHint: true,
@@ -233,9 +262,10 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         await rateLimiter.acquire();
         // No retry — scripts are not idempotent
-        const result = await session.call("ReGa.runScript", { script: args.script }, deps.config.ccu.scriptTimeout);
+        const result = await session.call("ReGa.runScript", { script: args.script }, deps.targets.active.profile.ccu.scriptTimeout);
 
         logger.info("tool_call", { tool: "run_script", duration_ms: Date.now() - start, status: "ok" });
         return toolResult(result);

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -3,7 +3,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { resolveTarget } from "../ccu/target-registry.js";
 import { toolResult, structuredResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
+
+// Optional per-call target override for read tools: route this one read to a
+// named CCU without switching the active target (handy for prod-vs-dev compares).
+const targetField = z.string().optional()
+  .describe("CCU target to read from (default: active). See list_ccu_targets.");
 
 export function registerReadTools(server: McpServer, deps: ServerDeps): void {
   registerGetValue(server, deps);
@@ -24,6 +30,7 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
         address: z.string().describe("Channel address (e.g. '000A1BE9A71F15:1')"),
         valueKey: z.string().describe("Datapoint name (e.g. 'STATE', 'LEVEL', 'ACTUAL_TEMPERATURE')"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
+        target: targetField,
       },
       outputSchema: {
         address: z.string(),
@@ -33,11 +40,12 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
       const start = Date.now();
 
       try {
-        const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
+        const { session, resolver } = resolveTarget(deps.targets, args.target);
+        const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
         await rateLimiter.acquire();
         const value = await withRetry(
@@ -73,6 +81,7 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         channels: z.array(z.string()).optional().describe("Array of channel addresses to read"),
         room: z.string().optional().describe("Room name — read all channels in this room"),
         function: z.string().optional().describe("Function name — read all channels in this function group"),
+        target: targetField,
       },
       outputSchema: {
         values: z.array(z.unknown()).describe("One entry per channel: {address, name, datapoints}"),
@@ -80,10 +89,12 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
       const start = Date.now();
 
       try {
+        const t = resolveTarget(deps.targets, args.target);
+        const { session } = t;
         // Build HM Script to collect values
         let script: string;
 
@@ -108,7 +119,7 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
 
         await rateLimiter.acquire();
         const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, t.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
@@ -207,6 +218,7 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
         address: z.string().describe("Channel address (e.g. '000A1BE9A71F15:1')"),
         paramsetKey: z.enum(["VALUES", "MASTER", "LINK"]).describe("Paramset to read"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
+        target: targetField,
       },
       outputSchema: {
         address: z.string(),
@@ -216,11 +228,12 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
       const start = Date.now();
 
       try {
-        const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
+        const { session, resolver } = resolveTarget(deps.targets, args.target);
+        const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
         await rateLimiter.acquire();
         const result = await withRetry(

--- a/src/tools/targets.ts
+++ b/src/tools/targets.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ServerDeps } from "../server.js";
+import type { Target } from "../ccu/target-registry.js";
+import { CcuError } from "../middleware/error-mapper.js";
+import { structuredResult } from "../utils.js";
+
+export function registerTargetTools(server: McpServer, deps: ServerDeps): void {
+  registerListTargets(server, deps);
+  registerGetConnectionInfo(server, deps);
+  registerUseCcu(server, deps);
+}
+
+// Identity view of a target — NEVER includes the password.
+function targetInfo(t: Target, activeName: string) {
+  return {
+    name: t.profile.name,
+    host: t.profile.ccu.host,
+    port: t.profile.ccu.port,
+    user: t.profile.ccu.user,
+    https: t.profile.ccu.https,
+    protected: t.profile.protected,
+    readonly: t.profile.readonly,
+    active: t.profile.name === activeName,
+    loggedIn: t.session.isLoggedIn(),
+    writesUnlocked: t.unlocked,
+  };
+}
+
+function registerListTargets(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "list_ccu_targets",
+    {
+      title: "List CCU Targets",
+      description:
+        "List all configured CCU targets (profiles) you can switch between with use_ccu — name, host, " +
+        "user, whether protected/read-only, which is active, and login state. Never exposes passwords.",
+      outputSchema: {
+        targets: z.array(z.unknown()).describe("Configured targets: {name, host, port, user, https, protected, readonly, active, loggedIn}"),
+        active: z.string().describe("Name of the currently active target"),
+      },
+      // Local-only: reads in-memory config; never reaches a CCU.
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async () => {
+      const activeName = deps.targets.active.profile.name;
+      const targets = deps.targets.list().map((t) => targetInfo(t, activeName));
+      return structuredResult({ targets, active: activeName }, { targets, active: activeName });
+    },
+  );
+}
+
+function registerGetConnectionInfo(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "get_connection_info",
+    {
+      title: "Get Connection Info",
+      description:
+        "Report which CCU target is currently active — host, user, https, protected/read-only flags, and " +
+        "login state. Use this to confirm WHERE a command will run (especially before a write). No password.",
+      outputSchema: {
+        name: z.string(),
+        host: z.string(),
+        port: z.number(),
+        user: z.string(),
+        https: z.boolean(),
+        protected: z.boolean(),
+        readonly: z.boolean(),
+        active: z.boolean(),
+        loggedIn: z.boolean(),
+        writesUnlocked: z.boolean(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async () => {
+      const active = deps.targets.active;
+      return structuredResult(targetInfo(active, active.profile.name));
+    },
+  );
+}
+
+function registerUseCcu(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "use_ccu",
+    {
+      title: "Switch CCU Target",
+      description:
+        "Switch the active CCU target. All subsequent tool calls go to this target until switched again " +
+        "(use the per-call `target` arg on read tools for a one-off without switching). Returns the new " +
+        "active connection info. Login happens lazily on the first call.",
+      inputSchema: {
+        profile: z.string().describe("Target name (see list_ccu_targets)"),
+      },
+      outputSchema: {
+        name: z.string(),
+        host: z.string(),
+        port: z.number(),
+        user: z.string(),
+        https: z.boolean(),
+        protected: z.boolean(),
+        readonly: z.boolean(),
+        active: z.boolean(),
+        loggedIn: z.boolean(),
+        writesUnlocked: z.boolean(),
+      },
+      annotations: { readOnlyHint: false, openWorldHint: false },
+    },
+    async (args) => {
+      try {
+        const t = deps.targets.use(args.profile);
+        deps.logger.info("ccu_target_switched", { target: t.profile.name });
+        return structuredResult(targetInfo(t, t.profile.name));
+      } catch (err) {
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+    },
+  );
+}

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -133,7 +133,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, sid);
     expect(res.status).toBe(200);
     const msg = await parseSse(res);
-    expect(msg.result.tools.length).toBe(25);
+    expect(msg.result.tools.length).toBe(28);
   });
 
   it("returns a structured tool error (not a crash) when a tool needs the CCU", async () => {
@@ -251,7 +251,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
       const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: i, method: "tools/list", params: {} }, sid);
       expect(res.status).toBe(200);
       const msg = await parseSse(res);
-      expect(msg.result.tools.length).toBe(25);
+      expect(msg.result.tools.length).toBe(28);
     }
   });
 

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { SessionManager } from "../../src/ccu/session.js";
 import { RateLimiter } from "../../src/middleware/rate-limiter.js";
-import { DeviceTypeCache } from "../../src/cache/device-type-cache.js";
-import { Resolver } from "../../src/middleware/resolver.js";
+import { TargetRegistry } from "../../src/ccu/target-registry.js";
 import { createLogger } from "../../src/logger.js";
 import { createMcpServer, type ServerDeps } from "../../src/server.js";
+import type { AppConfig } from "../../src/config.js";
 import { escapeHmScript } from "../../src/utils.js";
 import { callTool, parseToolResult } from "../unit/_helpers.js";
 import type { CcuConfig } from "../../src/ccu/types.js";
@@ -32,35 +31,39 @@ describeIf("MCP tools against live CCU", () => {
   };
 
   const logger = createLogger();
-  let session: SessionManager;
+  let targets: TargetRegistry;
   let server: McpServer;
   let deps: ServerDeps;
   let tempDir: string;
 
   beforeAll(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "debmatic-tools-live-"));
-    session = new SessionManager(config, logger, tempDir);
-    await session.login();
+    const appConfig: AppConfig = {
+      ccu: config,
+      profiles: [{ name: "default", protected: false, readonly: false, ccu: config }],
+      defaultProfile: "default",
+      mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
+      cache: { dir: tempDir, ttl: 86400 },
+      rateLimiter: { burst: 20, rate: 10 },
+      resourcePollInterval: 3600,
+    };
+    targets = new TargetRegistry(appConfig, logger, tempDir);
+    await targets.loginActive();
     deps = {
-      config: {
-        ccu: config,
-        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
-        cache: { dir: tempDir, ttl: 86400 },
-        rateLimiter: { burst: 20, rate: 10 },
-        resourcePollInterval: 3600,
-      },
-      session,
+      config: appConfig,
+      targets,
+      get session() { return targets.active.session; },
+      get resolver() { return targets.active.resolver; },
+      get deviceTypeCache() { return targets.active.deviceTypeCache; },
       rateLimiter: new RateLimiter(20, 10),
       logger,
-      deviceTypeCache: new DeviceTypeCache(tempDir, 86400, logger),
-      resolver: new Resolver(),
     };
     server = createMcpServer(deps);
   }, 30_000);
 
   afterAll(async () => {
-    await session.logout();
-    session.destroy();
+    await targets.logoutAll();
+    targets.destroyAll();
     deps.rateLimiter.destroy();
     await rm(tempDir, { recursive: true, force: true });
   });

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -4,33 +4,107 @@ import { Logger } from "../../src/logger.js";
 import { RateLimiter } from "../../src/middleware/rate-limiter.js";
 import { DeviceTypeCache } from "../../src/cache/device-type-cache.js";
 import { Resolver } from "../../src/middleware/resolver.js";
+import type { Target, TargetRegistry } from "../../src/ccu/target-registry.js";
+import { CcuError } from "../../src/middleware/error-mapper.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+type SessionCall = (method: string, params?: Record<string, unknown>, timeout?: number) => Promise<unknown>;
+
+interface TargetSpec {
+  name?: string;
+  protected?: boolean;
+  readonly?: boolean;
+  password?: string;
+  sessionCall?: SessionCall;
+}
+
+function makeSession(sessionCall?: SessionCall) {
+  return {
+    call: sessionCall ?? vi.fn(async () => []),
+    login: vi.fn(async () => {}),
+    logout: vi.fn(async () => {}),
+    isLoggedIn: vi.fn(() => true),
+    getSessionId: vi.fn(() => "test-session"),
+    callNoSession: vi.fn(async () => null),
+    destroy: vi.fn(),
+  } as any;
+}
+
+function makeTarget(spec: TargetSpec): Target {
+  const name = spec.name ?? "default";
+  return {
+    profile: {
+      name,
+      protected: spec.protected ?? false,
+      readonly: spec.readonly ?? false,
+      ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: spec.password ?? "pw", timeout: 5000, scriptTimeout: 10000 },
+    },
+    session: makeSession(spec.sessionCall),
+    resolver: new Resolver(),
+    deviceTypeCache: new DeviceTypeCache("/tmp/nonexistent-test", 86400, new Logger("error"), `device-type-cache.${name}.json`),
+    sysVarTypeCache: { entry: null },
+    unlocked: false,
+  };
+}
+
+// Minimal in-memory stand-in for TargetRegistry (real one builds live sessions).
+class FakeRegistry {
+  private readonly byName = new Map<string, Target>();
+  private readonly order: string[] = [];
+  private activeKey: string;
+  constructor(targets: Target[]) {
+    for (const t of targets) {
+      this.byName.set(t.profile.name.toLowerCase(), t);
+      this.order.push(t.profile.name);
+    }
+    this.activeKey = targets[0]!.profile.name.toLowerCase();
+  }
+  get active(): Target { return this.byName.get(this.activeKey)!; }
+  getByName(name: string): Target | undefined { return this.byName.get(name.toLowerCase()); }
+  has(name: string): boolean { return this.byName.has(name.toLowerCase()); }
+  list(): Target[] { return this.order.map((n) => this.byName.get(n.toLowerCase())!); }
+  use(name: string): Target {
+    const t = this.getByName(name);
+    if (!t) throw new CcuError({ error: "NOT_FOUND", code: 0, message: `Unknown CCU target: ${name}`, hint: "Call list_ccu_targets." });
+    this.activeKey = t.profile.name.toLowerCase();
+    return t;
+  }
+}
+
 export function createMockDeps(overrides?: {
-  sessionCall?: (method: string, params?: Record<string, unknown>, timeout?: number) => Promise<unknown>;
+  sessionCall?: SessionCall;
+  /** Mark the (single default) target protected. */
+  protected?: boolean;
+  /** Mark the (single default) target read-only. */
+  readonly?: boolean;
+  /** Build a multi-target registry instead of the single default target. */
+  targets?: TargetSpec[];
 }): ServerDeps {
   const rateLimiter = new RateLimiter(1000, 1000); // effectively unlimited for tests
+  const specs: TargetSpec[] = overrides?.targets ?? [{
+    name: "default",
+    protected: overrides?.protected,
+    readonly: overrides?.readonly,
+    sessionCall: overrides?.sessionCall,
+  }];
+  const registry = new FakeRegistry(specs.map(makeTarget));
+
   return {
     config: {
-      ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
+      ccu: registry.active.profile.ccu,
+      profiles: registry.list().map((t) => t.profile),
+      defaultProfile: registry.active.profile.name,
       mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,
     },
-    session: {
-      call: overrides?.sessionCall ?? vi.fn(async () => []),
-      login: vi.fn(async () => {}),
-      logout: vi.fn(async () => {}),
-      isLoggedIn: vi.fn(() => true),
-      getSessionId: vi.fn(() => "test-session"),
-      callNoSession: vi.fn(async () => null),
-      destroy: vi.fn(),
-    } as any,
+    targets: registry as unknown as TargetRegistry,
+    get session() { return registry.active.session; },
+    get resolver() { return registry.active.resolver; },
+    get deviceTypeCache() { return registry.active.deviceTypeCache; },
     rateLimiter,
     logger: new Logger("error"),
-    deviceTypeCache: new DeviceTypeCache("/tmp/nonexistent-test", 86400, new Logger("error")),
-    resolver: new Resolver(),
   };
 }
 

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -40,6 +40,11 @@ describe("loadConfig", () => {
     delete process.env.MCP_TLS_KEY;
     delete process.env.MCP_ALLOW_PLAINTEXT;
     delete process.env.LOG_LEVEL;
+    delete process.env.CCU_PROFILES;
+    delete process.env.CCU_DEFAULT_PROFILE;
+    for (const k of Object.keys(process.env)) {
+      if (/^CCU_(PROD|DEV|STAGING)_/.test(k)) delete process.env[k];
+    }
   });
 
   afterEach(() => {
@@ -319,5 +324,88 @@ describe("loadConfig", () => {
     expect(() => loadConfig()).toThrow(/MCP_AUTH_TOKEN_TTL_DAYS must be a positive number/);
     process.env.MCP_AUTH_TOKEN_TTL_DAYS = "soon";
     expect(() => loadConfig()).toThrow(/MCP_AUTH_TOKEN_TTL_DAYS must be a positive number/);
+  });
+
+  // Issue #69: multiple named CCU targets (profiles)
+  describe("CCU profiles", () => {
+    it("flat config (no CCU_PROFILES) yields a single 'default' profile, ccu alias intact", () => {
+      process.env.CCU_HOST = "debmatic";
+      process.env.CCU_PASSWORD = "secret";
+      const config = loadConfig();
+      expect(config.profiles).toHaveLength(1);
+      expect(config.profiles[0]!.name).toBe("default");
+      expect(config.profiles[0]!.protected).toBe(false);
+      expect(config.profiles[0]!.readonly).toBe(false);
+      expect(config.defaultProfile).toBe("default");
+      // ccu stays an alias of the default profile (back-compat)
+      expect(config.ccu).toBe(config.profiles[0]!.ccu);
+      expect(config.ccu.host).toBe("debmatic");
+      expect(config.ccu.password).toBe("secret");
+    });
+
+    it("builds one profile per CCU_PROFILES entry from CCU_<NAME>_* vars", () => {
+      process.env.CCU_PROFILES = "prod,dev";
+      process.env.CCU_DEFAULT_PROFILE = "prod";
+      process.env.CCU_PROD_HOST = "debmatic";
+      process.env.CCU_PROD_USER = "claude";
+      process.env.CCU_PROD_PASSWORD = "topsecret";
+      process.env.CCU_PROD_HTTPS = "true";
+      process.env.CCU_PROD_PROTECTED = "true";
+      process.env.CCU_DEV_HOST = "127.0.0.1";
+      process.env.CCU_DEV_PORT = "18080";
+      // dev password intentionally unset (OpenCCU default empty)
+
+      const config = loadConfig();
+      expect(config.profiles.map((p) => p.name)).toEqual(["prod", "dev"]);
+      expect(config.defaultProfile).toBe("prod");
+      expect(config.ccu.host).toBe("debmatic"); // alias = default (prod)
+
+      const prod = config.profiles[0]!;
+      expect(prod.protected).toBe(true);
+      expect(prod.ccu.user).toBe("claude");
+      expect(prod.ccu.https).toBe(true);
+      expect(prod.ccu.port).toBe(443); // https default
+
+      const dev = config.profiles[1]!;
+      expect(dev.protected).toBe(false);
+      expect(dev.ccu.host).toBe("127.0.0.1");
+      expect(dev.ccu.port).toBe(18080);
+      expect(dev.ccu.user).toBe("Admin"); // default
+      expect(dev.ccu.password).toBe(""); // empty allowed
+      expect(dev.ccu.https).toBe(false);
+    });
+
+    it("defaults the active profile to the first listed when CCU_DEFAULT_PROFILE is unset", () => {
+      process.env.CCU_PROFILES = "dev,prod";
+      process.env.CCU_DEV_HOST = "127.0.0.1";
+      process.env.CCU_PROD_HOST = "debmatic";
+      expect(loadConfig().defaultProfile).toBe("dev");
+    });
+
+    it("throws if a profile is missing its HOST", () => {
+      process.env.CCU_PROFILES = "prod";
+      // no CCU_PROD_HOST
+      expect(() => loadConfig()).toThrow(/profile "prod" is missing CCU_PROD_HOST/);
+    });
+
+    it("throws if CCU_DEFAULT_PROFILE names an unknown profile", () => {
+      process.env.CCU_PROFILES = "prod";
+      process.env.CCU_PROD_HOST = "debmatic";
+      process.env.CCU_DEFAULT_PROFILE = "dev";
+      expect(() => loadConfig()).toThrow(/CCU_DEFAULT_PROFILE="dev" is not one of CCU_PROFILES/);
+    });
+
+    it("rejects duplicate profile names", () => {
+      process.env.CCU_PROFILES = "prod,Prod";
+      process.env.CCU_PROD_HOST = "debmatic";
+      expect(() => loadConfig()).toThrow(/lists "Prod" more than once/);
+    });
+
+    it("reads per-profile READONLY flag", () => {
+      process.env.CCU_PROFILES = "prod";
+      process.env.CCU_PROD_HOST = "debmatic";
+      process.env.CCU_PROD_READONLY = "true";
+      expect(loadConfig().profiles[0]!.readonly).toBe(true);
+    });
   });
 });

--- a/test/unit/device-type-cache.test.ts
+++ b/test/unit/device-type-cache.test.ts
@@ -230,4 +230,30 @@ describe("warm edge cases (coverage round)", () => {
     expect(param).toMatchObject({ type: "FLOAT", operations: 7, min: 0, max: 1.01, unit: "%", valueList: ["a", "b"] });
     await new Promise((r) => setTimeout(r, 25)); // let background save finish
   });
+
+  // Issue #69: per-target caches must use distinct files so prod/dev don't mix.
+  it("uses a per-instance filename and keeps separate caches isolated on disk", async () => {
+    const prod = new DeviceTypeCache(tempDir, 86400, logger, "device-type-cache.prod.json");
+    const dev = new DeviceTypeCache(tempDir, 86400, logger, "device-type-cache.dev.json");
+
+    (prod as any).cache.set("HmIP-PROD", { interface: "HmIP-RF", channels: {} });
+    (dev as any).cache.set("HmIP-DEV", { interface: "HmIP-RF", channels: {} });
+    await prod.saveToDisk();
+    await dev.saveToDisk();
+
+    expect(JSON.parse(await readFile(join(tempDir, "device-type-cache.prod.json"), "utf-8")).types).toHaveProperty("HmIP-PROD");
+    expect(JSON.parse(await readFile(join(tempDir, "device-type-cache.dev.json"), "utf-8")).types).toHaveProperty("HmIP-DEV");
+
+    const prod2 = new DeviceTypeCache(tempDir, 86400, logger, "device-type-cache.prod.json");
+    await prod2.loadFromDisk();
+    expect(prod2.has("HmIP-PROD")).toBe(true);
+    expect(prod2.has("HmIP-DEV")).toBe(false);
+  });
+
+  it("defaults to the historical filename for back-compat", async () => {
+    const cache = new DeviceTypeCache(tempDir, 86400, logger);
+    (cache as any).cache.set("HmIP-X", { interface: "HmIP-RF", channels: {} });
+    await cache.saveToDisk();
+    expect(JSON.parse(await readFile(join(tempDir, "device-type-cache.json"), "utf-8")).types).toHaveProperty("HmIP-X");
+  });
 });

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -1,35 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { createMcpServer } from "../../src/server.js";
-import { Logger } from "../../src/logger.js";
-import { RateLimiter } from "../../src/middleware/rate-limiter.js";
-import { DeviceTypeCache } from "../../src/cache/device-type-cache.js";
-import { Resolver } from "../../src/middleware/resolver.js";
-
-// Minimal mock deps — we're testing that registration doesn't throw, not calling tools
-function createMockDeps() {
-  return {
-    config: {
-      ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
-      cache: { dir: "/tmp", ttl: 86400 },
-      rateLimiter: { burst: 20, rate: 10 },
-      resourcePollInterval: 60,
-    },
-    session: {
-      call: async () => [],
-      login: async () => {},
-      logout: async () => {},
-      isLoggedIn: () => true,
-      getSessionId: () => "test",
-      callNoSession: async () => null,
-      destroy: () => {},
-    } as any,
-    rateLimiter: new RateLimiter(20, 10),
-    logger: new Logger("error"),
-    deviceTypeCache: new DeviceTypeCache("/tmp", 86400, new Logger("error")),
-    resolver: new Resolver(),
-  };
-}
+import { createMockDeps } from "./_helpers.js";
 
 describe("MCP Server Registration", () => {
   it("creates server without errors", () => {
@@ -39,7 +10,7 @@ describe("MCP Server Registration", () => {
     deps.rateLimiter.destroy();
   });
 
-  it("registers all 18 tools", () => {
+  it("registers all tools", () => {
     const deps = createMockDeps();
     const server = createMcpServer(deps);
 
@@ -53,6 +24,7 @@ describe("MCP Server Registration", () => {
       "delete_system_variable",
       "describe_device_type",
       "execute_program",
+      "get_connection_info",
       "get_paramset",
       "get_rssi",
       "get_service_messages",
@@ -60,6 +32,7 @@ describe("MCP Server Registration", () => {
       "get_value",
       "get_values",
       "help",
+      "list_ccu_targets",
       "list_devices",
       "list_functions",
       "list_interfaces",
@@ -72,9 +45,10 @@ describe("MCP Server Registration", () => {
       "set_system_variable",
       "set_value",
       "unassign_channel",
+      "use_ccu",
     ]);
 
-    expect(Object.keys(tools).length).toBe(25);
+    expect(Object.keys(tools).length).toBe(28);
     deps.rateLimiter.destroy();
   });
 
@@ -131,7 +105,8 @@ describe("Tool annotations", () => {
   ];
   const WRITE_TOOLS = ["acknowledge_service_messages", "assign_channel", "create_system_variable", "delete_system_variable", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value", "unassign_channel"];
   const IDEMPOTENT_WRITES = ["acknowledge_service_messages", "assign_channel", "delete_system_variable", "put_paramset", "set_system_variable", "set_value", "unassign_channel"];
-  const LOCAL_TOOLS = ["help"]; // everything else reaches the external CCU
+  // help + the target-management tools are local-only (never reach a CCU).
+  const LOCAL_TOOLS = ["help", "list_ccu_targets", "get_connection_info", "use_ccu"];
 
   type Ann = {
     title?: string; readOnlyHint?: boolean; destructiveHint?: boolean;

--- a/test/unit/target-registry.test.ts
+++ b/test/unit/target-registry.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { TargetRegistry, resolveTarget, assertWritable } from "../../src/ccu/target-registry.js";
+import { Logger } from "../../src/logger.js";
+import type { AppConfig } from "../../src/config.js";
+import type { CcuProfile } from "../../src/ccu/types.js";
+import { CcuError } from "../../src/middleware/error-mapper.js";
+
+const logger = new Logger("error");
+
+function profile(name: string, opts?: Partial<Pick<CcuProfile, "protected" | "readonly">>): CcuProfile {
+  return {
+    name,
+    protected: opts?.protected ?? false,
+    readonly: opts?.readonly ?? false,
+    ccu: { host: `${name}-host`, port: 80, https: false, tlsVerify: false, user: "Admin", password: "", timeout: 5000, scriptTimeout: 10000 },
+  };
+}
+
+function appConfig(profiles: CcuProfile[], defaultProfile: string, cacheDir: string): AppConfig {
+  return {
+    ccu: profiles.find((p) => p.name === defaultProfile)!.ccu,
+    profiles,
+    defaultProfile,
+    mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
+    cache: { dir: cacheDir, ttl: 86400 },
+    rateLimiter: { burst: 20, rate: 10 },
+    resourcePollInterval: 60,
+  };
+}
+
+describe("TargetRegistry", () => {
+  let tempDir: string;
+  beforeEach(async () => { tempDir = await mkdtemp(join(tmpdir(), "ccu-registry-")); });
+  afterEach(async () => { await rm(tempDir, { recursive: true, force: true }); });
+
+  it("builds one target per profile and makes the default active", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod", { protected: true }), profile("dev")], "prod", tempDir), logger, tempDir);
+    expect(reg.list().map((t) => t.profile.name)).toEqual(["prod", "dev"]);
+    expect(reg.active.profile.name).toBe("prod");
+    expect(reg.active.profile.protected).toBe(true);
+  });
+
+  it("getByName / has are case-insensitive; unknown is undefined", () => {
+    const reg = new TargetRegistry(appConfig([profile("Prod"), profile("dev")], "Prod", tempDir), logger, tempDir);
+    expect(reg.getByName("prod")!.profile.name).toBe("Prod");
+    expect(reg.has("DEV")).toBe(true);
+    expect(reg.getByName("nope")).toBeUndefined();
+    expect(reg.has("nope")).toBe(false);
+  });
+
+  it("use() switches the active target and returns it", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
+    const t = reg.use("dev");
+    expect(t.profile.name).toBe("dev");
+    expect(reg.active.profile.name).toBe("dev");
+  });
+
+  it("use() on an unknown target throws a NOT_FOUND CcuError", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod")], "prod", tempDir), logger, tempDir);
+    expect(() => reg.use("ghost")).toThrowError(CcuError);
+    try { reg.use("ghost"); } catch (e) { expect((e as CcuError).structured.error).toBe("NOT_FOUND"); }
+  });
+
+  it("each target gets its own resolver, caches, and sysvar holder", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
+    const [prod, dev] = reg.list();
+    expect(prod!.resolver).not.toBe(dev!.resolver);
+    expect(prod!.deviceTypeCache).not.toBe(dev!.deviceTypeCache);
+    expect(prod!.sysVarTypeCache).not.toBe(dev!.sysVarTypeCache);
+    expect(prod!.unlocked).toBe(false);
+  });
+
+  it("saveCaches writes a distinct file per target; default keeps the legacy name", async () => {
+    const reg = new TargetRegistry(appConfig([profile("default"), profile("dev")], "default", tempDir), logger, tempDir);
+    const [def, dev] = reg.list();
+    (def!.deviceTypeCache as any).cache.set("HmIP-DEF", { interface: "HmIP-RF", channels: {} });
+    (dev!.deviceTypeCache as any).cache.set("HmIP-DEV", { interface: "HmIP-RF", channels: {} });
+    await reg.saveCaches();
+    const files = (await readdir(tempDir)).sort();
+    expect(files).toContain("device-type-cache.json");      // legacy name for "default"
+    expect(files).toContain("device-type-cache.dev.json");  // suffixed for "dev"
+  });
+});
+
+describe("resolveTarget", () => {
+  let tempDir: string;
+  beforeEach(async () => { tempDir = await mkdtemp(join(tmpdir(), "ccu-resolve-")); });
+  afterEach(async () => { await rm(tempDir, { recursive: true, force: true }); });
+
+  it("returns the active target when no name is given", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
+    expect(resolveTarget(reg).profile.name).toBe("prod");
+  });
+
+  it("returns the named target without switching active", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
+    expect(resolveTarget(reg, "dev").profile.name).toBe("dev");
+    expect(reg.active.profile.name).toBe("prod"); // unchanged
+  });
+
+  it("throws NOT_FOUND for an unknown name", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod")], "prod", tempDir), logger, tempDir);
+    expect(() => resolveTarget(reg, "ghost")).toThrowError(/Unknown CCU target/);
+  });
+});
+
+describe("assertWritable", () => {
+  let tempDir: string;
+  beforeEach(async () => { tempDir = await mkdtemp(join(tmpdir(), "ccu-guard-")); });
+  afterEach(async () => { await rm(tempDir, { recursive: true, force: true }); });
+
+  function target(opts?: Partial<Pick<CcuProfile, "protected" | "readonly">>) {
+    const reg = new TargetRegistry(appConfig([profile("t", opts)], "t", tempDir), logger, tempDir);
+    return reg.active;
+  }
+
+  it("allows writes to an unprotected target", () => {
+    expect(() => assertWritable(target(), undefined)).not.toThrow();
+  });
+
+  it("refuses a read-only target even with confirm", () => {
+    expect(() => assertWritable(target({ readonly: true }), true)).toThrowError(/read-only/);
+  });
+
+  it("refuses a protected target without confirm, then unlocks with confirm:true", () => {
+    const t = target({ protected: true });
+    expect(() => assertWritable(t, undefined)).toThrowError(/protected/);
+    expect(t.unlocked).toBe(false);
+    // confirm unlocks for the session
+    expect(() => assertWritable(t, true)).not.toThrow();
+    expect(t.unlocked).toBe(true);
+    // subsequent writes no longer need confirm
+    expect(() => assertWritable(t, undefined)).not.toThrow();
+  });
+});

--- a/test/unit/tools-targets.test.ts
+++ b/test/unit/tools-targets.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
+import type { ServerDeps } from "../../src/server.js";
+
+describe("CCU target tools (issue #69)", () => {
+  let deps: ServerDeps;
+  afterEach(() => deps && cleanupDeps(deps));
+
+  function twoTargets() {
+    return createTestServer({
+      targets: [
+        { name: "prod", protected: true, password: "PROD-SECRET", sessionCall: async () => "prod-ok" },
+        { name: "dev", sessionCall: async () => "dev-ok" },
+      ],
+    });
+  }
+
+  it("list_ccu_targets lists all targets, marks the active one, never leaks passwords", async () => {
+    const t = twoTargets(); deps = t.deps;
+    const res = parseToolResult(await callTool(t.server, "list_ccu_targets")) as any;
+    expect(res.active).toBe("prod");
+    expect(res.targets.map((x: any) => x.name)).toEqual(["prod", "dev"]);
+    const prod = res.targets.find((x: any) => x.name === "prod");
+    expect(prod.active).toBe(true);
+    expect(prod.protected).toBe(true);
+    expect(prod).not.toHaveProperty("password");
+    // Hard redaction guard: the password must not appear anywhere in the output.
+    expect(JSON.stringify(res)).not.toContain("PROD-SECRET");
+  });
+
+  it("get_connection_info reports the active target", async () => {
+    const t = twoTargets(); deps = t.deps;
+    const res = parseToolResult(await callTool(t.server, "get_connection_info")) as any;
+    expect(res.name).toBe("prod");
+    expect(res.active).toBe(true);
+    expect(res.protected).toBe(true);
+    expect(JSON.stringify(res)).not.toContain("PROD-SECRET");
+  });
+
+  it("use_ccu switches the active target and routes later calls to it", async () => {
+    const t = twoTargets(); deps = t.deps;
+    const switched = parseToolResult(await callTool(t.server, "use_ccu", { profile: "dev" })) as any;
+    expect(switched.name).toBe("dev");
+    expect(switched.active).toBe(true);
+
+    // get_connection_info now reflects dev
+    const info = parseToolResult(await callTool(t.server, "get_connection_info")) as any;
+    expect(info.name).toBe("dev");
+
+    // a read now hits the dev session
+    const val = parseToolResult(await callTool(t.server, "get_value", { address: "ABC:1", valueKey: "STATE", interface: "X" })) as any;
+    expect(val.value).toBe("dev-ok");
+  });
+
+  it("use_ccu on an unknown target returns a NOT_FOUND error", async () => {
+    const t = twoTargets(); deps = t.deps;
+    const res: any = await callTool(t.server, "use_ccu", { profile: "nope" });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res)).toContain("NOT_FOUND");
+  });
+
+  it("per-call target reads another target without switching the active one", async () => {
+    const t = twoTargets(); deps = t.deps;
+    // active is prod; read dev via the per-call target override
+    const val = parseToolResult(await callTool(t.server, "get_value", { address: "ABC:1", valueKey: "STATE", interface: "X", target: "dev" })) as any;
+    expect(val.value).toBe("dev-ok");
+    // active is still prod
+    const info = parseToolResult(await callTool(t.server, "get_connection_info")) as any;
+    expect(info.name).toBe("prod");
+  });
+});
+
+describe("protected-target write guard (issue #69)", () => {
+  let deps: ServerDeps;
+  afterEach(() => deps && cleanupDeps(deps));
+
+  it("refuses a write to a protected target without confirm:true", async () => {
+    const t = createTestServer({ protected: true, sessionCall: async () => "ok" });
+    deps = t.deps;
+    const res: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res)).toContain("protected");
+  });
+
+  it("allows the write with confirm:true and stays unlocked for the session", async () => {
+    let writes = 0;
+    const t = createTestServer({
+      protected: true,
+      sessionCall: async (method: string) => { if (method === "Interface.setValue") writes++; return null; },
+    });
+    deps = t.deps;
+
+    const ok: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true, interface: "X", type: "bool", confirm: true });
+    expect(ok.isError).toBeFalsy();
+    expect(writes).toBe(1);
+
+    // second write needs no confirm (unlocked for this session)
+    const ok2: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: false, interface: "X", type: "bool" });
+    expect(ok2.isError).toBeFalsy();
+    expect(writes).toBe(2);
+  });
+
+  it("a read-only target refuses writes even with confirm:true", async () => {
+    const t = createTestServer({ readonly: true, sessionCall: async () => null });
+    deps = t.deps;
+    const res: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true, interface: "X", type: "bool", confirm: true });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res)).toContain("read-only");
+  });
+
+  it("an unprotected target writes without confirm", async () => {
+    let writes = 0;
+    const t = createTestServer({
+      sessionCall: async (method: string) => { if (method === "Interface.setValue") writes++; return null; },
+    });
+    deps = t.deps;
+    const ok: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true, interface: "X", type: "bool" });
+    expect(ok.isError).toBeFalsy();
+    expect(writes).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #69.

Lets one server reach several CCUs (e.g. **prod + dev**) without running two
MCP servers and **without the LLM ever handling passwords** — the model passes
a profile *name*; secrets stay in the environment.

## Config
- `CCU_PROFILES` lists named profiles; `CCU_<NAME>_*` supplies each one's
  connection + policy. `CCU_DEFAULT_PROFILE` picks the startup-active target.
- **Back-compat:** with `CCU_PROFILES` unset, the flat `CCU_*` vars form a
  single `default` profile (unchanged behavior); `config.ccu` stays an alias of it.
- Per-profile password may be **empty** (OpenCCU dev boxes default to it).

## Runtime
- `TargetRegistry` owns one `SessionManager` / `Resolver` / `DeviceTypeCache` /
  sysvar cache per target plus the active pointer. Caches and session files are
  per-target so prod/dev never pollute each other (the `default` profile keeps
  the historical filenames, so existing on-disk caches still load).
- `ServerDeps.session/resolver/deviceTypeCache` became getters for the active
  target, so every existing tool follows a switch with no change.

## Tools
- New: `list_ccu_targets`, `get_connection_info`, `use_ccu` — never expose
  passwords. `get_system_info` now reports the active target.
- Read tools (`get_value` / `get_values` / `get_paramset` / `list_devices` /
  `describe_device_type`) take an optional `target` to read another CCU for one
  call without switching (prod-vs-dev compares).
- Write tools take `confirm`; a `protected` target refuses writes until
  `confirm:true` (unlocks for the session), a `readonly` target always refuses.
  See the [enforcement-model design comment](https://github.com/claymore666/ccu-mcp/issues/69#issuecomment-4762404014).

## Tests
348 unit/e2e pass, lint clean. New: config profiles + back-compat + validation,
target tools + password redaction, protected/readonly write guard, the
`TargetRegistry`/`resolveTarget`/`assertWritable` units, and per-target cache
isolation; registration count updated to 28 tools.

## Verified live
Tested through the real MCP integration against both CCUs (prod release box +
a local OpenCCU dev VM): target listing (no secrets), `use_ccu` switching,
per-call `target` routing (dev empty vs. prod device list), lazy login, and a
protected-prod write refused pre-CCU without `confirm`.

## Known limitation
In HTTP transport the active target is process-global across MCP sessions (fine
for stdio); the per-call `target` arg is the concurrency-safe path there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
