### PR TITLE
fix: acknowledge_service_messages — AlConfirm() does not exist in HM Script (#74)

### DIFF
--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -48,7 +48,10 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
             string sId;
             foreach(sId, svcs.EnumIDs()) {
               object svc = dom.GetObject(sId);
-              if (svc && svc.IsTypeOf(OT_ALARMDP) && svc.AlState() == asOncoming) {
+              ! HM Script has NO operator precedence (right-to-left evaluation,
+              ! see issue #74) — null-check first, parenthesize comparisons.
+              if (svc) {
+              if (svc.IsTypeOf(OT_ALARMDP) && (svc.AlState() == asOncoming)) {
                 if (!first) { Write(","); } first = false;
                 ! Parse address from alarm name: AL-<address>.<dpName>
                 string alName = svc.Name();
@@ -72,6 +75,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
                 Write(',"address":"' # chAddr # '"');
                 Write(',"timestamp":"' # svc.AlOccurrenceTime() # '"');
                 Write('}');
+              }
               }
             }
           }
@@ -161,9 +165,12 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
         }
 
         // Enumerate active alarms (same OT_ALARMDP objects get_service_messages
-        // lists), AlConfirm() the ones matching the requested id/address, and
+        // lists), AlReceipt() the ones matching the requested id/address, and
         // report what was confirmed. Confirming in ReGa avoids a second round
         // trip and means we only ever confirm currently-active alarms.
+        // AlReceipt() is what the WebUI itself uses (OCCU functions.fn::ReceiptAlarm);
+        // there is no AlConfirm() in ReGa — an unknown method aborts the whole
+        // script at parse time with EMPTY output (issue #74).
         const wantId = escapeHmScript(args.id ?? "");
         const wantAddr = escapeHmScript(args.address ?? "");
         const script = `
@@ -176,7 +183,11 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
             string sId;
             foreach(sId, svcs.EnumIDs()) {
               object svc = dom.GetObject(sId);
-              if (svc && svc.IsTypeOf(OT_ALARMDP) && svc.AlState() == asOncoming) {
+              ! HM Script has NO operator precedence (right-to-left evaluation,
+              ! see issue #74) — null-check first, parenthesize comparisons.
+              ! Unparenthesized 'a != "" && b == c' mis-groups and is ALWAYS true.
+              if (svc) {
+              if (svc.IsTypeOf(OT_ALARMDP) && (svc.AlState() == asOncoming)) {
                 string alName = svc.Name();
                 string chAddr = "";
                 string dpName = "";
@@ -190,16 +201,17 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
                   }
                 }
                 boolean match = false;
-                if (wantId != "" && sId == wantId) { match = true; }
-                if (wantAddr != "" && chAddr == wantAddr) { match = true; }
+                if ((wantId != "") && (sId == wantId)) { match = true; }
+                if ((wantAddr != "") && (chAddr == wantAddr)) { match = true; }
                 if (match) {
-                  svc.AlConfirm();
+                  svc.AlReceipt();
                   if (!first) { Write(","); } first = false;
                   ! JSON-escape user-controlled names (backslash first, then quote)
                   dpName = dpName.Replace("\\\\", "\\\\\\\\");
                   dpName = dpName.Replace("\\"", "\\\\\\"");
                   Write('{"id":"' # sId # '","type":"' # dpName # '","address":"' # chAddr # '"}');
                 }
+              }
               }
             }
           }

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -113,7 +113,7 @@ describeIf("MCP tools against live CCU", () => {
     expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
   }, 30_000);
 
-  // Exercises the real ReGa enumeration + AlConfirm path without mutating the
+  // Exercises the real ReGa enumeration + AlReceipt path without mutating the
   // user's CCU: a bogus id matches no active alarm → empty confirmed → NOT_FOUND.
   // We deliberately do NOT auto-confirm a real active alarm (it would silently
   // dismiss the user's warnings during a test run).
@@ -122,6 +122,51 @@ describeIf("MCP tools against live CCU", () => {
     expect(result.isError).toBe(true);
     expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
   }, 30_000);
+
+  // Full acknowledge round-trip against the real ReGa (issue #74): create a
+  // throwaway alarm datapoint, raise it to asOncoming, register it in
+  // ID_SERVICES, confirm it through the tool, then clean everything up. This
+  // is the test that would have caught AlConfirm(): ReGa aborts a script
+  // containing an unknown method at PARSE time with empty output, so the
+  // NOT_FOUND test above passes even when the script never ran.
+  it("acknowledge_service_messages confirms a synthetic alarm end-to-end (issue #74)", async () => {
+    const ALARM_NAME = "AL-MCP_LIVE_TEST:0.ISSUE_74";
+    const setup = parseToolResult(await callTool(server, "run_script", {
+      script: `
+        object al = dom.CreateObject(OT_ALARMDP, "${ALARM_NAME}");
+        al.ValueType(ivtBinary);
+        al.ValueSubType(istAlarm);
+        al.AlArm(true);
+        al.State(true);
+        dom.GetObject(ID_SERVICES).Add(al.ID());
+        Write('{"id":"' # al.ID() # '","state":' # al.AlState() # '}');
+      `,
+    })) as { id: string; state: number };
+    expect(setup.state).toBe(1); // asOncoming
+
+    try {
+      const result = parseToolResult(await callTool(server, "acknowledge_service_messages", {
+        id: setup.id,
+      })) as { confirmed: Array<{ id: string }>; count: number };
+      expect(result.count).toBe(1);
+      expect(result.confirmed[0].id).toBe(setup.id);
+
+      // the alarm must actually have left the asOncoming state
+      const after = parseToolResult(await callTool(server, "run_script", {
+        script: `Write(dom.GetObject("${setup.id}").AlState());`,
+      }));
+      expect(after).not.toBe("1");
+    } finally {
+      await callTool(server, "run_script", {
+        script: `
+          dom.GetObject(ID_SERVICES).Remove("${setup.id}");
+          dom.DeleteObject("${setup.id}");
+          object leftover = dom.GetObject("${ALARM_NAME}");
+          if (leftover) { Write("LEFTOVER"); } else { Write("clean"); }
+        `,
+      });
+    }
+  }, 60_000);
 
   it("acknowledge_service_messages rejects an empty request with INVALID_INPUT", async () => {
     const result: any = await callTool(server, "acknowledge_service_messages", {});

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -106,14 +106,21 @@ describe("acknowledge_service_messages handler", () => {
     cleanupDeps(deps);
   });
 
-  it("generates a script that confirms (AlConfirm) and escapes the requested id/address", async () => {
+  it("generates a script that confirms (AlReceipt) and escapes the requested id/address", async () => {
     const sessionCall = vi.fn().mockResolvedValue(JSON.stringify({ confirmed: [{ id: "1", type: "x", address: 'A":0' }] }));
     const { server, deps } = createTestServer({ sessionCall });
 
     await callTool(server, "acknowledge_service_messages", { address: 'A":0' });
     const script = sessionCall.mock.calls[0][1].script as string;
-    expect(script).toContain("AlConfirm()");
+    // AlReceipt() is the real ReGa method (issue #74) — AlConfirm() does not
+    // exist and would abort the whole script at parse time with empty output.
+    expect(script).toContain("AlReceipt()");
+    expect(script).not.toContain("AlConfirm");
     expect(script).toContain("OT_ALARMDP");
+    // HM Script has no operator precedence: comparisons combined with && must
+    // be individually parenthesized or the condition mis-groups (issue #74).
+    expect(script).toContain('if ((wantId != "") && (sId == wantId))');
+    expect(script).toContain('if ((wantAddr != "") && (chAddr == wantAddr))');
     // the embedded address literal is escaped (quote -> \")
     expect(script).toContain('string wantAddr = "A\\":0";');
     cleanupDeps(deps);


### PR DESCRIPTION
## Summary

Fixes #74, reported by @mdzio.

`acknowledge_service_messages` called `svc.AlConfirm()`, which does not exist in HM Script. ReGa aborts a script containing an unknown method at **parse time** with empty output — even when the call sits in a branch that never executes. So the tool returned NOT_FOUND on every invocation since it shipped, and the existing live test (NOT_FOUND for a bogus id) passed for the wrong reason.

The fix uses `AlReceipt()` — the method the WebUI itself uses (OCCU `functions.fn::ReceiptAlarm`).

## Second bug (masked by the first)

HM Script has no operator precedence; expressions evaluate strictly right-to-left. Verified live on an OpenCCU 3.87.6 VM: `if (wantId != "" && sId == wantId)` is **always true** — even for non-matching ids and an empty `wantId`. Had the script parsed, a single acknowledge would have confirmed *every* active service message. All comparisons combined with `&&` are now individually parenthesized and object null-checks moved to their own `if`, matching the OCCU WebUI style, in both diagnostics scripts.

## Testing

- `npm test` — 375 unit/e2e tests pass; `npm run lint` clean.
- New self-cleaning live round-trip test (gated on `CCU_HOST`): create synthetic `OT_ALARMDP` → raise to `asOncoming` → `ID_SERVICES.Add()` → acknowledge through the tool → assert state left `asOncoming` → `Remove()` + `DeleteObject()`. Passes against the OpenCCU dev VM. This is the test that would have caught the bug — the mocked e2e layer cannot.
- Unit test that previously asserted `AlConfirm()` in the generated script now asserts `AlReceipt()` and the parenthesized conditions.