### PR TITLE
chore(release): v1.6.0 prep — version bump + doc reconciliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ Each profile takes the same settings as the flat vars, prefixed
 
 - `CCU_<NAME>_PROTECTED=true` — write tools refuse unless called with
   `confirm: true`, which unlocks writes to that target for the rest of the session.
+  Exception: `run_script` and `delete_system_variable` require `confirm: true` on
+  **every** call — they never ride on the session unlock (scripts bypass all
+  typed-tool guards; deletion is unrecoverable), and confirming them does not
+  unlock the session for other writes.
 - `CCU_<NAME>_READONLY=true` — write tools are refused outright.
 
 With `CCU_PROFILES` unset, the flat `CCU_*` vars are used as a single `default`
@@ -273,7 +277,7 @@ without switching.
 
 ## Tools
 
-25 tools organized by what you'd actually want to do:
+28 tools organized by what you'd actually want to do:
 
 **Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `list_links`, `describe_device_type`
 
@@ -282,6 +286,8 @@ without switching.
 **Change things** — `set_value`, `put_paramset`, `set_system_variable`, `create_system_variable`, `delete_system_variable`, `assign_channel`, `unassign_channel`, `execute_program`
 
 **Check health** — `get_service_messages`, `acknowledge_service_messages`, `get_rssi`, `get_system_info`
+
+**Switch targets** — `list_ccu_targets`, `get_connection_info`, `use_ccu` (multi-CCU profiles; see above)
 
 **Other** — `help` (context-aware), `run_script` (raw HomeMatic Script for bulk operations, renaming devices/channels, querying room membership, or anything not covered by the other tools)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,18 @@ services:
       # - CCU_HTTPS=false
       # - CCU_USER=Admin
 
+      # === Multiple CCU targets (optional; see README "Multiple CCU targets") ===
+      # Named profiles instead of the flat CCU_* vars above. Per profile:
+      # CCU_<NAME>_HOST/USER/PASSWORD/PORT/HTTPS/..., plus policy flags.
+      # - CCU_PROFILES=prod,dev
+      # - CCU_DEFAULT_PROFILE=prod
+      # - CCU_PROD_HOST=192.168.x.x
+      # - CCU_PROD_PASSWORD=secret
+      # - CCU_PROD_PROTECTED=true   # writes need confirm:true (run_script/delete_system_variable: every call)
+      # - CCU_DEV_HOST=192.168.x.y
+      # - CCU_DEV_PASSWORD=secret2
+      # - CCU_DEV_READONLY=false
+
       # === MCP transport (optional) ===
       # - MCP_TRANSPORT=http
       # - MCP_PORT=3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.5.0",
+  "version": "1.6.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -68,6 +68,16 @@
         {
           "name": "MCP_ALLOWED_HOSTS",
           "description": "Extra Host header values accepted by DNS-rebinding protection (comma-separated host:port); add your hostname when behind a proxy or container DNS name",
+          "format": "string"
+        },
+        {
+          "name": "CCU_PROFILES",
+          "description": "Comma-separated names of multiple CCU targets (e.g. 'prod,dev'). Each profile takes the flat CCU_* settings prefixed CCU_<NAME>_ (CCU_PROD_HOST, ...), plus policy flags CCU_<NAME>_PROTECTED (writes need confirm:true) and CCU_<NAME>_READONLY. Unset = single default profile from the flat CCU_* vars",
+          "format": "string"
+        },
+        {
+          "name": "CCU_DEFAULT_PROFILE",
+          "description": "Which profile from CCU_PROFILES is active at startup (default: the first listed)",
           "format": "string"
         }
       ]


### PR DESCRIPTION
Release prep per the runbook (steps 1–3):

- Version 1.5.0 → **1.6.0** in `package.json` + both `server.json` spots (`npm version minor` + sync script; `check:versions` green).
- **README**: tool count 25 → 28; adds the missing *Switch targets* group (`list_ccu_targets`, `get_connection_info`, `use_ccu`); documents the per-call confirm exception for `run_script`/`delete_system_variable` on protected targets (#72).
- **server.json**: adds `CCU_PROFILES` / `CCU_DEFAULT_PROFILE` to `environmentVariables` (#69). `mcp-publisher validate` ✅.
- **docker-compose.yml**: commented multi-profile example block (#69).

Pre-flight done: `npm publish --dry-run` lists the expected tarball (112 files, 96.9 kB), versions in sync, schema valid. Milestone v1.6.0 carries #69/#72/#73/#74 and PRs #70/#71/#75/#76/#77.