### PR TITLE
fix: per-call confirm for run_script & delete_system_variable on protected targets (#72)

### DIFF
--- a/src/ccu/target-registry.ts
+++ b/src/ccu/target-registry.ts
@@ -159,8 +159,19 @@ export function resolveTarget(targets: TargetRegistry, name?: string): Target {
  * Gate a write against a target's policy. `readonly` targets always refuse;
  * `protected` targets refuse until the caller passes confirm:true once, which
  * unlocks writes to that target for the rest of the session.
+ *
+ * `alwaysConfirm` marks a high-blast-radius tool (run_script,
+ * delete_system_variable): the session unlock never applies — every call
+ * needs its own confirm:true, and a confirmed call does NOT unlock the
+ * session for other writes (issue #72). run_script bypasses all value/type
+ * guards the typed tools enforce, so it must not ride on a confirmation that
+ * was given for a harmless set_value.
  */
-export function assertWritable(target: Target, confirm: boolean | undefined): void {
+export function assertWritable(
+  target: Target,
+  confirm: boolean | undefined,
+  opts?: { alwaysConfirm?: boolean },
+): void {
   if (target.profile.readonly) {
     throw new CcuError({
       error: "INVALID_INPUT",
@@ -169,13 +180,25 @@ export function assertWritable(target: Target, confirm: boolean | undefined): vo
       hint: "Switch to a writable target with use_ccu, or clear its readonly flag in config.",
     });
   }
-  if (target.profile.protected && !target.unlocked) {
+  if (!target.profile.protected) return;
+  if (opts?.alwaysConfirm) {
+    if (confirm !== true) {
+      throw new CcuError({
+        error: "INVALID_INPUT",
+        code: 0,
+        message: `CCU target "${target.profile.name}" is protected. This tool requires confirm:true on EVERY call — the session unlock does not apply to it.`,
+        hint: "High-impact operation on a protected CCU. Pass confirm:true with this call to proceed.",
+      });
+    }
+    return; // per-call authorization only — never unlocks the session
+  }
+  if (!target.unlocked) {
     if (confirm !== true) {
       throw new CcuError({
         error: "INVALID_INPUT",
         code: 0,
         message: `CCU target "${target.profile.name}" is protected. Re-issue with confirm:true to authorize writes for this session.`,
-        hint: "Safety gate on a production CCU. Pass confirm:true to proceed; later writes this session won't need it.",
+        hint: "Safety gate on a production CCU. Pass confirm:true to proceed; later writes this session won't need it (except run_script and delete_system_variable, which confirm every call).",
       });
     }
     target.unlocked = true;

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -401,10 +401,11 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
     "delete_system_variable",
     {
       title: "Delete System Variable",
-      description: "Delete a system variable by name. Use list_system_variables to see existing names.",
+      description: "Delete a system variable by name. Use list_system_variables to see existing names. " +
+        "On a protected target, EVERY call needs confirm:true — the session unlock from other write tools does not apply.",
       inputSchema: {
         name: z.string().describe("Variable name (exact match)"),
-        confirm: confirmField,
+        confirm: z.boolean().optional().describe("Required true on EVERY call against a protected CCU target (e.g. prod) — deletion never rides on the session unlock."),
       },
       annotations: {
         destructiveHint: true,
@@ -415,7 +416,8 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
     async (args) => runTool("delete_system_variable", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
       const typeCacheHolder = deps.targets.active.sysVarTypeCache;
-      assertWritable(deps.targets.active, args.confirm);
+      // Destructive and unrecoverable — per-call confirm (#72)
+      assertWritable(deps.targets.active, args.confirm, { alwaysConfirm: true });
       // Validate existence so an unknown name is a clean NOT_FOUND rather than
       // a silent no-op (deleteSysVarByName doesn't report a missing name).
       await rateLimiter.acquire();

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -47,6 +47,10 @@ This server can be configured with several named CCU targets (profiles). One is
   call without switching (e.g. compare prod vs dev).
 - A \`protected\` target (e.g. prod) refuses writes unless you pass \`confirm: true\`
   once — that unlocks writes to it for the rest of the session.
+- Exception: \`run_script\` and \`delete_system_variable\` require \`confirm: true\`
+  on EVERY call against a protected target. They never ride on the session
+  unlock (scripts bypass all typed-tool guards; deletion is unrecoverable),
+  and confirming them does not unlock the session for other writes.
 
 ## Tips
 - Use \`list_devices\` with room/function filters to reduce output
@@ -139,7 +143,7 @@ Returns: {name, type, created: true}
 INVALID_INPUT if the name already exists (or enum without values). Use set_system_variable to write it.`,
 
   delete_system_variable: `Delete a system variable by name.
-Args: name (string, exact match)
+Args: name (string, exact match), confirm (REQUIRED true on every call against a protected target — never rides on the session unlock)
 Returns: {name, deleted: true}
 NOT_FOUND if the name doesn't exist.`,
 
@@ -176,7 +180,7 @@ Returns: {devices: [{address, name, interface, links: [{peer, peerName, rssiDevi
 rssiDevice/rssiPeer are dBm (higher = better); null means no measurement. Use to diagnose flaky devices.`,
 
   run_script: `Execute arbitrary HomeMatic Script. NOT idempotent — never auto-retried.
-Args: script (string), confirm? (true to write to a protected target)
+Args: script (string), confirm (REQUIRED true on every call against a protected target — scripts bypass all typed-tool guards and never ride on the session unlock)
 Returns: Script output`,
 
   list_ccu_targets: `List configured CCU targets (profiles) you can switch between.
@@ -247,10 +251,11 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
       description:
         "Execute arbitrary HomeMatic Script on the CCU. " +
         "NOT idempotent — will not be auto-retried. " +
-        "Use for anything the other tools don't cover.",
+        "Use for anything the other tools don't cover. " +
+        "On a protected target, EVERY call needs confirm:true — the session unlock from other write tools does not apply.",
       inputSchema: {
         script: z.string().describe("HomeMatic Script to execute"),
-        confirm: z.boolean().optional().describe("Set true to authorize this script against a protected CCU target (e.g. prod)."),
+        confirm: z.boolean().optional().describe("Required true on EVERY call against a protected CCU target (e.g. prod) — scripts never ride on the session unlock."),
       },
       annotations: {
         destructiveHint: true,
@@ -259,7 +264,8 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => runTool("run_script", deps.logger, async () => {
       const { session, rateLimiter } = deps;
-      assertWritable(deps.targets.active, args.confirm);
+      // Scripts bypass every guard the typed tools enforce — per-call confirm (#72)
+      assertWritable(deps.targets.active, args.confirm, { alwaysConfirm: true });
       await rateLimiter.acquire();
       // No retry — scripts are not idempotent
       const result = await session.call("ReGa.runScript", { script: args.script }, deps.targets.active.profile.ccu.scriptTimeout);

--- a/test/unit/target-registry.test.ts
+++ b/test/unit/target-registry.test.ts
@@ -150,4 +150,29 @@ describe("assertWritable", () => {
     // subsequent writes no longer need confirm
     expect(() => assertWritable(t, undefined)).not.toThrow();
   });
+
+  // Issue #72: high-blast-radius tools (run_script, delete_system_variable)
+  // never ride on the session unlock — every call needs its own confirm.
+  it("alwaysConfirm ignores the session unlock: each call needs confirm:true", () => {
+    const t = target({ protected: true });
+    assertWritable(t, true); // ordinary write unlocks the session
+    expect(t.unlocked).toBe(true);
+    // ...but an alwaysConfirm tool still refuses without its own confirm
+    expect(() => assertWritable(t, undefined, { alwaysConfirm: true })).toThrowError(/EVERY call/);
+    expect(() => assertWritable(t, true, { alwaysConfirm: true })).not.toThrow();
+    // and refuses again on the next call — no per-call carryover
+    expect(() => assertWritable(t, undefined, { alwaysConfirm: true })).toThrowError(/EVERY call/);
+  });
+
+  it("a confirmed alwaysConfirm call does not unlock the session for other writes", () => {
+    const t = target({ protected: true });
+    expect(() => assertWritable(t, true, { alwaysConfirm: true })).not.toThrow();
+    expect(t.unlocked).toBe(false);
+    expect(() => assertWritable(t, undefined)).toThrowError(/protected/);
+  });
+
+  it("alwaysConfirm is a no-op gate on unprotected targets and still refuses readonly", () => {
+    expect(() => assertWritable(target(), undefined, { alwaysConfirm: true })).not.toThrow();
+    expect(() => assertWritable(target({ readonly: true }), true, { alwaysConfirm: true })).toThrowError(/read-only/);
+  });
 });


### PR DESCRIPTION
## Summary

Implements option 1 from #72: the session unlock (`confirm: true` once per session) no longer applies to the two high-blast-radius tools.

- **`run_script`** bypasses every value/range/type guard the typed tools enforce — it now requires `confirm: true` on **every** call against a `protected` target.
- **`delete_system_variable`** is unrecoverable — same per-call rule.
- A confirmed call to either does **not** unlock the session for other writes.
- Unprotected/readonly semantics unchanged (readonly still refuses everything).
- Help text, tool descriptions, and the conceptual guide document the model; the standard protected-target error now mentions the exception.

## Testing

- 3 new unit tests covering the confirm/unlock interaction (session unlock ignored, no carryover between calls, no session unlock from a confirmed script).
- `npm run lint` clean; 358 unit/e2e tests pass.
- **Live-verified against the protected prod target:** script without confirm → refused with the per-call message; with confirm → runs; a normal write afterwards → still gated (session stayed locked); second script without confirm → refused again.

Fixes #72