### PR TITLE
fix: bound HTTP session map & rate-limiter queue; refactor: shared runTool wrapper (review I-2)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,39 @@ async function main(): Promise<void> {
       },
       logger,
     );
-    const sessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
+    // Bound the session map. Each MCP session pins a McpServer + transport that
+    // is removed only on transport.onclose (explicit DELETE / clean teardown).
+    // A client that initializes then drops its connection — or reconnects in a
+    // loop — would otherwise leak one pair per session forever. Cap the count
+    // and reclaim sessions idle past the timeout. Auth runs before session
+    // creation, so only valid-token holders reach here, but a single misbehaving
+    // authenticated client must still not grow this without bound.
+    const MAX_SESSIONS = 256;
+    const SESSION_IDLE_MS = 30 * 60_000; // 30 min without a request → reclaim
+    const sessions = new Map<
+      string,
+      { server: McpServer; transport: StreamableHTTPServerTransport; lastSeen: number }
+    >();
+
+    // Reclaim sessions whose last request predates `cutoff`. Returns how many
+    // were evicted. Shared by the periodic sweep and the at-capacity fast path.
+    const evictIdleSessions = (cutoff: number): number => {
+      let evicted = 0;
+      for (const [sid, s] of sessions) {
+        if (s.lastSeen < cutoff) {
+          sessions.delete(sid);
+          s.server.close().catch(() => {});
+          evicted++;
+        }
+      }
+      if (evicted > 0) logger.info("mcp_sessions_idle_evicted", { evicted, sessions: sessions.size });
+      return evicted;
+    };
+
+    // Periodic idle sweep. unref'd so it never holds the process open; cleared
+    // on shutdown via closeTransports.
+    const idleSweep = setInterval(() => evictIdleSessions(Date.now() - SESSION_IDLE_MS), 60_000);
+    idleSweep.unref();
 
     const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       try {
@@ -182,15 +214,32 @@ async function main(): Promise<void> {
           return;
         }
 
-        // Existing session: route to its transport (POST, GET/SSE, DELETE)
+        // Existing session: route to its transport (POST, GET/SSE, DELETE) and
+        // mark it active so the idle sweep doesn't reclaim a session in use.
         const sessionId = req.headers["mcp-session-id"];
-        if (typeof sessionId === "string" && sessions.has(sessionId)) {
-          await sessions.get(sessionId)!.transport.handleRequest(req, res);
+        const existing = typeof sessionId === "string" ? sessions.get(sessionId) : undefined;
+        if (existing) {
+          existing.lastSeen = Date.now();
+          await existing.transport.handleRequest(req, res);
           return;
         }
 
-        // No (known) session: create a fresh transport + server pair. The
-        // transport itself rejects non-initialize requests without a session.
+        // No (known) session: a fresh transport + server pair is about to be
+        // created. Enforce the cap first — try reclaiming idle sessions, and if
+        // still full, refuse with 503 so a flood of initialize requests can't
+        // grow the map without bound.
+        if (sessions.size >= MAX_SESSIONS) {
+          evictIdleSessions(Date.now() - SESSION_IDLE_MS);
+          if (sessions.size >= MAX_SESSIONS) {
+            logger.warn("mcp_sessions_at_capacity", { sessions: sessions.size, max: MAX_SESSIONS });
+            res.writeHead(503, { "Content-Type": "application/json", "Retry-After": "60" });
+            res.end(JSON.stringify({ error: "Server at session capacity, retry later" }));
+            return;
+          }
+        }
+
+        // Create a fresh transport + server pair. The transport itself rejects
+        // non-initialize requests without a session.
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           // Defense-in-depth against DNS rebinding: reject requests whose Host
@@ -205,7 +254,7 @@ async function main(): Promise<void> {
           allowedHosts: config.mcp.allowedHosts,
           allowedOrigins: config.mcp.allowedOrigins,
           onsessioninitialized: (sid) => {
-            sessions.set(sid, { server: sessionServer, transport });
+            sessions.set(sid, { server: sessionServer, transport, lastSeen: Date.now() });
             logger.info("mcp_session_started", { sessions: sessions.size });
           },
         });
@@ -267,6 +316,7 @@ async function main(): Promise<void> {
     );
     poller.start();
     closeTransports = async () => {
+      clearInterval(idleSweep);
       await Promise.allSettled([...sessions.values()].map((s) => s.server.close()));
       sessions.clear();
     };

--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -1,15 +1,24 @@
+import { CcuError } from "./error-mapper.js";
+
 export class RateLimiter {
   private tokens: number;
   private readonly maxTokens: number;
   private readonly refillRate: number; // tokens per second
+  private readonly maxQueue: number;
   private lastRefill: number;
   private waitQueue: Array<() => void> = [];
   private refillTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(maxBurst: number = 20, refillRate: number = 10) {
+  constructor(maxBurst: number = 20, refillRate: number = 10, maxQueue: number = 1000) {
     this.maxTokens = maxBurst;
     this.tokens = maxBurst;
     this.refillRate = refillRate;
+    // Backpressure bound: callers waiting on a token queue here. Without a cap a
+    // sustained flood (faster than refillRate) grows the queue — and the pending
+    // promises behind it — without limit. The cap is deliberately generous (a
+    // backstop, not normal-load shaping); past it acquire() rejects so a caller
+    // fails fast with a clear error instead of parking on an ever-growing queue.
+    this.maxQueue = maxQueue;
     this.lastRefill = Date.now();
 
     // Start refill timer only when there are queued requests
@@ -49,6 +58,18 @@ export class RateLimiter {
     if (this.tokens >= 1) {
       this.tokens -= 1;
       return;
+    }
+
+    // At capacity — refuse rather than queue unboundedly. RATE_LIMITED is not
+    // retriable (see retry.ts), so a flooded caller fails fast instead of
+    // looping back into the same full queue.
+    if (this.waitQueue.length >= this.maxQueue) {
+      throw new CcuError({
+        error: "RATE_LIMITED",
+        code: 0,
+        message: "Too many requests queued for the CCU; the server is overloaded.",
+        hint: "Reduce concurrent calls and retry shortly. Raise CCU_RATE_LIMIT_BURST/RATE if this is sustained legitimate load.",
+      });
     }
 
     // Wait for a token to become available

--- a/src/middleware/tool-handler.ts
+++ b/src/middleware/tool-handler.ts
@@ -1,0 +1,38 @@
+import type { Logger } from "../logger.js";
+import { CcuError } from "./error-mapper.js";
+
+type LogFields = Record<string, unknown>;
+
+/**
+ * Shared wrapper for tool handler bodies (review finding I-2). Collapses the
+ * boilerplate that every tool repeated by hand — start timer, run the body,
+ * emit one `tool_call` log (ok/error) with duration, and map a thrown
+ * `CcuError` to an MCP error result (re-throwing anything else) — into one
+ * place so logging and error mapping can't drift between tools.
+ *
+ * The body receives a `log` callback to contribute extra success-log fields
+ * (e.g. `{ address }`, `{ deviceCount }`); they're merged into the `ok` line.
+ * The handler stays `async (args) => runTool(name, logger, (log) => …)`, so the
+ * SDK still infers `args` from the tool's input schema.
+ */
+export async function runTool<R>(
+  tool: string,
+  logger: Logger,
+  body: (log: (fields: LogFields) => void) => Promise<R>,
+): Promise<R | ReturnType<CcuError["toMcpError"]>> {
+  const start = Date.now();
+  let extra: LogFields = {};
+  const log = (fields: LogFields): void => {
+    extra = { ...extra, ...fields };
+  };
+
+  try {
+    const result = await body(log);
+    logger.info("tool_call", { tool, duration_ms: Date.now() - start, status: "ok", ...extra });
+    return result;
+  } catch (err) {
+    logger.info("tool_call", { tool, duration_ms: Date.now() - start, status: "error" });
+    if (err instanceof CcuError) return err.toMcpError();
+    throw err;
+  }
+}

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -4,6 +4,7 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult, parseValue, escapeHmScript } from "../utils.js";
 
@@ -46,57 +47,49 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("set_value", deps.logger, async (log) => {
       const { session, rateLimiter, logger, deviceTypeCache } = deps;
-      const start = Date.now();
+      assertWritable(deps.targets.active, args.confirm);
+      const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
+      const valueType = args.type ?? deps.resolver.resolveType(args.address, args.valueKey, deviceTypeCache) ?? inferType(args.value);
 
+      // Read previous value (best-effort)
+      let previousValue: unknown = null;
       try {
-        assertWritable(deps.targets.active, args.confirm);
-        const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
-        const valueType = args.type ?? deps.resolver.resolveType(args.address, args.valueKey, deviceTypeCache) ?? inferType(args.value);
-
-        // Read previous value (best-effort)
-        let previousValue: unknown = null;
-        try {
-          await rateLimiter.acquire();
-          previousValue = await session.call("Interface.getValue", {
-            interface: iface,
-            address: args.address,
-            valueKey: args.valueKey,
-          });
-        } catch {
-          // Pre-read failed — continue with write
-        }
-
-        // Write new value
         await rateLimiter.acquire();
-        await withRetry(
-          () => session.call("Interface.setValue", {
-            interface: iface,
-            address: args.address,
-            valueKey: args.valueKey,
-            type: valueType,
-            value: args.value,
-          }),
-          "Interface.setValue",
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "set_value", duration_ms: Date.now() - start, status: "ok", address: args.address });
-        return toolResult({
+        previousValue = await session.call("Interface.getValue", {
+          interface: iface,
           address: args.address,
           valueKey: args.valueKey,
-          previousValue: parseValue(previousValue),
-          newValue: args.value,
-          interface: iface,
-          type: valueType,
         });
-      } catch (err) {
-        logger.info("tool_call", { tool: "set_value", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      } catch {
+        // Pre-read failed — continue with write
       }
-    },
+
+      // Write new value
+      await rateLimiter.acquire();
+      await withRetry(
+        () => session.call("Interface.setValue", {
+          interface: iface,
+          address: args.address,
+          valueKey: args.valueKey,
+          type: valueType,
+          value: args.value,
+        }),
+        "Interface.setValue",
+        logger,
+      );
+
+      log({ address: args.address });
+      return toolResult({
+        address: args.address,
+        valueKey: args.valueKey,
+        previousValue: parseValue(previousValue),
+        newValue: args.value,
+        interface: iface,
+        type: valueType,
+      });
+    }),
   );
 }
 
@@ -122,42 +115,33 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("put_paramset", deps.logger, async () => {
       const { session, rateLimiter, logger, deviceTypeCache } = deps;
-      const start = Date.now();
+      assertWritable(deps.targets.active, args.confirm);
+      const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
+      // CCU expects set as array of {name, type, value} objects
+      const paramArray = Object.entries(args.set).map(([name, value]) => {
+        // Try to resolve type from device type cache
+        let type = deps.resolver.resolveType(args.address, name, deviceTypeCache);
+        if (!type) type = inferType(value);
+        return { name, type, value: String(value) };
+      });
 
-        // CCU expects set as array of {name, type, value} objects
-        const paramArray = Object.entries(args.set).map(([name, value]) => {
-          // Try to resolve type from device type cache
-          let type = deps.resolver.resolveType(args.address, name, deviceTypeCache);
-          if (!type) type = inferType(value);
-          return { name, type, value: String(value) };
-        });
+      await rateLimiter.acquire();
+      await withRetry(
+        () => session.call("Interface.putParamset", {
+          interface: iface,
+          address: args.address,
+          paramsetKey: args.paramsetKey,
+          set: paramArray,
+        }),
+        "Interface.putParamset",
+        logger,
+      );
 
-        await rateLimiter.acquire();
-        await withRetry(
-          () => session.call("Interface.putParamset", {
-            interface: iface,
-            address: args.address,
-            paramsetKey: args.paramsetKey,
-            set: paramArray,
-          }),
-          "Interface.putParamset",
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "put_paramset", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult({ address: args.address, paramsetKey: args.paramsetKey, written: args.set });
-      } catch (err) {
-        logger.info("tool_call", { tool: "put_paramset", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      return toolResult({ address: args.address, paramsetKey: args.paramsetKey, written: args.set });
+    }),
   );
 }
 
@@ -185,86 +169,76 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("set_system_variable", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
       const typeCacheHolder = deps.targets.active.sysVarTypeCache;
-      const start = Date.now();
+      assertWritable(deps.targets.active, args.confirm);
+      // Look up variable type (cached) to choose correct setter
+      let method: string;
+      let sysVarType: string | undefined;
+      if (typeCacheHolder.entry && Date.now() - typeCacheHolder.entry.ts < SYSVAR_TYPE_TTL_MS) {
+        sysVarType = typeCacheHolder.entry.types.get(args.name);
+      }
+      if (sysVarType === undefined) {
+        await rateLimiter.acquire();
+        const allVars = await withRetry(
+          () => session.call("SysVar.getAll"),
+          "SysVar.getAll",
+          logger,
+        ) as Array<{ name: string; type: string }>;
+        typeCacheHolder.entry = { ts: Date.now(), types: new Map(allVars.map((v) => [v.name, v.type])) };
+        sysVarType = typeCacheHolder.entry.types.get(args.name);
+      }
 
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        // Look up variable type (cached) to choose correct setter
-        let method: string;
-        let sysVarType: string | undefined;
-        if (typeCacheHolder.entry && Date.now() - typeCacheHolder.entry.ts < SYSVAR_TYPE_TTL_MS) {
-          sysVarType = typeCacheHolder.entry.types.get(args.name);
-        }
-        if (sysVarType === undefined) {
+      if (sysVarType !== undefined) {
+        const varType = sysVarType.toUpperCase();
+        if (varType.includes("BOOL") || varType.includes("ALARM")) {
+          method = "SysVar.setBool";
+        } else if (varType.includes("FLOAT") || varType.includes("NUMBER") || varType.includes("INTEGER")) {
+          method = "SysVar.setFloat";
+        } else if (varType.includes("ENUM") || varType.includes("LIST")) {
+          method = "SysVar.setFloat"; // Enums use numeric index
+        } else if (varType.includes("STRING")) {
+          // String variables: use ReGa.runScript as there's no SysVar.setString API
           await rateLimiter.acquire();
-          const allVars = await withRetry(
-            () => session.call("SysVar.getAll"),
-            "SysVar.getAll",
+          const escapedName = escapeHmScript(String(args.name));
+          const escapedValue = escapeHmScript(String(args.value));
+          await withRetry(
+            () => session.call("ReGa.runScript", {
+              script: `var sv = dom.GetObject("${escapedName}"); if (sv) { sv.State("${escapedValue}"); }`,
+            }, deps.targets.active.profile.ccu.scriptTimeout),
+            "ReGa.runScript",
             logger,
-          ) as Array<{ name: string; type: string }>;
-          typeCacheHolder.entry = { ts: Date.now(), types: new Map(allVars.map((v) => [v.name, v.type])) };
-          sysVarType = typeCacheHolder.entry.types.get(args.name);
-        }
-
-        if (sysVarType !== undefined) {
-          const varType = sysVarType.toUpperCase();
-          if (varType.includes("BOOL") || varType.includes("ALARM")) {
-            method = "SysVar.setBool";
-          } else if (varType.includes("FLOAT") || varType.includes("NUMBER") || varType.includes("INTEGER")) {
-            method = "SysVar.setFloat";
-          } else if (varType.includes("ENUM") || varType.includes("LIST")) {
-            method = "SysVar.setFloat"; // Enums use numeric index
-          } else if (varType.includes("STRING")) {
-            // String variables: use ReGa.runScript as there's no SysVar.setString API
-            await rateLimiter.acquire();
-            const escapedName = escapeHmScript(String(args.name));
-            const escapedValue = escapeHmScript(String(args.value));
-            await withRetry(
-              () => session.call("ReGa.runScript", {
-                script: `var sv = dom.GetObject("${escapedName}"); if (sv) { sv.State("${escapedValue}"); }`,
-              }, deps.targets.active.profile.ccu.scriptTimeout),
-              "ReGa.runScript",
-              logger,
-            );
-            logger.info("tool_call", { tool: "set_system_variable", duration_ms: Date.now() - start, status: "ok" });
-            return toolResult({ name: args.name, value: args.value, method: "ReGa.runScript (string)" });
-          } else {
-            logger.warn("sysvar_unknown_type", { name: args.name, type: sysVarType });
-            throw new CcuError({
-              error: "INVALID_INPUT",
-              code: 0,
-              message: `System variable "${args.name}" has unsupported type: ${sysVarType}`,
-              hint: "Supported types are bool/alarm, float/integer, enum/list, and string.",
-            });
-          }
+          );
+          return toolResult({ name: args.name, value: args.value, method: "ReGa.runScript (string)" });
         } else {
-          logger.warn("sysvar_not_found", { name: args.name });
+          logger.warn("sysvar_unknown_type", { name: args.name, type: sysVarType });
           throw new CcuError({
-            error: "NOT_FOUND",
+            error: "INVALID_INPUT",
             code: 0,
-            message: `System variable not found: ${args.name}`,
-            hint: "Call list_system_variables to see available variables (name must match exactly).",
+            message: `System variable "${args.name}" has unsupported type: ${sysVarType}`,
+            hint: "Supported types are bool/alarm, float/integer, enum/list, and string.",
           });
         }
-
-        await rateLimiter.acquire();
-        await withRetry(
-          () => session.call(method, { name: args.name, value: args.value }),
-          method,
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "set_system_variable", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult({ name: args.name, value: args.value, method });
-      } catch (err) {
-        logger.info("tool_call", { tool: "set_system_variable", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      } else {
+        logger.warn("sysvar_not_found", { name: args.name });
+        throw new CcuError({
+          error: "NOT_FOUND",
+          code: 0,
+          message: `System variable not found: ${args.name}`,
+          hint: "Call list_system_variables to see available variables (name must match exactly).",
+        });
       }
-    },
+
+      await rateLimiter.acquire();
+      await withRetry(
+        () => session.call(method, { name: args.name, value: args.value }),
+        method,
+        logger,
+      );
+
+      return toolResult({ name: args.name, value: args.value, method });
+    }),
   );
 }
 
@@ -292,141 +266,133 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("create_system_variable", deps.logger, async (log) => {
       const { session, rateLimiter, logger } = deps;
       const typeCacheHolder = deps.targets.active.sysVarTypeCache;
-      const start = Date.now();
-
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        if (args.type === "enum" && (!args.values || args.values.length === 0)) {
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: "An enum system variable requires a non-empty 'values' list.",
-            hint: "Pass values, e.g. [\"off\", \"low\", \"high\"].",
-          });
-        }
-
-        // Reject duplicates up front (creating over an existing name corrupts it).
-        await rateLimiter.acquire();
-        const existing = await withRetry(
-          () => session.call("SysVar.getAll"),
-          "SysVar.getAll",
-          logger,
-        ) as Array<{ name: string }>;
-        if (existing.some((v) => v.name === args.name)) {
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: `System variable already exists: ${args.name}`,
-            hint: "Pick a unique name, or use set_system_variable to change the existing one.",
-          });
-        }
-
-        // Create via ReGa (no SysVar.createString exists, and this keeps all four
-        // types on one code path). Ordering matters and was verified live: set
-        // ValueType + Name + type-specifics, Add(sv.ID()), and only THEN set
-        // ValueUnit/DPInfo — setting those *before* Add makes the CCU store the
-        // variable under a deduplicated " N" name (silent rename). The script
-        // returns the actual stored name so we never report a name we didn't get.
-        const name = escapeHmScript(args.name);
-        const info = escapeHmScript(args.description ?? "");
-        const unit = escapeHmScript(args.unit ?? "");
-        let typeSetup: string;
-        switch (args.type) {
-          case "bool":
-            typeSetup =
-              'sv.ValueType(ivtBinary);\n' +
-              'sv.ValueSubType(istBool);\n' +
-              `sv.Name("${name}");\n` +
-              'sv.ValueName0("false");\n' +
-              'sv.ValueName1("true");\n' +
-              'sv.State(false);';
-            break;
-          case "float": {
-            const min = Number.isFinite(args.min) ? args.min : 0;
-            const max = Number.isFinite(args.max) ? args.max : 100;
-            typeSetup =
-              'sv.ValueType(ivtFloat);\n' +
-              `sv.Name("${name}");\n` +
-              `sv.ValueMin(${min});\n` +
-              `sv.ValueMax(${max});\n` +
-              'sv.State(0);';
-            break;
-          }
-          case "enum": {
-            const list = escapeHmScript((args.values ?? []).join(";"));
-            typeSetup =
-              'sv.ValueType(ivtInteger);\n' +
-              'sv.ValueSubType(istEnum);\n' +
-              `sv.Name("${name}");\n` +
-              `sv.ValueList("${list}");\n` +
-              'sv.State(0);';
-            break;
-          }
-          case "string":
-          default:
-            typeSetup =
-              'sv.ValueType(ivtString);\n' +
-              `sv.Name("${name}");\n` +
-              'sv.State("");';
-            break;
-        }
-
-        // ValueUnit applies to float only; DPInfo (description) to all. Both go
-        // AFTER Add (see comment above).
-        const postAdd =
-          (args.type === "float" ? `sv.ValueUnit("${unit}");\n` : "") +
-          `sv.DPInfo("${info}");`;
-
-        const script =
-          `object oSysVars = dom.GetObject(ID_SYSTEM_VARIABLES);\n` +
-          `object sv = dom.CreateObject(OT_VARDP);\n` +
-          `${typeSetup}\n` +
-          `sv.Internal(false);\n` +
-          `oSysVars.Add(sv.ID());\n` +
-          `${postAdd}\n` +
-          `dom.RTUpdate(false);\n` +
-          `WriteLine(sv.Name());`;
-
-        await rateLimiter.acquire();
-        const createResult = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
-          "ReGa.runScript",
-          logger,
-        );
-
-        // The script echoes the ACTUAL stored name. The CCU silently dedups a
-        // requested name against existing similar names (e.g. "X" becomes "X 1"
-        // when an "X 2" already exists), which the exact-match pre-check above
-        // can't see. If we didn't get the name we asked for, undo it and report
-        // the collision rather than leaving a surprise variable behind.
-        const actualName = typeof createResult === "string" && createResult.trim()
-          ? createResult.trim()
-          : args.name;
-        if (actualName !== args.name) {
-          try {
-            await rateLimiter.acquire();
-            await session.call("SysVar.deleteSysVarByName", { name: actualName });
-          } catch { /* best-effort cleanup of the unintended object */ }
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: `System variable name unavailable: "${args.name}" (the CCU would store it as "${actualName}")`,
-            hint: "Pick a different name — the CCU deduplicates against existing similar names.",
-          });
-        }
-
-        typeCacheHolder.entry = null; // new variable must be visible to the next set
-        logger.info("tool_call", { tool: "create_system_variable", duration_ms: Date.now() - start, status: "ok", type: args.type });
-        return toolResult({ name: actualName, type: args.type, created: true });
-      } catch (err) {
-        logger.info("tool_call", { tool: "create_system_variable", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      assertWritable(deps.targets.active, args.confirm);
+      if (args.type === "enum" && (!args.values || args.values.length === 0)) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: "An enum system variable requires a non-empty 'values' list.",
+          hint: "Pass values, e.g. [\"off\", \"low\", \"high\"].",
+        });
       }
-    },
+
+      // Reject duplicates up front (creating over an existing name corrupts it).
+      await rateLimiter.acquire();
+      const existing = await withRetry(
+        () => session.call("SysVar.getAll"),
+        "SysVar.getAll",
+        logger,
+      ) as Array<{ name: string }>;
+      if (existing.some((v) => v.name === args.name)) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: `System variable already exists: ${args.name}`,
+          hint: "Pick a unique name, or use set_system_variable to change the existing one.",
+        });
+      }
+
+      // Create via ReGa (no SysVar.createString exists, and this keeps all four
+      // types on one code path). Ordering matters and was verified live: set
+      // ValueType + Name + type-specifics, Add(sv.ID()), and only THEN set
+      // ValueUnit/DPInfo — setting those *before* Add makes the CCU store the
+      // variable under a deduplicated " N" name (silent rename). The script
+      // returns the actual stored name so we never report a name we didn't get.
+      const name = escapeHmScript(args.name);
+      const info = escapeHmScript(args.description ?? "");
+      const unit = escapeHmScript(args.unit ?? "");
+      let typeSetup: string;
+      switch (args.type) {
+        case "bool":
+          typeSetup =
+            'sv.ValueType(ivtBinary);\n' +
+            'sv.ValueSubType(istBool);\n' +
+            `sv.Name("${name}");\n` +
+            'sv.ValueName0("false");\n' +
+            'sv.ValueName1("true");\n' +
+            'sv.State(false);';
+          break;
+        case "float": {
+          const min = Number.isFinite(args.min) ? args.min : 0;
+          const max = Number.isFinite(args.max) ? args.max : 100;
+          typeSetup =
+            'sv.ValueType(ivtFloat);\n' +
+            `sv.Name("${name}");\n` +
+            `sv.ValueMin(${min});\n` +
+            `sv.ValueMax(${max});\n` +
+            'sv.State(0);';
+          break;
+        }
+        case "enum": {
+          const list = escapeHmScript((args.values ?? []).join(";"));
+          typeSetup =
+            'sv.ValueType(ivtInteger);\n' +
+            'sv.ValueSubType(istEnum);\n' +
+            `sv.Name("${name}");\n` +
+            `sv.ValueList("${list}");\n` +
+            'sv.State(0);';
+          break;
+        }
+        case "string":
+        default:
+          typeSetup =
+            'sv.ValueType(ivtString);\n' +
+            `sv.Name("${name}");\n` +
+            'sv.State("");';
+          break;
+      }
+
+      // ValueUnit applies to float only; DPInfo (description) to all. Both go
+      // AFTER Add (see comment above).
+      const postAdd =
+        (args.type === "float" ? `sv.ValueUnit("${unit}");\n` : "") +
+        `sv.DPInfo("${info}");`;
+
+      const script =
+        `object oSysVars = dom.GetObject(ID_SYSTEM_VARIABLES);\n` +
+        `object sv = dom.CreateObject(OT_VARDP);\n` +
+        `${typeSetup}\n` +
+        `sv.Internal(false);\n` +
+        `oSysVars.Add(sv.ID());\n` +
+        `${postAdd}\n` +
+        `dom.RTUpdate(false);\n` +
+        `WriteLine(sv.Name());`;
+
+      await rateLimiter.acquire();
+      const createResult = await withRetry(
+        () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
+        "ReGa.runScript",
+        logger,
+      );
+
+      // The script echoes the ACTUAL stored name. The CCU silently dedups a
+      // requested name against existing similar names (e.g. "X" becomes "X 1"
+      // when an "X 2" already exists), which the exact-match pre-check above
+      // can't see. If we didn't get the name we asked for, undo it and report
+      // the collision rather than leaving a surprise variable behind.
+      const actualName = typeof createResult === "string" && createResult.trim()
+        ? createResult.trim()
+        : args.name;
+      if (actualName !== args.name) {
+        try {
+          await rateLimiter.acquire();
+          await session.call("SysVar.deleteSysVarByName", { name: actualName });
+        } catch { /* best-effort cleanup of the unintended object */ }
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: `System variable name unavailable: "${args.name}" (the CCU would store it as "${actualName}")`,
+          hint: "Pick a different name — the CCU deduplicates against existing similar names.",
+        });
+      }
+
+      typeCacheHolder.entry = null; // new variable must be visible to the next set
+      log({ type: args.type });
+      return toolResult({ name: actualName, type: args.type, created: true });
+    }),
   );
 }
 
@@ -446,46 +412,37 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("delete_system_variable", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
       const typeCacheHolder = deps.targets.active.sysVarTypeCache;
-      const start = Date.now();
-
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        // Validate existence so an unknown name is a clean NOT_FOUND rather than
-        // a silent no-op (deleteSysVarByName doesn't report a missing name).
-        await rateLimiter.acquire();
-        const existing = await withRetry(
-          () => session.call("SysVar.getAll"),
-          "SysVar.getAll",
-          logger,
-        ) as Array<{ name: string }>;
-        if (!existing.some((v) => v.name === args.name)) {
-          throw new CcuError({
-            error: "NOT_FOUND",
-            code: 0,
-            message: `System variable not found: ${args.name}`,
-            hint: "Call list_system_variables to see available variables (name must match exactly).",
-          });
-        }
-
-        await rateLimiter.acquire();
-        await withRetry(
-          () => session.call("SysVar.deleteSysVarByName", { name: args.name }),
-          "SysVar.deleteSysVarByName",
-          logger,
-        );
-
-        typeCacheHolder.entry = null; // removed variable must not linger in the cache
-        logger.info("tool_call", { tool: "delete_system_variable", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult({ name: args.name, deleted: true });
-      } catch (err) {
-        logger.info("tool_call", { tool: "delete_system_variable", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      assertWritable(deps.targets.active, args.confirm);
+      // Validate existence so an unknown name is a clean NOT_FOUND rather than
+      // a silent no-op (deleteSysVarByName doesn't report a missing name).
+      await rateLimiter.acquire();
+      const existing = await withRetry(
+        () => session.call("SysVar.getAll"),
+        "SysVar.getAll",
+        logger,
+      ) as Array<{ name: string }>;
+      if (!existing.some((v) => v.name === args.name)) {
+        throw new CcuError({
+          error: "NOT_FOUND",
+          code: 0,
+          message: `System variable not found: ${args.name}`,
+          hint: "Call list_system_variables to see available variables (name must match exactly).",
+        });
       }
-    },
+
+      await rateLimiter.acquire();
+      await withRetry(
+        () => session.call("SysVar.deleteSysVarByName", { name: args.name }),
+        "SysVar.deleteSysVarByName",
+        logger,
+      );
+
+      typeCacheHolder.entry = null; // removed variable must not linger in the cache
+      return toolResult({ name: args.name, deleted: true });
+    }),
   );
 }
 
@@ -514,106 +471,97 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool(toolName, deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
+      assertWritable(deps.targets.active, args.confirm);
+      if (!args.room && !args.function) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: "Provide a room and/or a function to assign the channel to.",
+          hint: "Pass room and/or function by name (see list_rooms / list_functions).",
+        });
+      }
 
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        if (!args.room && !args.function) {
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: "Provide a room and/or a function to assign the channel to.",
-            hint: "Pass room and/or function by name (see list_rooms / list_functions).",
-          });
-        }
+      // Resolve the channel address → channel ID (the membership APIs take IDs).
+      await rateLimiter.acquire();
+      const devices = await withRetry(
+        () => session.call("Device.listAllDetail"),
+        "Device.listAllDetail",
+        logger,
+      ) as CcuDevice[];
+      deps.resolver.updateDeviceList(devices);
+      let channelId: string | undefined;
+      for (const d of devices) {
+        const ch = d.channels.find((c) => c.address === args.channel);
+        if (ch) { channelId = ch.id; break; }
+      }
+      if (!channelId) {
+        throw new CcuError({
+          error: "NOT_FOUND",
+          code: 0,
+          message: `Channel not found: ${args.channel}`,
+          hint: "Call list_devices to find valid channel addresses.",
+        });
+      }
 
-        // Resolve the channel address → channel ID (the membership APIs take IDs).
+      const applied: Array<{ kind: "room" | "function"; name: string }> = [];
+
+      if (args.room) {
         await rateLimiter.acquire();
-        const devices = await withRetry(
-          () => session.call("Device.listAllDetail"),
-          "Device.listAllDetail",
+        const rooms = await withRetry(
+          () => session.call("Room.getAll"),
+          "Room.getAll",
           logger,
-        ) as CcuDevice[];
-        deps.resolver.updateDeviceList(devices);
-        let channelId: string | undefined;
-        for (const d of devices) {
-          const ch = d.channels.find((c) => c.address === args.channel);
-          if (ch) { channelId = ch.id; break; }
-        }
-        if (!channelId) {
+        ) as Array<{ id: string; name: string }>;
+        const room = rooms.find((r) => r.name === args.room);
+        if (!room) {
           throw new CcuError({
             error: "NOT_FOUND",
             code: 0,
-            message: `Channel not found: ${args.channel}`,
-            hint: "Call list_devices to find valid channel addresses.",
+            message: `Room not found: ${args.room}`,
+            hint: `Valid rooms: ${rooms.map((r) => r.name).join(", ")}`,
           });
         }
-
-        const applied: Array<{ kind: "room" | "function"; name: string }> = [];
-
-        if (args.room) {
-          await rateLimiter.acquire();
-          const rooms = await withRetry(
-            () => session.call("Room.getAll"),
-            "Room.getAll",
-            logger,
-          ) as Array<{ id: string; name: string }>;
-          const room = rooms.find((r) => r.name === args.room);
-          if (!room) {
-            throw new CcuError({
-              error: "NOT_FOUND",
-              code: 0,
-              message: `Room not found: ${args.room}`,
-              hint: `Valid rooms: ${rooms.map((r) => r.name).join(", ")}`,
-            });
-          }
-          await rateLimiter.acquire();
-          await withRetry(
-            () => session.call(mode === "add" ? "Room.addChannel" : "Room.removeChannel", { id: room.id, channelId }),
-            "Room.modifyChannel",
-            logger,
-          );
-          applied.push({ kind: "room", name: room.name });
-        }
-
-        if (args.function) {
-          await rateLimiter.acquire();
-          const functions = await withRetry(
-            () => session.call("Subsection.getAll"),
-            "Subsection.getAll",
-            logger,
-          ) as Array<{ id: string; name: string }>;
-          const fn = functions.find((f) => f.name === args.function);
-          if (!fn) {
-            throw new CcuError({
-              error: "NOT_FOUND",
-              code: 0,
-              message: `Function not found: ${args.function}`,
-              hint: `Valid functions: ${functions.map((f) => f.name).join(", ")}`,
-            });
-          }
-          await rateLimiter.acquire();
-          await withRetry(
-            () => session.call(mode === "add" ? "Subsection.addChannel" : "Subsection.removeChannel", { id: fn.id, channelId }),
-            "Subsection.modifyChannel",
-            logger,
-          );
-          applied.push({ kind: "function", name: fn.name });
-        }
-
-        logger.info("tool_call", { tool: toolName, duration_ms: Date.now() - start, status: "ok" });
-        return toolResult({
-          channel: args.channel,
-          [mode === "add" ? "assignedTo" : "removedFrom"]: applied,
-        });
-      } catch (err) {
-        logger.info("tool_call", { tool: toolName, duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+        await rateLimiter.acquire();
+        await withRetry(
+          () => session.call(mode === "add" ? "Room.addChannel" : "Room.removeChannel", { id: room.id, channelId }),
+          "Room.modifyChannel",
+          logger,
+        );
+        applied.push({ kind: "room", name: room.name });
       }
-    },
+
+      if (args.function) {
+        await rateLimiter.acquire();
+        const functions = await withRetry(
+          () => session.call("Subsection.getAll"),
+          "Subsection.getAll",
+          logger,
+        ) as Array<{ id: string; name: string }>;
+        const fn = functions.find((f) => f.name === args.function);
+        if (!fn) {
+          throw new CcuError({
+            error: "NOT_FOUND",
+            code: 0,
+            message: `Function not found: ${args.function}`,
+            hint: `Valid functions: ${functions.map((f) => f.name).join(", ")}`,
+          });
+        }
+        await rateLimiter.acquire();
+        await withRetry(
+          () => session.call(mode === "add" ? "Subsection.addChannel" : "Subsection.removeChannel", { id: fn.id, channelId }),
+          "Subsection.modifyChannel",
+          logger,
+        );
+        applied.push({ kind: "function", name: fn.name });
+      }
+
+      return toolResult({
+        channel: args.channel,
+        [mode === "add" ? "assignedTo" : "removedFrom"]: applied,
+      });
+    }),
   );
 }
 
@@ -634,43 +582,34 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("execute_program", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
+      assertWritable(deps.targets.active, args.confirm);
+      // The CCU's Program.execute reports success even for nonexistent IDs
+      // (issue #18) — validate against the program list first.
+      await rateLimiter.acquire();
+      const programs = await withRetry(
+        () => session.call("Program.getAll"),
+        "Program.getAll",
+        logger,
+      ) as Array<{ id: string; name: string }>;
 
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        // The CCU's Program.execute reports success even for nonexistent IDs
-        // (issue #18) — validate against the program list first.
-        await rateLimiter.acquire();
-        const programs = await withRetry(
-          () => session.call("Program.getAll"),
-          "Program.getAll",
-          logger,
-        ) as Array<{ id: string; name: string }>;
-
-        const program = programs.find((p) => String(p.id) === args.id);
-        if (!program) {
-          throw new CcuError({
-            error: "NOT_FOUND",
-            code: 0,
-            message: `Program not found: ${args.id}`,
-            hint: "Call list_programs to see available programs and their IDs.",
-          });
-        }
-
-        await rateLimiter.acquire();
-        // No retry — Program.execute is not idempotent
-        await session.call("Program.execute", { id: args.id });
-
-        logger.info("tool_call", { tool: "execute_program", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult({ id: args.id, name: program.name, executed: true });
-      } catch (err) {
-        logger.info("tool_call", { tool: "execute_program", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      const program = programs.find((p) => String(p.id) === args.id);
+      if (!program) {
+        throw new CcuError({
+          error: "NOT_FOUND",
+          code: 0,
+          message: `Program not found: ${args.id}`,
+          hint: "Call list_programs to see available programs and their IDs.",
+        });
       }
-    },
+
+      await rateLimiter.acquire();
+      // No retry — Program.execute is not idempotent
+      await session.call("Program.execute", { id: args.id });
+
+      return toolResult({ id: args.id, name: program.name, executed: true });
+    }),
   );
 }
 

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -4,6 +4,7 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION, loadBuildInfo } from "../utils.js";
 
@@ -30,11 +31,8 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
       outputSchema: { messages: z.array(z.unknown()).describe("Active alarms: {id, type, address, channelName, timestamp}") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => {
+    async () => runTool("get_service_messages", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-
-      try {
         // Two single passes instead of a nested per-alarm channel scan: emit the
         // alarms first while collecting their addresses, then resolve channel
         // names in ONE sweep over all channels (sentinel-comma Find, as in
@@ -114,14 +112,8 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
           }));
         }
 
-        logger.info("tool_call", { tool: "get_service_messages", duration_ms: Date.now() - start, status: "ok" });
         return structuredResult({ messages: Array.isArray(messages) ? messages : [] }, messages);
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_service_messages", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+    }),
   );
 }
 
@@ -145,11 +137,8 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("acknowledge_service_messages", deps.logger, async (log) => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-
-      try {
         assertWritable(deps.targets.active, args.confirm);
         if (!args.id && !args.address) {
           throw new CcuError({
@@ -230,14 +219,9 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
           });
         }
 
-        logger.info("tool_call", { tool: "acknowledge_service_messages", duration_ms: Date.now() - start, status: "ok", count: confirmed.length });
+        log({ count: confirmed.length });
         return toolResult({ confirmed, count: confirmed.length });
-      } catch (err) {
-        logger.info("tool_call", { tool: "acknowledge_service_messages", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+    }),
   );
 }
 
@@ -275,67 +259,58 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => {
-      const { session, rateLimiter, logger, deviceTypeCache } = deps;
-      const start = Date.now();
+    async () => runTool("get_system_info", deps.logger, async () => {
+      const { session, rateLimiter, deviceTypeCache } = deps;
+      const active = deps.targets.active;
+      const results: Record<string, unknown> = {
+        serverVersion: VERSION,
+        target: active.profile.name,
+        user: active.profile.ccu.user,
+      };
 
-      try {
-        const active = deps.targets.active;
-        const results: Record<string, unknown> = {
-          serverVersion: VERSION,
-          target: active.profile.name,
-          user: active.profile.ccu.user,
-        };
+      // These four are LEVEL ADMIN on the CCU (verified in OCCU methods.conf),
+      // so they only return real values for an admin session. We use that as a
+      // capability probe: any non-empty result => the login has admin rights.
+      const calls: Array<{ key: string; method: string }> = [
+        { key: "version", method: "CCU.getVersion" },
+        { key: "serial", method: "CCU.getSerial" },
+        { key: "address", method: "CCU.getAddress" },
+        { key: "hmipAddress", method: "CCU.getHmIPAddress" },
+      ];
 
-        // These four are LEVEL ADMIN on the CCU (verified in OCCU methods.conf),
-        // so they only return real values for an admin session. We use that as a
-        // capability probe: any non-empty result => the login has admin rights.
-        const calls: Array<{ key: string; method: string }> = [
-          { key: "version", method: "CCU.getVersion" },
-          { key: "serial", method: "CCU.getSerial" },
-          { key: "address", method: "CCU.getAddress" },
-          { key: "hmipAddress", method: "CCU.getHmIPAddress" },
-        ];
-
-        let anyAdminOk = false;
-        for (const { key, method } of calls) {
-          try {
-            await rateLimiter.acquire();
-            const value = await session.call(method);
-            if (value !== null && value !== undefined && value !== "") {
-              results[key] = value;
-              anyAdminOk = true;
-            } else {
-              results[key] = "N/A"; // empty/no value rather than null
-            }
-          } catch {
-            results[key] = "N/A"; // permission denied or call failed
+      let anyAdminOk = false;
+      for (const { key, method } of calls) {
+        try {
+          await rateLimiter.acquire();
+          const value = await session.call(method);
+          if (value !== null && value !== undefined && value !== "") {
+            results[key] = value;
+            anyAdminOk = true;
+          } else {
+            results[key] = "N/A"; // empty/no value rather than null
           }
+        } catch {
+          results[key] = "N/A"; // permission denied or call failed
         }
-
-        // Infer role: admin-only calls answered => ADMIN; otherwise logged in but
-        // without those rights => USER; not logged in / unreachable => UNKNOWN.
-        const loggedIn = active.session.isLoggedIn();
-        results.role = anyAdminOk ? "ADMIN" : (loggedIn ? "USER" : "UNKNOWN");
-        if (!anyAdminOk && loggedIn) {
-          results.accessNote =
-            `Firmware version, serial and addresses are ADMIN-only on the CCU; ` +
-            `'${active.profile.ccu.user}' is a non-admin (USER) login, so those show "N/A". ` +
-            `Use an ADMIN account to see them.`;
-        }
-
-        results.cacheTypes = deviceTypeCache.size();
-        results.cacheWarming = deviceTypeCache.isWarming();
-        results.build = loadBuildInfo();
-
-        logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult(results as Record<string, unknown>);
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
       }
-    },
+
+      // Infer role: admin-only calls answered => ADMIN; otherwise logged in but
+      // without those rights => USER; not logged in / unreachable => UNKNOWN.
+      const loggedIn = active.session.isLoggedIn();
+      results.role = anyAdminOk ? "ADMIN" : (loggedIn ? "USER" : "UNKNOWN");
+      if (!anyAdminOk && loggedIn) {
+        results.accessNote =
+          `Firmware version, serial and addresses are ADMIN-only on the CCU; ` +
+          `'${active.profile.ccu.user}' is a non-admin (USER) login, so those show "N/A". ` +
+          `Use an ADMIN account to see them.`;
+      }
+
+      results.cacheTypes = deviceTypeCache.size();
+      results.cacheWarming = deviceTypeCache.isWarming();
+      results.build = loadBuildInfo();
+
+      return structuredResult(results as Record<string, unknown>);
+    }),
   );
 }
 
@@ -358,11 +333,8 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("get_rssi", deps.logger, async (log) => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-
-      try {
         // Device list → address→{name,interface}. Same call list_devices uses;
         // also refresh the resolver so later interface lookups are warm.
         await rateLimiter.acquire();
@@ -487,14 +459,9 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
           bidcosInterfaces = [];
         }
 
-        logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "ok", devices: deviceEntries.length });
+        log({ devices: deviceEntries.length });
         return structuredResult({ devices: deviceEntries, interfaces: bidcosInterfaces });
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+    }),
   );
 }
 

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -2,10 +2,10 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
-import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { runTool } from "../middleware/tool-handler.js";
 import { resolveTarget } from "../ccu/target-registry.js";
-import { toolResult, structuredResult } from "../utils.js";
+import { structuredResult } from "../utils.js";
 
 // Optional per-call target override (route one read to a named CCU).
 const targetField = z.string().optional()
@@ -41,97 +41,89 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
       outputSchema: { devices: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("list_devices", deps.logger, async (log) => {
       const { rateLimiter, logger } = deps;
-      const start = Date.now();
+      const { session, resolver } = resolveTarget(deps.targets, args.target);
+      await rateLimiter.acquire();
+      const result = await withRetry(
+        () => session.call("Device.listAllDetail"),
+        "Device.listAllDetail",
+        logger,
+      );
 
-      try {
-        const { session, resolver } = resolveTarget(deps.targets, args.target);
-        await rateLimiter.acquire();
-        const result = await withRetry(
-          () => session.call("Device.listAllDetail"),
-          "Device.listAllDetail",
-          logger,
-        );
+      let devices = result as CcuDevice[];
 
-        let devices = result as CcuDevice[];
+      // Update resolver's device list
+      resolver.updateDeviceList(devices);
 
-        // Update resolver's device list
-        resolver.updateDeviceList(devices);
+      if (args.room || args.function) {
+        const channelIds = new Set<string>();
 
-        if (args.room || args.function) {
-          const channelIds = new Set<string>();
-
-          if (args.room) {
-            await rateLimiter.acquire();
-            const rooms = await withRetry(
-              () => session.call("Room.getAll"),
-              "Room.getAll",
-              logger,
-            ) as Array<{ id: string; name: string; channelIds: string[] }>;
-            const room = rooms.find((r) => r.name === args.room);
-            if (room) for (const id of room.channelIds) channelIds.add(id);
-          }
-
-          if (args.function) {
-            await rateLimiter.acquire();
-            const functions = await withRetry(
-              () => session.call("Subsection.getAll"),
-              "Subsection.getAll",
-              logger,
-            ) as Array<{ id: string; name: string; channelIds: string[] }>;
-            const func = functions.find((f) => f.name === args.function);
-            if (func) for (const id of func.channelIds) channelIds.add(id);
-          }
-
-          devices = channelIds.size > 0
-            ? devices.filter((d) => d.channels.some((ch) => channelIds.has(ch.id)))
-            : [];
+        if (args.room) {
+          await rateLimiter.acquire();
+          const rooms = await withRetry(
+            () => session.call("Room.getAll"),
+            "Room.getAll",
+            logger,
+          ) as Array<{ id: string; name: string; channelIds: string[] }>;
+          const room = rooms.find((r) => r.name === args.room);
+          if (room) for (const id of room.channelIds) channelIds.add(id);
         }
 
-        if (args.type) devices = devices.filter((d) => d.type === args.type);
-
-        if (args.name) {
-          const needle = args.name.toLowerCase();
-          devices = devices.filter(
-            (d) =>
-              d.name.toLowerCase().includes(needle) ||
-              d.channels.some((ch) => ch.name.toLowerCase().includes(needle)),
-          );
+        if (args.function) {
+          await rateLimiter.acquire();
+          const functions = await withRetry(
+            () => session.call("Subsection.getAll"),
+            "Subsection.getAll",
+            logger,
+          ) as Array<{ id: string; name: string; channelIds: string[] }>;
+          const func = functions.find((f) => f.name === args.function);
+          if (func) for (const id of func.channelIds) channelIds.add(id);
         }
 
-        const hasFilter = args.room || args.function || args.type || args.name;
-
-        // Compact format when unfiltered (summary only), full details when filtered
-        // Hide 50-channel virtual receivers (HM-RCV-50, HmIP-RCV-50) in compact mode
-        const HIDDEN_TYPES = new Set(["HM-RCV-50", "HmIP-RCV-50"]);
-        const output = hasFilter
-          ? devices
-          : devices
-            .filter((d) => !HIDDEN_TYPES.has(d.type))
-            .map((d) => ({
-              id: d.id,
-              name: d.name,
-              address: d.address,
-              interface: d.interface,
-              type: d.type,
-              channelCount: d.channels.length,
-              channels: d.channels.map((ch) => ({
-                address: ch.address,
-                name: ch.name,
-                index: ch.index,
-                channelType: ch.channelType,
-              })),
-            }));
-
-        logger.info("tool_call", { tool: "list_devices", duration_ms: Date.now() - start, status: "ok", deviceCount: devices.length });
-        return structuredResult({ devices: Array.isArray(output) ? output : [] }, output);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_devices", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+        devices = channelIds.size > 0
+          ? devices.filter((d) => d.channels.some((ch) => channelIds.has(ch.id)))
+          : [];
       }
-    },
+
+      if (args.type) devices = devices.filter((d) => d.type === args.type);
+
+      if (args.name) {
+        const needle = args.name.toLowerCase();
+        devices = devices.filter(
+          (d) =>
+            d.name.toLowerCase().includes(needle) ||
+            d.channels.some((ch) => ch.name.toLowerCase().includes(needle)),
+        );
+      }
+
+      const hasFilter = args.room || args.function || args.type || args.name;
+
+      // Compact format when unfiltered (summary only), full details when filtered
+      // Hide 50-channel virtual receivers (HM-RCV-50, HmIP-RCV-50) in compact mode
+      const HIDDEN_TYPES = new Set(["HM-RCV-50", "HmIP-RCV-50"]);
+      const output = hasFilter
+        ? devices
+        : devices
+          .filter((d) => !HIDDEN_TYPES.has(d.type))
+          .map((d) => ({
+            id: d.id,
+            name: d.name,
+            address: d.address,
+            interface: d.interface,
+            type: d.type,
+            channelCount: d.channels.length,
+            channels: d.channels.map((ch) => ({
+              address: ch.address,
+              name: ch.name,
+              index: ch.index,
+              channelType: ch.channelType,
+            })),
+          }));
+
+      log({ deviceCount: devices.length });
+      return structuredResult({ devices: Array.isArray(output) ? output : [] }, output);
+    }),
   );
 }
 
@@ -144,20 +136,12 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
       outputSchema: { interfaces: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => {
+    async () => runTool("list_interfaces", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-      try {
-        await rateLimiter.acquire();
-        const result = await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger);
-        logger.info("tool_call", { tool: "list_interfaces", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult({ interfaces: Array.isArray(result) ? result : [] }, result);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_interfaces", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      await rateLimiter.acquire();
+      const result = await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger);
+      return structuredResult({ interfaces: Array.isArray(result) ? result : [] }, result);
+    }),
   );
 }
 
@@ -170,20 +154,12 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
       outputSchema: { rooms: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => {
+    async () => runTool("list_rooms", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-      try {
-        await rateLimiter.acquire();
-        const result = await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger);
-        logger.info("tool_call", { tool: "list_rooms", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult({ rooms: Array.isArray(result) ? result : [] }, result);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_rooms", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      await rateLimiter.acquire();
+      const result = await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger);
+      return structuredResult({ rooms: Array.isArray(result) ? result : [] }, result);
+    }),
   );
 }
 
@@ -196,20 +172,12 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
       outputSchema: { functions: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => {
+    async () => runTool("list_functions", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-      try {
-        await rateLimiter.acquire();
-        const result = await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger);
-        logger.info("tool_call", { tool: "list_functions", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult({ functions: Array.isArray(result) ? result : [] }, result);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_functions", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      await rateLimiter.acquire();
+      const result = await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger);
+      return structuredResult({ functions: Array.isArray(result) ? result : [] }, result);
+    }),
   );
 }
 
@@ -225,26 +193,18 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
       outputSchema: { programs: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("list_programs", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-      try {
-        await rateLimiter.acquire();
-        let programs = await withRetry(() => session.call("Program.getAll"), "Program.getAll", logger) as Array<{ name: string }>;
+      await rateLimiter.acquire();
+      let programs = await withRetry(() => session.call("Program.getAll"), "Program.getAll", logger) as Array<{ name: string }>;
 
-        if (args.name) {
-          const needle = args.name.toLowerCase();
-          programs = programs.filter((p) => p.name.toLowerCase().includes(needle));
-        }
-
-        logger.info("tool_call", { tool: "list_programs", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult({ programs: Array.isArray(programs) ? programs : [] }, programs);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_programs", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      if (args.name) {
+        const needle = args.name.toLowerCase();
+        programs = programs.filter((p) => p.name.toLowerCase().includes(needle));
       }
-    },
+
+      return structuredResult({ programs: Array.isArray(programs) ? programs : [] }, programs);
+    }),
   );
 }
 
@@ -260,26 +220,18 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
       outputSchema: { systemVariables: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("list_system_variables", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-      try {
-        await rateLimiter.acquire();
-        let sysvars = await withRetry(() => session.call("SysVar.getAll"), "SysVar.getAll", logger) as Array<{ name: string }>;
+      await rateLimiter.acquire();
+      let sysvars = await withRetry(() => session.call("SysVar.getAll"), "SysVar.getAll", logger) as Array<{ name: string }>;
 
-        if (args.name) {
-          const needle = args.name.toLowerCase();
-          sysvars = sysvars.filter((v) => v.name.toLowerCase().includes(needle));
-        }
-
-        logger.info("tool_call", { tool: "list_system_variables", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult({ systemVariables: Array.isArray(sysvars) ? sysvars : [] }, sysvars);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_system_variables", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      if (args.name) {
+        const needle = args.name.toLowerCase();
+        sysvars = sysvars.filter((v) => v.name.toLowerCase().includes(needle));
       }
-    },
+
+      return structuredResult({ systemVariables: Array.isArray(sysvars) ? sysvars : [] }, sysvars);
+    }),
   );
 }
 
@@ -299,27 +251,20 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
       outputSchema: { deviceType: z.string().optional().describe("Echoed device type; other keys hold the channel/datapoint schema or a not-found hint") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
-      const { rateLimiter, logger } = deps;
-      const start = Date.now();
-
-      let target;
-      try {
-        target = resolveTarget(deps.targets, args.target);
-      } catch (err) {
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-      const { session, resolver, deviceTypeCache } = target;
+    async (args) => runTool("describe_device_type", deps.logger, async (log) => {
+      const { rateLimiter } = deps;
+      // resolveTarget may throw NOT_FOUND for an unknown target — runTool maps it.
+      const { session, resolver, deviceTypeCache } = resolveTarget(deps.targets, args.target);
 
       let cached = deviceTypeCache.get(args.deviceType);
 
       if (cached) {
-        logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: true });
+        log({ cached: true });
         return structuredResult({ deviceType: args.deviceType, ...cached });
       }
 
       // Cache miss — try live query if we can find a device instance
+      log({ cached: false });
       const devices = resolver.getDeviceList();
       if (devices) {
         const device = devices.find((d) => d.type === args.deviceType);
@@ -331,7 +276,6 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
               session, rateLimiter,
             );
             if (cached) {
-              logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: false });
               return structuredResult({ deviceType: args.deviceType, ...cached });
             }
           } catch {
@@ -340,13 +284,12 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
         }
       }
 
-      logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: false });
       return structuredResult({
         deviceType: args.deviceType,
         message: "Device type not in cache. Cache may still be warming. Try again shortly or call list_devices first.",
         availableTypes: Object.keys(deviceTypeCache.getAll()),
       });
-    },
+    }),
   );
 }
 
@@ -365,79 +308,71 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
       outputSchema: { links: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("list_links", deps.logger, async (log) => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
+      // Channel address → name map; SENDER/RECEIVER from getLinks are channel addresses.
+      await rateLimiter.acquire();
+      const devices = await withRetry(
+        () => session.call("Device.listAllDetail"),
+        "Device.listAllDetail",
+        logger,
+      ) as CcuDevice[];
+      deps.resolver.updateDeviceList(devices);
+      const channelName = new Map<string, string>();
+      for (const d of devices) for (const ch of d.channels) channelName.set(ch.address, ch.name);
 
-      try {
-        // Channel address → name map; SENDER/RECEIVER from getLinks are channel addresses.
-        await rateLimiter.acquire();
-        const devices = await withRetry(
-          () => session.call("Device.listAllDetail"),
-          "Device.listAllDetail",
-          logger,
-        ) as CcuDevice[];
-        deps.resolver.updateDeviceList(devices);
-        const channelName = new Map<string, string>();
-        for (const d of devices) for (const ch of d.channels) channelName.set(ch.address, ch.name);
+      // Auto-iterate all interfaces (BidCos-RF, HmIP-RF, …) like the cache warmer.
+      await rateLimiter.acquire();
+      const interfaces = await withRetry(
+        () => session.call("Interface.listInterfaces"),
+        "Interface.listInterfaces",
+        logger,
+      ) as Array<{ name: string }>;
 
-        // Auto-iterate all interfaces (BidCos-RF, HmIP-RF, …) like the cache warmer.
-        await rateLimiter.acquire();
-        const interfaces = await withRetry(
-          () => session.call("Interface.listInterfaces"),
-          "Interface.listInterfaces",
-          logger,
-        ) as Array<{ name: string }>;
+      // Match a channel address against the filter: exact channel, or any
+      // channel of the given device address (so a device-level filter works).
+      const matchesAddr = (chAddr: string): boolean => {
+        if (!args.address) return true;
+        return chAddr === args.address || chAddr.split(":")[0] === args.address;
+      };
 
-        // Match a channel address against the filter: exact channel, or any
-        // channel of the given device address (so a device-level filter works).
-        const matchesAddr = (chAddr: string): boolean => {
-          if (!args.address) return true;
-          return chAddr === args.address || chAddr.split(":")[0] === args.address;
-        };
-
-        const links: Array<Record<string, unknown>> = [];
-        for (const iface of interfaces) {
-          let raw: unknown;
-          try {
-            await rateLimiter.acquire();
-            raw = await withRetry(
-              () => session.call("Interface.getLinks", { interface: iface.name, address: args.address ?? "", flags: 0 }),
-              "Interface.getLinks",
-              logger,
-            );
-          } catch {
-            continue; // interface doesn't expose getLinks
-          }
-          if (!Array.isArray(raw)) continue;
-
-          for (const l of raw as Array<Record<string, unknown>>) {
-            // JSON-RPC getLinks returns lowercase fields (see occu
-            // .../interface/getlinks.tcl): sender, receiver, name, description, flags.
-            const sender = String(l.sender ?? "");
-            const receiver = String(l.receiver ?? "");
-            // Re-filter client-side in case the interface ignores the address arg.
-            if (!matchesAddr(sender) && !matchesAddr(receiver)) continue;
-            links.push({
-              sender,
-              senderName: channelName.get(sender) ?? "",
-              receiver,
-              receiverName: channelName.get(receiver) ?? "",
-              name: l.name ?? "",
-              description: l.description ?? "",
-              flags: l.flags ?? 0,
-              interface: iface.name,
-            });
-          }
+      const links: Array<Record<string, unknown>> = [];
+      for (const iface of interfaces) {
+        let raw: unknown;
+        try {
+          await rateLimiter.acquire();
+          raw = await withRetry(
+            () => session.call("Interface.getLinks", { interface: iface.name, address: args.address ?? "", flags: 0 }),
+            "Interface.getLinks",
+            logger,
+          );
+        } catch {
+          continue; // interface doesn't expose getLinks
         }
+        if (!Array.isArray(raw)) continue;
 
-        logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "ok", links: links.length });
-        return structuredResult({ links }, links);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+        for (const l of raw as Array<Record<string, unknown>>) {
+          // JSON-RPC getLinks returns lowercase fields (see occu
+          // .../interface/getlinks.tcl): sender, receiver, name, description, flags.
+          const sender = String(l.sender ?? "");
+          const receiver = String(l.receiver ?? "");
+          // Re-filter client-side in case the interface ignores the address arg.
+          if (!matchesAddr(sender) && !matchesAddr(receiver)) continue;
+          links.push({
+            sender,
+            senderName: channelName.get(sender) ?? "",
+            receiver,
+            receiverName: channelName.get(receiver) ?? "",
+            name: l.name ?? "",
+            description: l.description ?? "",
+            flags: l.flags ?? 0,
+            interface: iface.name,
+          });
+        }
       }
-    },
+
+      log({ links: links.length });
+      return structuredResult({ links }, links);
+    }),
   );
 }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
-import { CcuError } from "../middleware/error-mapper.js";
+import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult } from "../utils.js";
 
@@ -257,23 +257,14 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
         openWorldHint: true,
       },
     },
-    async (args) => {
-      const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
+    async (args) => runTool("run_script", deps.logger, async () => {
+      const { session, rateLimiter } = deps;
+      assertWritable(deps.targets.active, args.confirm);
+      await rateLimiter.acquire();
+      // No retry — scripts are not idempotent
+      const result = await session.call("ReGa.runScript", { script: args.script }, deps.targets.active.profile.ccu.scriptTimeout);
 
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        await rateLimiter.acquire();
-        // No retry — scripts are not idempotent
-        const result = await session.call("ReGa.runScript", { script: args.script }, deps.targets.active.profile.ccu.scriptTimeout);
-
-        logger.info("tool_call", { tool: "run_script", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(result);
-      } catch (err) {
-        logger.info("tool_call", { tool: "run_script", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      return toolResult(result);
+    }),
   );
 }

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -107,14 +107,14 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         } else if (args.function) {
           script = buildGetValuesScript(`"${escapeHmScript(args.function)}"`, "function");
         } else {
-          return {
-            isError: true,
-            content: [{ type: "text" as const, text: JSON.stringify({
-              error: "INVALID_INPUT",
-              message: "Provide either channels, room, or function parameter.",
-              hint: "At least one filter is required to avoid reading all devices.",
-            }) }],
-          };
+          // Route through CcuError like every other tool (the catch below maps
+          // it via toMcpError) instead of hand-building an isError result.
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: "Provide either channels, room, or function parameter.",
+            hint: "At least one filter is required to avoid reading all devices.",
+          });
         }
 
         await rateLimiter.acquire();

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -3,8 +3,9 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { runTool } from "../middleware/tool-handler.js";
 import { resolveTarget } from "../ccu/target-registry.js";
-import { toolResult, structuredResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
+import { structuredResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
 
 // Optional per-call target override for read tools: route this one read to a
 // named CCU without switching the active target (handy for prod-vs-dev compares).
@@ -39,33 +40,25 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("get_value", deps.logger, async (log) => {
       const { rateLimiter, logger } = deps;
-      const start = Date.now();
+      const { session, resolver } = resolveTarget(deps.targets, args.target);
+      const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
-      try {
-        const { session, resolver } = resolveTarget(deps.targets, args.target);
-        const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
+      await rateLimiter.acquire();
+      const value = await withRetry(
+        () => session.call("Interface.getValue", {
+          interface: iface,
+          address: args.address,
+          valueKey: args.valueKey,
+        }),
+        "Interface.getValue",
+        logger,
+      );
 
-        await rateLimiter.acquire();
-        const value = await withRetry(
-          () => session.call("Interface.getValue", {
-            interface: iface,
-            address: args.address,
-            valueKey: args.valueKey,
-          }),
-          "Interface.getValue",
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "get_value", duration_ms: Date.now() - start, status: "ok", address: args.address });
-        return structuredResult({ address: args.address, valueKey: args.valueKey, value: parseValue(value) });
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_value", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      log({ address: args.address });
+      return structuredResult({ address: args.address, valueKey: args.valueKey, value: parseValue(value) });
+    }),
   );
 }
 
@@ -88,52 +81,43 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("get_values", deps.logger, async () => {
       const { rateLimiter, logger } = deps;
-      const start = Date.now();
+      const t = resolveTarget(deps.targets, args.target);
+      const { session } = t;
+      // Build HM Script to collect values
+      let script: string;
 
-      try {
-        const t = resolveTarget(deps.targets, args.target);
-        const { session } = t;
-        // Build HM Script to collect values
-        let script: string;
-
-        if (args.channels && args.channels.length > 0) {
-          // Comma-delimited with sentinel commas for exact matching via Find()
-          const addrList = "," + args.channels.map((a) => escapeHmScript(a)).join(",") + ",";
-          script = buildGetValuesScript(`"${addrList}"`, "addresses");
-        } else if (args.room) {
-          script = buildGetValuesScript(`"${escapeHmScript(args.room)}"`, "room");
-        } else if (args.function) {
-          script = buildGetValuesScript(`"${escapeHmScript(args.function)}"`, "function");
-        } else {
-          // Route through CcuError like every other tool (the catch below maps
-          // it via toMcpError) instead of hand-building an isError result.
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: "Provide either channels, room, or function parameter.",
-            hint: "At least one filter is required to avoid reading all devices.",
-          });
-        }
-
-        await rateLimiter.acquire();
-        const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, t.profile.ccu.scriptTimeout),
-          "ReGa.runScript",
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "get_values", duration_ms: Date.now() - start, status: "ok" });
-        const data = typeof result === "string" ? tryParseJson(result) : result;
-        // Wrap the array for structuredContent; keep the bare array as the text block.
-        return structuredResult({ values: Array.isArray(data) ? data : [] }, data);
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_values", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      if (args.channels && args.channels.length > 0) {
+        // Comma-delimited with sentinel commas for exact matching via Find()
+        const addrList = "," + args.channels.map((a) => escapeHmScript(a)).join(",") + ",";
+        script = buildGetValuesScript(`"${addrList}"`, "addresses");
+      } else if (args.room) {
+        script = buildGetValuesScript(`"${escapeHmScript(args.room)}"`, "room");
+      } else if (args.function) {
+        script = buildGetValuesScript(`"${escapeHmScript(args.function)}"`, "function");
+      } else {
+        // Route through CcuError like every other tool (runTool maps it via
+        // toMcpError) instead of hand-building an isError result.
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: "Provide either channels, room, or function parameter.",
+          hint: "At least one filter is required to avoid reading all devices.",
+        });
       }
-    },
+
+      await rateLimiter.acquire();
+      const result = await withRetry(
+        () => session.call("ReGa.runScript", { script }, t.profile.ccu.scriptTimeout),
+        "ReGa.runScript",
+        logger,
+      );
+
+      const data = typeof result === "string" ? tryParseJson(result) : result;
+      // Wrap the array for structuredContent; keep the bare array as the text block.
+      return structuredResult({ values: Array.isArray(data) ? data : [] }, data);
+    }),
   );
 }
 
@@ -227,37 +211,28 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("get_paramset", deps.logger, async () => {
       const { rateLimiter, logger } = deps;
-      const start = Date.now();
+      const { session, resolver } = resolveTarget(deps.targets, args.target);
+      const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
-      try {
-        const { session, resolver } = resolveTarget(deps.targets, args.target);
-        const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
+      await rateLimiter.acquire();
+      const result = await withRetry(
+        () => session.call("Interface.getParamset", {
+          interface: iface,
+          address: args.address,
+          paramsetKey: args.paramsetKey,
+        }),
+        "Interface.getParamset",
+        logger,
+      );
 
-        await rateLimiter.acquire();
-        const result = await withRetry(
-          () => session.call("Interface.getParamset", {
-            interface: iface,
-            address: args.address,
-            paramsetKey: args.paramsetKey,
-          }),
-          "Interface.getParamset",
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "get_paramset", duration_ms: Date.now() - start, status: "ok" });
-        // Parse values to native types if result is a flat object
-        const params = (typeof result === "object" && result !== null && !Array.isArray(result))
-          ? parseValues(result as Record<string, unknown>)
-          : result;
-        return structuredResult({ address: args.address, paramsetKey: args.paramsetKey, params });
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_paramset", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      // Parse values to native types if result is a flat object
+      const params = (typeof result === "object" && result !== null && !Array.isArray(result))
+        ? parseValues(result as Record<string, unknown>)
+        : result;
+      return structuredResult({ address: args.address, paramsetKey: args.paramsetKey, params });
+    }),
   );
 }
 

--- a/test/unit/rate-limiter.test.ts
+++ b/test/unit/rate-limiter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { RateLimiter } from "../../src/middleware/rate-limiter.js";
+import { CcuError } from "../../src/middleware/error-mapper.js";
 
 describe("RateLimiter", () => {
   let limiter: RateLimiter;
@@ -29,6 +30,26 @@ describe("RateLimiter", () => {
 
     // Should have waited a bit (at least one refill cycle of 100ms)
     expect(elapsed).toBeGreaterThanOrEqual(50);
+  });
+
+  it("rejects with RATE_LIMITED once the wait queue is full", async () => {
+    // 0 tokens, no refill, queue capped at 2: the first 2 acquires park, the
+    // 3rd exceeds the cap and must reject rather than grow the queue.
+    limiter = new RateLimiter(0, 0, 2);
+
+    const queued1 = limiter.acquire();
+    const queued2 = limiter.acquire();
+
+    await expect(limiter.acquire()).rejects.toBeInstanceOf(CcuError);
+    await limiter.acquire().catch((err) => {
+      expect(err).toBeInstanceOf(CcuError);
+      expect((err as CcuError).structured.error).toBe("RATE_LIMITED");
+    });
+
+    // The two genuinely-queued waiters are still pending; destroy releases them
+    // so the test doesn't leak unsettled promises.
+    limiter.destroy();
+    await Promise.all([queued1, queued2]);
   });
 
   it("destroy releases waiting requests", async () => {


### PR DESCRIPTION
## Summary

Lands the round-6 review work that was finished on 2026-06-22 but never PR'd.

**Fix (`32a5958`):**
- Bounds the HTTP-mode session map: cap 256 sessions, 30-min idle eviction via a periodic unref'd sweep, and 503 + `Retry-After` when at capacity — an authenticated client reconnecting in a loop can no longer grow the map without bound.
- Bounds the rate-limiter queue (new unit test included).
- Routes a `get_values` error path through `CcuError` instead of leaking a raw throw.

**Refactor (3 commits, review finding I-2):**
- Extracts `src/middleware/tool-handler.ts::runTool` — one shared wrapper for the timer/`tool_call` log/`CcuError`→MCP-error boilerplate every tool handler had hand-rolled — and applies it across read, discovery, control, diagnostics, and meta tools. Net −63 lines; logging and error mapping can no longer drift between tools.

## Testing

- Merges cleanly onto current dev (verified in a scratch worktree; zero conflicts).
- The #74 fix (`AlReceipt()`, nested null-checks, parenthesized comparisons) survives intact in both diagnostics scripts after the merge.
- `npm run lint` clean; 355 unit/e2e tests pass on the merged tree.
- Post-merge: live smoke test of read tools against the prod CCU planned, since the refactor touches every handler.