### PR TITLE
Release v1.6.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,39 @@ CCU_CA_CERT=
 # Verify against the system trust store (only if the CCU has a publicly-trusted cert).
 CCU_TLS_VERIFY=false
 
+# ─── Multiple CCU targets / profiles (optional, issue #69) ──────────────────
+# By default the flat CCU_* vars above define a single target. To reach several
+# CCUs from ONE server (e.g. prod + dev), list profile names here and define
+# CCU_<NAME>_* vars for each. The active target is switched at runtime with the
+# use_ccu tool; read tools also take an optional `target` arg. When CCU_PROFILES
+# is unset, the flat CCU_* vars are used as a single "default" profile.
+CCU_PROFILES=
+# Which profile is active at startup (defaults to the first one listed).
+CCU_DEFAULT_PROFILE=
+#
+# Per-profile vars follow the pattern CCU_<PROFILE>_<SETTING> (profile name
+# upper-cased, non-alphanumerics → "_"). Each profile supports the same settings
+# as the flat ones: HOST (required), PASSWORD (may be empty — OpenCCU dev boxes
+# default to it), USER, PORT, HTTPS, TIMEOUT, SCRIPT_TIMEOUT, TLS_FINGERPRINT,
+# CA_CERT, TLS_VERIFY, plus two policy flags:
+#   CCU_<NAME>_PROTECTED=true  → write tools refuse unless called with confirm:true
+#   CCU_<NAME>_READONLY=true   → write tools are refused outright
+# These per-profile vars are read dynamically, so they are NOT listed as keys
+# here. Example (prod = the real box, protected; dev = a local OpenCCU VM):
+#   CCU_PROFILES=prod,dev
+#   CCU_DEFAULT_PROFILE=prod
+#   CCU_PROD_HOST=debmatic
+#   CCU_PROD_USER=claude
+#   CCU_PROD_PASSWORD=...
+#   CCU_PROD_HTTPS=true
+#   CCU_PROD_PORT=443
+#   CCU_PROD_TLS_FINGERPRINT=...
+#   CCU_PROD_PROTECTED=true
+#   CCU_DEV_HOST=127.0.0.1
+#   CCU_DEV_PORT=18080
+#   CCU_DEV_USER=Admin
+#   CCU_DEV_PASSWORD=
+
 # ─── CCU rate limiting (optional) ───────────────────────────────────────────
 # Max burst of requests sent to the CCU.
 CCU_RATE_LIMIT_BURST=20

--- a/README.md
+++ b/README.md
@@ -277,6 +277,10 @@ Other device types should work too — the server queries the CCU for parameter 
 - [debmatic](https://github.com/alexreinert/debmatic) — Run HomeMatic on Debian, Ubuntu, Raspberry Pi OS, Armbian
 - [OCCU](https://github.com/eq-3/occu) — eQ-3's original Open CCU SDK (the upstream HomeMatic software); now being superseded by the community-maintained [OpenCCU](https://github.com/OpenCCU/OpenCCU)
 - [MCP](https://modelcontextprotocol.io/) — Model Context Protocol specification
+- [ccu-ai-mcp](https://github.com/mdzio/ccu-ai-mcp) by **Mathias (mdzio)** — a
+  kindred MCP server for HomeMatic, taking a deliberately different, elegant
+  approach (a lean Go core with user-defined HM-Script tools). See his write-up
+  on the [HomeMatic forum](https://homematic-forum.de/forum/viewtopic.php?t=88226).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For Claude Code, create a `.mcp.json` file in your project directory (or any dir
 ```json
 {
   "mcpServers": {
-    "debmatic": {
+    "ccu-mcp": {
       "command": "npx",
       "args": ["ccu-mcp", "--stdio"],
       "env": {
@@ -69,12 +69,12 @@ For Claude Code, create a `.mcp.json` file in your project directory (or any dir
 
 Replace `your-ccu-hostname-or-ip` with your CCU's hostname (like `homematic-ccu3`) or IP (like `192.168.1.50`), and `your-ccu-admin-password` with the password you use to log into the CCU WebUI.
 
-Restart Claude Code. Run `/mcp` to check it connected. You should see `debmatic` in the list.
+Restart Claude Code. Run `/mcp` to check it connected. You should see `ccu-mcp` in the list.
 
 Alternatively, use the Claude Code CLI:
 
 ```bash
-claude mcp add debmatic -- npx ccu-mcp --stdio
+claude mcp add ccu-mcp -- npx ccu-mcp --stdio
 ```
 
 ### Option B: Docker (standalone HTTP server)
@@ -106,7 +106,7 @@ This prints something like `MCP_AUTH_TOKEN=e96suzi1iG0H-GPif6K2...`. The part af
 ```json
 {
   "mcpServers": {
-    "debmatic": {
+    "ccu-mcp": {
       "url": "http://your-server-ip:3000",
       "headers": {
         "Authorization": "Bearer PASTE-YOUR-TOKEN-HERE"
@@ -120,10 +120,10 @@ To inject the token automatically (requires `jq`):
 
 ```bash
 TOKEN=$(docker exec ccu-mcp grep MCP_AUTH_TOKEN /data/.env | cut -d= -f2)
-jq --arg t "$TOKEN" '.mcpServers.debmatic.headers.Authorization = "Bearer " + $t' .mcp.json > .mcp.json.tmp && mv .mcp.json.tmp .mcp.json
+jq --arg t "$TOKEN" '.mcpServers["ccu-mcp"].headers.Authorization = "Bearer " + $t' .mcp.json > .mcp.json.tmp && mv .mcp.json.tmp .mcp.json
 ```
 
-This only updates the `debmatic` entry — other servers in your `.mcp.json` are left alone.
+This only updates the `ccu-mcp` entry — other servers in your `.mcp.json` are left alone.
 
 **4. Check it's healthy:**
 
@@ -222,7 +222,7 @@ variables**. Provide them in whichever of these you prefer — you need just one
   ```json
   {
     "mcpServers": {
-      "ccu": {
+      "ccu-mcp": {
         "command": "node",
         "args": ["--env-file=/path/to/.env", "/path/to/ccu-mcp/dist/index.js", "--stdio"]
       }

--- a/README.md
+++ b/README.md
@@ -208,6 +208,65 @@ All configuration is via environment variables:
 | `CCU_RATE_LIMIT_RATE` | `10` | Sustained CCU requests per second |
 | `RESOURCE_POLL_INTERVAL` | `60` | Seconds between polls for MCP resource change notifications |
 
+### Multiple CCU targets (profiles)
+
+By default the `CCU_*` vars above configure a single CCU. To reach several CCUs
+(e.g. **prod + dev**) from one server, define named profiles instead:
+
+```sh
+CCU_PROFILES=prod,dev
+CCU_DEFAULT_PROFILE=prod           # active at startup (defaults to the first listed)
+
+CCU_PROD_HOST=ccu.example
+CCU_PROD_USER=ai
+CCU_PROD_PASSWORD=...
+CCU_PROD_HTTPS=true
+CCU_PROD_PROTECTED=true            # writes need confirm:true
+
+CCU_DEV_HOST=127.0.0.1
+CCU_DEV_PORT=18080
+CCU_DEV_USER=Admin
+CCU_DEV_PASSWORD=                  # may be empty (e.g. an OpenCCU dev box)
+```
+
+Each profile takes the same settings as the flat vars, prefixed
+`CCU_<NAME>_` (name upper-cased, non-alphanumerics → `_`): `HOST` (required),
+`PASSWORD` (may be empty), `USER`, `PORT`, `HTTPS`, `TIMEOUT`, `SCRIPT_TIMEOUT`,
+`TLS_FINGERPRINT`, `CA_CERT`, `TLS_VERIFY` — plus two policy flags:
+
+- `CCU_<NAME>_PROTECTED=true` — write tools refuse unless called with
+  `confirm: true`, which unlocks writes to that target for the rest of the session.
+- `CCU_<NAME>_READONLY=true` — write tools are refused outright.
+
+With `CCU_PROFILES` unset, the flat `CCU_*` vars are used as a single `default`
+profile (unchanged behavior). At runtime, `list_ccu_targets` shows the targets,
+`get_connection_info` reports the active one, and `use_ccu` switches it. Read
+tools also accept an optional `target` to read from another CCU for a single call
+without switching.
+
+### Using a `.env` file
+
+The server reads its configuration from **environment variables** and does not
+load a `.env` file on its own. To keep secrets out of `.mcp.json`, load a `.env`
+with Node's built-in flag (Node ≥ 20.6):
+
+```json
+{
+  "mcpServers": {
+    "ccu": {
+      "command": "node",
+      "args": ["--env-file=/path/to/.env", "/path/to/ccu-mcp/dist/index.js", "--stdio"]
+    }
+  }
+}
+```
+
+Copy [`.env.example`](.env.example) to `.env` and fill it in (it documents every
+variable, including the profile vars above). Docker users can pass the same file
+with `docker run --env-file .env` or compose's `env_file:`. Keep `.env`
+gitignored. Alternatively, set the variables inline in the `.mcp.json` `env`
+block or export them in your shell.
+
 ## Tools
 
 25 tools organized by what you'd actually want to do:

--- a/README.md
+++ b/README.md
@@ -208,10 +208,37 @@ All configuration is via environment variables:
 | `CCU_RATE_LIMIT_RATE` | `10` | Sustained CCU requests per second |
 | `RESOURCE_POLL_INTERVAL` | `60` | Seconds between polls for MCP resource change notifications |
 
+### How to supply these (inline, `.env`, or export)
+
+The required `CCU_HOST` / `CCU_PASSWORD` (and everything else) are **environment
+variables**. Provide them in whichever of these you prefer — you need just one:
+
+- **Inline in `.mcp.json`** — the `env` block shown in [Option A](#option-a-stdio-direct-simplest)
+  above. Simplest; self-contained.
+- **Shell `export`** — as in [Quick start](#quick-start) above.
+- **A `.env` file** — keeps secrets out of `.mcp.json`. The server does not read
+  `.env` on its own, so load it with Node's built-in flag (Node ≥ 20.6):
+
+  ```json
+  {
+    "mcpServers": {
+      "ccu": {
+        "command": "node",
+        "args": ["--env-file=/path/to/.env", "/path/to/ccu-mcp/dist/index.js", "--stdio"]
+      }
+    }
+  }
+  ```
+
+  Copy [`.env.example`](.env.example) to `.env` and fill it in (it documents every
+  variable). Docker users can pass the same file with `docker run --env-file .env`
+  or compose's `env_file:`. Keep `.env` gitignored.
+
 ### Multiple CCU targets (profiles)
 
 By default the `CCU_*` vars above configure a single CCU. To reach several CCUs
-(e.g. **prod + dev**) from one server, define named profiles instead:
+(e.g. **prod + dev**) from one server, define named profiles instead. Set these
+the same way as any other config (inline, `.env`, or export — see above):
 
 ```sh
 CCU_PROFILES=prod,dev
@@ -243,29 +270,6 @@ profile (unchanged behavior). At runtime, `list_ccu_targets` shows the targets,
 `get_connection_info` reports the active one, and `use_ccu` switches it. Read
 tools also accept an optional `target` to read from another CCU for a single call
 without switching.
-
-### Using a `.env` file
-
-The server reads its configuration from **environment variables** and does not
-load a `.env` file on its own. To keep secrets out of `.mcp.json`, load a `.env`
-with Node's built-in flag (Node ≥ 20.6):
-
-```json
-{
-  "mcpServers": {
-    "ccu": {
-      "command": "node",
-      "args": ["--env-file=/path/to/.env", "/path/to/ccu-mcp/dist/index.js", "--stdio"]
-    }
-  }
-}
-```
-
-Copy [`.env.example`](.env.example) to `.env` and fill it in (it documents every
-variable, including the profile vars above). Docker users can pass the same file
-with `docker run --env-file .env` or compose's `env_file:`. Keep `.env`
-gitignored. Alternatively, set the variables inline in the `.mcp.json` `env`
-block or export them in your shell.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ Each profile takes the same settings as the flat vars, prefixed
 
 - `CCU_<NAME>_PROTECTED=true` — write tools refuse unless called with
   `confirm: true`, which unlocks writes to that target for the rest of the session.
+  Exception: `run_script` and `delete_system_variable` require `confirm: true` on
+  **every** call — they never ride on the session unlock (scripts bypass all
+  typed-tool guards; deletion is unrecoverable), and confirming them does not
+  unlock the session for other writes.
 - `CCU_<NAME>_READONLY=true` — write tools are refused outright.
 
 With `CCU_PROFILES` unset, the flat `CCU_*` vars are used as a single `default`
@@ -273,7 +277,7 @@ without switching.
 
 ## Tools
 
-25 tools organized by what you'd actually want to do:
+28 tools organized by what you'd actually want to do:
 
 **Find things** — `list_devices`, `list_rooms`, `list_functions`, `list_interfaces`, `list_programs`, `list_system_variables`, `list_links`, `describe_device_type`
 
@@ -282,6 +286,8 @@ without switching.
 **Change things** — `set_value`, `put_paramset`, `set_system_variable`, `create_system_variable`, `delete_system_variable`, `assign_channel`, `unassign_channel`, `execute_program`
 
 **Check health** — `get_service_messages`, `acknowledge_service_messages`, `get_rssi`, `get_system_info`
+
+**Switch targets** — `list_ccu_targets`, `get_connection_info`, `use_ccu` (multi-CCU profiles; see above)
 
 **Other** — `help` (context-aware), `run_script` (raw HomeMatic Script for bulk operations, renaming devices/channels, querying room membership, or anything not covered by the other tools)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,18 @@ services:
       # - CCU_HTTPS=false
       # - CCU_USER=Admin
 
+      # === Multiple CCU targets (optional; see README "Multiple CCU targets") ===
+      # Named profiles instead of the flat CCU_* vars above. Per profile:
+      # CCU_<NAME>_HOST/USER/PASSWORD/PORT/HTTPS/..., plus policy flags.
+      # - CCU_PROFILES=prod,dev
+      # - CCU_DEFAULT_PROFILE=prod
+      # - CCU_PROD_HOST=192.168.x.x
+      # - CCU_PROD_PASSWORD=secret
+      # - CCU_PROD_PROTECTED=true   # writes need confirm:true (run_script/delete_system_variable: every call)
+      # - CCU_DEV_HOST=192.168.x.y
+      # - CCU_DEV_PASSWORD=secret2
+      # - CCU_DEV_READONLY=false
+
       # === MCP transport (optional) ===
       # - MCP_TRANSPORT=http
       # - MCP_PORT=3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/gen-build-info.mjs",
     "start": "node dist/index.js",
     "start:stdio": "node dist/index.js --stdio",
     "start:http": "node dist/index.js --http",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/scripts/gen-build-info.mjs
+++ b/scripts/gen-build-info.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Stamp the current git state into dist/build-info.json at build time so a
+// running server can report exactly which checkout it was built from
+// (get_system_info exposes it). Best-effort: outside a git checkout (e.g. an
+// npm tarball or `git archive`), every git field is null — the build still
+// succeeds. Runs after `tsc` (see package.json "build"), so dist/ exists.
+import { execFileSync } from "node:child_process";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const git = (args) => {
+  try {
+    return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch {
+    return null; // not a git checkout, or git unavailable
+  }
+};
+
+const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]);
+const status = git(["status", "--porcelain"]);
+
+const buildInfo = {
+  // branch is "HEAD" when detached (e.g. a CI checkout of a tag) — report null
+  branch: branch === "HEAD" ? null : branch,
+  commit: git(["rev-parse", "--short", "HEAD"]),
+  // exact-match returns the tag only when HEAD is *on* a tag, else null
+  tag: git(["describe", "--tags", "--exact-match"]),
+  // human-readable: <tag>-<n>-g<sha>[-dirty], or just <sha> with no tags
+  describe: git(["describe", "--tags", "--dirty", "--always"]),
+  // null when not a git checkout; true if the working tree has uncommitted changes
+  dirty: status === null ? null : status.length > 0,
+  builtAt: new Date().toISOString(),
+};
+
+const distDir = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+mkdirSync(distDir, { recursive: true });
+writeFileSync(join(distDir, "build-info.json"), JSON.stringify(buildInfo, null, 2) + "\n");
+console.log("build-info:", JSON.stringify(buildInfo));

--- a/scripts/gen-build-info.mjs
+++ b/scripts/gen-build-info.mjs
@@ -18,7 +18,10 @@ const git = (args) => {
 };
 
 const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]);
-const status = git(["status", "--porcelain"]);
+// Tracked modifications only (--untracked-files=no), matching `git describe --dirty`
+// semantics: stray untracked files (drafts, build output) don't change which
+// committed source the build came from, so they must not flip the dirty flag.
+const status = git(["status", "--porcelain", "--untracked-files=no"]);
 
 const buildInfo = {
   // branch is "HEAD" when detached (e.g. a CI checkout of a tag) — report null
@@ -28,7 +31,7 @@ const buildInfo = {
   tag: git(["describe", "--tags", "--exact-match"]),
   // human-readable: <tag>-<n>-g<sha>[-dirty], or just <sha> with no tags
   describe: git(["describe", "--tags", "--dirty", "--always"]),
-  // null when not a git checkout; true if the working tree has uncommitted changes
+  // null when not a git checkout; true if tracked files have uncommitted changes
   dirty: status === null ? null : status.length > 0,
   builtAt: new Date().toISOString(),
 };

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.5.0",
+  "version": "1.6.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -68,6 +68,16 @@
         {
           "name": "MCP_ALLOWED_HOSTS",
           "description": "Extra Host header values accepted by DNS-rebinding protection (comma-separated host:port); add your hostname when behind a proxy or container DNS name",
+          "format": "string"
+        },
+        {
+          "name": "CCU_PROFILES",
+          "description": "Comma-separated names of multiple CCU targets (e.g. 'prod,dev'). Each profile takes the flat CCU_* settings prefixed CCU_<NAME>_ (CCU_PROD_HOST, ...), plus policy flags CCU_<NAME>_PROTECTED (writes need confirm:true) and CCU_<NAME>_READONLY. Unset = single default profile from the flat CCU_* vars",
+          "format": "string"
+        },
+        {
+          "name": "CCU_DEFAULT_PROFILE",
+          "description": "Which profile from CCU_PROFILES is active at startup (default: the first listed)",
           "format": "string"
         }
       ]

--- a/src/cache/device-type-cache.ts
+++ b/src/cache/device-type-cache.ts
@@ -6,7 +6,7 @@ import type { Logger } from "../logger.js";
 import type { CachedDeviceType, CachedParamDescription, DeviceTypeCacheFile } from "./types.js";
 import { CACHE_VERSION } from "./types.js";
 
-const CACHE_FILENAME = "device-type-cache.json";
+const DEFAULT_CACHE_FILENAME = "device-type-cache.json";
 
 // Device types warmed in parallel; per-request pacing stays with the rate limiter
 const WARM_CONCURRENCY = 3;
@@ -37,13 +37,17 @@ export class DeviceTypeCache {
   private readonly cacheDir: string;
   private readonly ttl: number;
   private readonly logger: Logger;
+  private readonly fileName: string;
   private warming = false;
   private inflightQueries = new Map<string, Promise<CachedDeviceType | undefined>>();
 
-  constructor(cacheDir: string, ttl: number, logger: Logger) {
+  constructor(cacheDir: string, ttl: number, logger: Logger, fileName?: string) {
     this.cacheDir = cacheDir;
     this.ttl = ttl;
     this.logger = logger;
+    // Per-target cache file so different CCUs don't pollute each other's schema
+    // cache (default keeps the historical single-file name for back-compat).
+    this.fileName = fileName || DEFAULT_CACHE_FILENAME;
   }
 
   get(deviceType: string): CachedDeviceType | undefined {
@@ -64,7 +68,7 @@ export class DeviceTypeCache {
 
   /** Load cache from disk. Returns true if valid cache was loaded. */
   async loadFromDisk(): Promise<boolean> {
-    const filePath = join(this.cacheDir, CACHE_FILENAME);
+    const filePath = join(this.cacheDir, this.fileName);
     try {
       const data = await readFile(filePath, "utf-8");
       const parsed = JSON.parse(data) as DeviceTypeCacheFile;
@@ -89,7 +93,7 @@ export class DeviceTypeCache {
 
   /** Atomic write: serialize → tmp file → rename */
   async saveToDisk(): Promise<void> {
-    const filePath = join(this.cacheDir, CACHE_FILENAME);
+    const filePath = join(this.cacheDir, this.fileName);
     const tmpPath = filePath + ".tmp";
 
     const data: DeviceTypeCacheFile = {

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -6,7 +6,7 @@ import { CcuError } from "../middleware/error-mapper.js";
 import type { Logger } from "../logger.js";
 
 const SESSION_RENEW_INTERVAL = 60_000; // Renew every 60s
-const SESSION_FILE = "session.json";
+const DEFAULT_SESSION_FILE = "session.json";
 const LOGIN_RETRY_DELAY = 3_000;
 const LOGIN_MAX_RETRIES = 3;
 
@@ -15,15 +15,19 @@ export class SessionManager {
   private readonly config: CcuConfig;
   private readonly logger: Logger;
   private readonly cacheDir: string;
+  private readonly sessionFile: string;
   private sessionId: string | null = null;
   private renewTimer: ReturnType<typeof setInterval> | null = null;
   private loginPromise: Promise<void> | null = null;
 
-  constructor(config: CcuConfig, logger: Logger, cacheDir?: string) {
+  constructor(config: CcuConfig, logger: Logger, cacheDir?: string, sessionFile?: string) {
     this.config = config;
     this.client = new CcuClient(config, logger);
     this.logger = logger;
     this.cacheDir = cacheDir || "/tmp";
+    // Per-target session file so multiple SessionManagers don't fight over one
+    // session.json (each target's session is keyed by host/port/user too).
+    this.sessionFile = sessionFile || DEFAULT_SESSION_FILE;
   }
 
   /**
@@ -127,7 +131,7 @@ export class SessionManager {
 
   private async tryRestoreSession(): Promise<boolean> {
     try {
-      const filePath = join(this.cacheDir, SESSION_FILE);
+      const filePath = join(this.cacheDir, this.sessionFile);
       const data = JSON.parse(await readFile(filePath, "utf-8"));
 
       if (data.sessionId && data.host === this.config.host && data.port === this.config.port
@@ -153,7 +157,7 @@ export class SessionManager {
     if (!this.sessionId) return;
     try {
       await mkdir(this.cacheDir, { recursive: true });
-      const filePath = join(this.cacheDir, SESSION_FILE);
+      const filePath = join(this.cacheDir, this.sessionFile);
       const tmpPath = filePath + ".tmp";
       const data = JSON.stringify({
         sessionId: this.sessionId,
@@ -173,7 +177,7 @@ export class SessionManager {
   private async clearPersistedSession(): Promise<void> {
     try {
       const { unlink } = await import("node:fs/promises");
-      await unlink(join(this.cacheDir, SESSION_FILE));
+      await unlink(join(this.cacheDir, this.sessionFile));
     } catch {
       // Ignore
     }

--- a/src/ccu/target-registry.ts
+++ b/src/ccu/target-registry.ts
@@ -1,0 +1,172 @@
+import type { AppConfig } from "../config.js";
+import type { CcuProfile } from "./types.js";
+import type { Logger } from "../logger.js";
+import type { RateLimiter } from "../middleware/rate-limiter.js";
+import { SessionManager } from "./session.js";
+import { Resolver } from "../middleware/resolver.js";
+import { DeviceTypeCache } from "../cache/device-type-cache.js";
+import { CcuError } from "../middleware/error-mapper.js";
+
+/** Short-lived sysvar name→type cache (issue #9), now scoped per target. */
+export interface SysVarTypeCacheHolder {
+  entry: { ts: number; types: Map<string, string> } | null;
+}
+
+/**
+ * One connected CCU target: its profile (connection + policy), its own session,
+ * resolver, device-type cache, and sysvar-type cache. Caches are per-target so
+ * a dev and prod CCU never pollute each other.
+ */
+export interface Target {
+  profile: CcuProfile;
+  session: SessionManager;
+  resolver: Resolver;
+  deviceTypeCache: DeviceTypeCache;
+  sysVarTypeCache: SysVarTypeCacheHolder;
+  /**
+   * Writes to a `protected` target are unlocked for the rest of the session
+   * once the caller confirms once (the "ask once per session" model). Always
+   * false → no effect for non-protected targets.
+   */
+  unlocked: boolean;
+}
+
+// Filesystem-safe per-target suffix for cache/session filenames.
+function fileSuffix(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Holds every configured CCU target and which one is active. Tools reach the
+ * active target via ServerDeps getters; an optional per-call `target` arg routes
+ * a single call elsewhere via resolveTarget().
+ */
+export class TargetRegistry {
+  private readonly targets = new Map<string, Target>(); // keyed by lowercased name
+  private readonly order: string[] = []; // actual names, config order
+  private activeKey: string;
+
+  constructor(config: AppConfig, logger: Logger, cacheDir: string) {
+    for (const profile of config.profiles) {
+      // The back-compat single "default" profile keeps the historical filenames
+      // so existing on-disk session/cache still load; named profiles get a suffix.
+      const suffix = profile.name === "default" ? "" : `.${fileSuffix(profile.name)}`;
+      const target: Target = {
+        profile,
+        session: new SessionManager(profile.ccu, logger, cacheDir, `session${suffix}.json`),
+        resolver: new Resolver(),
+        deviceTypeCache: new DeviceTypeCache(cacheDir, config.cache.ttl, logger, `device-type-cache${suffix}.json`),
+        sysVarTypeCache: { entry: null },
+        unlocked: false,
+      };
+      this.targets.set(profile.name.toLowerCase(), target);
+      this.order.push(profile.name);
+    }
+    this.activeKey = config.defaultProfile.toLowerCase();
+  }
+
+  get active(): Target {
+    return this.targets.get(this.activeKey)!;
+  }
+
+  getByName(name: string): Target | undefined {
+    return this.targets.get(name.toLowerCase());
+  }
+
+  has(name: string): boolean {
+    return this.targets.has(name.toLowerCase());
+  }
+
+  /** All targets in configured order. */
+  list(): Target[] {
+    return this.order.map((n) => this.targets.get(n.toLowerCase())!);
+  }
+
+  /** Switch the active target; throws NOT_FOUND on an unknown name. */
+  use(name: string): Target {
+    const t = this.getByName(name);
+    if (!t) {
+      throw new CcuError({
+        error: "NOT_FOUND",
+        code: 0,
+        message: `Unknown CCU target: ${name}`,
+        hint: `Configured targets: ${this.order.join(", ")}. Call list_ccu_targets.`,
+      });
+    }
+    this.activeKey = t.profile.name.toLowerCase();
+    return t;
+  }
+
+  /** Log in the active target (other targets log in lazily on first use). */
+  async loginActive(): Promise<void> {
+    await this.active.session.login();
+  }
+
+  /** Load each target's device-type cache from disk. */
+  async loadCaches(): Promise<void> {
+    await Promise.all(this.list().map((t) => t.deviceTypeCache.loadFromDisk()));
+  }
+
+  /** Warm only the active target's cache (others warm lazily on first query). */
+  warmActive(rateLimiter: RateLimiter): Promise<void> {
+    const t = this.active;
+    return t.deviceTypeCache.warm(t.session, rateLimiter);
+  }
+
+  async saveCaches(): Promise<void> {
+    await Promise.allSettled(this.list().map((t) => t.deviceTypeCache.saveToDisk()));
+  }
+
+  async logoutAll(): Promise<void> {
+    await Promise.allSettled(this.list().map((t) => t.session.logout()));
+  }
+
+  destroyAll(): void {
+    for (const t of this.list()) t.session.destroy();
+  }
+}
+
+/**
+ * Resolve the target for a tool call: the optional per-call `target` name, or
+ * the active target when omitted. Throws NOT_FOUND for an unknown name.
+ */
+export function resolveTarget(targets: TargetRegistry, name?: string): Target {
+  if (!name) return targets.active;
+  const t = targets.getByName(name);
+  if (!t) {
+    throw new CcuError({
+      error: "NOT_FOUND",
+      code: 0,
+      message: `Unknown CCU target: ${name}`,
+      hint: "Call list_ccu_targets to see configured targets.",
+    });
+  }
+  return t;
+}
+
+/**
+ * Gate a write against a target's policy. `readonly` targets always refuse;
+ * `protected` targets refuse until the caller passes confirm:true once, which
+ * unlocks writes to that target for the rest of the session.
+ */
+export function assertWritable(target: Target, confirm: boolean | undefined): void {
+  if (target.profile.readonly) {
+    throw new CcuError({
+      error: "INVALID_INPUT",
+      code: 0,
+      message: `CCU target "${target.profile.name}" is read-only; writes are refused.`,
+      hint: "Switch to a writable target with use_ccu, or clear its readonly flag in config.",
+    });
+  }
+  if (target.profile.protected && !target.unlocked) {
+    if (confirm !== true) {
+      throw new CcuError({
+        error: "INVALID_INPUT",
+        code: 0,
+        message: `CCU target "${target.profile.name}" is protected. Re-issue with confirm:true to authorize writes for this session.`,
+        hint: "Safety gate on a production CCU. Pass confirm:true to proceed; later writes this session won't need it.",
+      });
+    }
+    target.unlocked = true;
+  }
+}

--- a/src/ccu/target-registry.ts
+++ b/src/ccu/target-registry.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { AppConfig } from "../config.js";
 import type { CcuProfile } from "./types.js";
 import type { Logger } from "../logger.js";
@@ -31,9 +32,19 @@ export interface Target {
   unlocked: boolean;
 }
 
-// Filesystem-safe per-target suffix for cache/session filenames.
+// Filesystem-safe, collision-free per-target suffix for cache/session filenames.
+// The readable slug alone can collide for names that differ only in punctuation
+// ("my-ccu" vs "my.ccu" both slugify to "my-ccu"), which would make two distinct
+// targets share one on-disk session/device-type-cache file. Append a short hash
+// of the canonical (lowercased) name so distinct names always map to distinct
+// files, keeping the slug only for human readability. (The session file is also
+// host/port/user-guarded on restore, but the device-type cache file is not, so
+// the filename must carry the uniqueness.)
 function fileSuffix(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  const canonical = name.toLowerCase();
+  const slug = canonical.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  const hash = createHash("sha256").update(canonical).digest("hex").slice(0, 8);
+  return slug ? `${slug}-${hash}` : hash;
 }
 
 /**

--- a/src/ccu/target-registry.ts
+++ b/src/ccu/target-registry.ts
@@ -159,8 +159,19 @@ export function resolveTarget(targets: TargetRegistry, name?: string): Target {
  * Gate a write against a target's policy. `readonly` targets always refuse;
  * `protected` targets refuse until the caller passes confirm:true once, which
  * unlocks writes to that target for the rest of the session.
+ *
+ * `alwaysConfirm` marks a high-blast-radius tool (run_script,
+ * delete_system_variable): the session unlock never applies — every call
+ * needs its own confirm:true, and a confirmed call does NOT unlock the
+ * session for other writes (issue #72). run_script bypasses all value/type
+ * guards the typed tools enforce, so it must not ride on a confirmation that
+ * was given for a harmless set_value.
  */
-export function assertWritable(target: Target, confirm: boolean | undefined): void {
+export function assertWritable(
+  target: Target,
+  confirm: boolean | undefined,
+  opts?: { alwaysConfirm?: boolean },
+): void {
   if (target.profile.readonly) {
     throw new CcuError({
       error: "INVALID_INPUT",
@@ -169,13 +180,25 @@ export function assertWritable(target: Target, confirm: boolean | undefined): vo
       hint: "Switch to a writable target with use_ccu, or clear its readonly flag in config.",
     });
   }
-  if (target.profile.protected && !target.unlocked) {
+  if (!target.profile.protected) return;
+  if (opts?.alwaysConfirm) {
+    if (confirm !== true) {
+      throw new CcuError({
+        error: "INVALID_INPUT",
+        code: 0,
+        message: `CCU target "${target.profile.name}" is protected. This tool requires confirm:true on EVERY call — the session unlock does not apply to it.`,
+        hint: "High-impact operation on a protected CCU. Pass confirm:true with this call to proceed.",
+      });
+    }
+    return; // per-call authorization only — never unlocks the session
+  }
+  if (!target.unlocked) {
     if (confirm !== true) {
       throw new CcuError({
         error: "INVALID_INPUT",
         code: 0,
         message: `CCU target "${target.profile.name}" is protected. Re-issue with confirm:true to authorize writes for this session.`,
-        hint: "Safety gate on a production CCU. Pass confirm:true to proceed; later writes this session won't need it.",
+        hint: "Safety gate on a production CCU. Pass confirm:true to proceed; later writes this session won't need it (except run_script and delete_system_variable, which confirm every call).",
       });
     }
     target.unlocked = true;

--- a/src/ccu/types.ts
+++ b/src/ccu/types.ts
@@ -143,6 +143,26 @@ export interface ParamDescription {
 }
 
 // Config
+/**
+ * A named CCU target (e.g. `prod`, `dev`). Profiles let one server reach
+ * several CCUs; the connection details live in `ccu`, and the two policy flags
+ * gate writes. Built from env in config.ts.
+ */
+export interface CcuProfile {
+  /** Profile name as used by use_ccu / the optional per-call `target` arg. */
+  name: string;
+  /**
+   * Production seatbelt: when true, write tools refuse unless the caller passes
+   * `confirm:true` (which unlocks writes to this target for the rest of the
+   * session). Declared explicitly per profile — never inferred from the name.
+   */
+  protected: boolean;
+  /** When true, write tools are refused outright (even with confirm). */
+  readonly: boolean;
+  /** Connection details for this target. */
+  ccu: CcuConfig;
+}
+
 export interface CcuConfig {
   host: string;
   port: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,17 @@
 import { readFileSync } from "node:fs";
-import type { CcuConfig } from "./ccu/types.js";
+import type { CcuConfig, CcuProfile } from "./ccu/types.js";
 
 export interface AppConfig {
+  /**
+   * Connection details for the DEFAULT target. Kept as an alias of
+   * `profiles[defaultProfile].ccu` for back-compat with code/tests that read
+   * `config.ccu.*` (e.g. `scriptTimeout`). Prefer `profiles` for new code.
+   */
   ccu: CcuConfig;
+  /** All configured CCU targets (always ≥1; a flat config yields one `default`). */
+  profiles: CcuProfile[];
+  /** Name of the target active at startup. */
+  defaultProfile: string;
   mcp: {
     transport: "http" | "stdio";
     port: number;
@@ -76,16 +85,6 @@ export interface AppConfig {
 }
 
 export function loadConfig(): AppConfig {
-  const host = process.env.CCU_HOST;
-  if (!host) {
-    throw new Error("CCU_HOST environment variable is required");
-  }
-
-  const password = process.env.CCU_PASSWORD;
-  if (!password) {
-    throw new Error("CCU_PASSWORD environment variable is required");
-  }
-
   // CLI flags override env vars for transport
   const args = process.argv.slice(2);
   let transport: "http" | "stdio" = (process.env.MCP_TRANSPORT as "http" | "stdio") || "http";
@@ -145,36 +144,102 @@ export function loadConfig(): AppConfig {
   }
 
   // CCU TLS verification (issue #51). A CCU ships a self-signed cert, so verify
-  // it either by pinning the leaf fingerprint (CCU_TLS_FINGERPRINT) or by
-  // trusting a CA/self-signed PEM (CCU_CA_CERT). Fingerprint takes precedence.
-  const tlsFingerprint = process.env.CCU_TLS_FINGERPRINT?.trim() || undefined;
-  const caCertPath = process.env.CCU_CA_CERT?.trim() || undefined;
-  let caCert: string | undefined;
-  if (caCertPath) {
+  // it either by pinning the leaf fingerprint or by trusting a CA/self-signed
+  // PEM. Read the PEM here; the env var name is only for the error message
+  // (don't interpolate the env-derived PATH into logs — js/clear-text-logging).
+  const readCaCert = (envName: string, path: string | undefined): string | undefined => {
+    if (!path) return undefined;
     try {
-      caCert = readFileSync(caCertPath, "utf-8");
+      return readFileSync(path, "utf-8");
     } catch (err) {
-      // Don't interpolate the env-derived path here: a fatal config error is
-      // logged at the top level, and echoing raw env values into logs is a
-      // leak vector (js/clear-text-logging). The fs error already names the
-      // path for the operator.
-      throw new Error(`CCU_CA_CERT could not be read: ${(err as Error).message}`);
+      throw new Error(`${envName} could not be read: ${(err as Error).message}`);
     }
+  };
+
+  // Build one named profile from CCU_<PREFIX>_* env vars (issue #69). These are
+  // read DYNAMICALLY (template-literal keys), so the env-example-sync test's
+  // literal scan doesn't see them — intentional; they're documented as comments
+  // in .env.example. Password may be empty (OpenCCU dev boxes default to it).
+  const buildProfile = (name: string): CcuProfile => {
+    const p = name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+    const get = (suffix: string): string | undefined => process.env[`CCU_${p}_${suffix}`]?.trim() || undefined;
+    const host = get("HOST");
+    if (!host) throw new Error(`profile "${name}" is missing CCU_${p}_HOST`);
+    const https = process.env[`CCU_${p}_HTTPS`] === "true";
+    return {
+      name,
+      protected: process.env[`CCU_${p}_PROTECTED`] === "true",
+      readonly: process.env[`CCU_${p}_READONLY`] === "true",
+      ccu: {
+        host,
+        port: parseIntEnv(`CCU_${p}_PORT`, https ? "443" : "80"),
+        https,
+        tlsVerify: process.env[`CCU_${p}_TLS_VERIFY`] === "true",
+        tlsFingerprint: get("TLS_FINGERPRINT"),
+        caCert: readCaCert(`CCU_${p}_CA_CERT`, get("CA_CERT")),
+        user: get("USER") || "Admin",
+        password: process.env[`CCU_${p}_PASSWORD`] ?? "",
+        timeout: parseIntEnv(`CCU_${p}_TIMEOUT`, "10000"),
+        scriptTimeout: parseIntEnv(`CCU_${p}_SCRIPT_TIMEOUT`, "30000"),
+      },
+    };
+  };
+
+  const profilesEnv = process.env.CCU_PROFILES?.trim();
+  let profiles: CcuProfile[];
+  let defaultProfile: string;
+
+  if (!profilesEnv) {
+    // Back-compat: no CCU_PROFILES ⇒ one "default" profile from the flat
+    // CCU_HOST/CCU_PASSWORD/... vars, with the exact validation as before.
+    const host = process.env.CCU_HOST;
+    if (!host) throw new Error("CCU_HOST environment variable is required");
+    const password = process.env.CCU_PASSWORD;
+    if (!password) throw new Error("CCU_PASSWORD environment variable is required");
+    profiles = [{
+      name: "default",
+      protected: false,
+      readonly: false,
+      ccu: {
+        host,
+        port: parseIntEnv("CCU_PORT", process.env.CCU_HTTPS === "true" ? "443" : "80"),
+        https: process.env.CCU_HTTPS === "true",
+        tlsVerify: process.env.CCU_TLS_VERIFY === "true",
+        tlsFingerprint: process.env.CCU_TLS_FINGERPRINT?.trim() || undefined,
+        caCert: readCaCert("CCU_CA_CERT", process.env.CCU_CA_CERT?.trim() || undefined),
+        user: process.env.CCU_USER || "Admin",
+        password,
+        timeout: parseIntEnv("CCU_TIMEOUT", "10000"),
+        scriptTimeout: parseIntEnv("CCU_SCRIPT_TIMEOUT", "30000"),
+      },
+    }];
+    defaultProfile = "default";
+  } else {
+    const names = profilesEnv.split(",").map((s) => s.trim()).filter(Boolean);
+    if (names.length === 0) throw new Error("CCU_PROFILES is set but lists no profile names");
+    const seen = new Set<string>();
+    for (const n of names) {
+      const key = n.toLowerCase();
+      if (seen.has(key)) throw new Error(`CCU_PROFILES lists "${n}" more than once`);
+      seen.add(key);
+    }
+    profiles = names.map(buildProfile);
+    const requested = process.env.CCU_DEFAULT_PROFILE?.trim();
+    const match = requested
+      ? profiles.find((p) => p.name.toLowerCase() === requested.toLowerCase())
+      : profiles[0];
+    if (!match) {
+      throw new Error(`CCU_DEFAULT_PROFILE="${requested}" is not one of CCU_PROFILES (${names.join(", ")})`);
+    }
+    defaultProfile = match.name;
   }
 
+  const defaultCcu = profiles.find((p) => p.name === defaultProfile)!.ccu;
+
   return {
-    ccu: {
-      host,
-      port: parseIntEnv("CCU_PORT", process.env.CCU_HTTPS === "true" ? "443" : "80"),
-      https: process.env.CCU_HTTPS === "true",
-      tlsVerify: process.env.CCU_TLS_VERIFY === "true",
-      tlsFingerprint,
-      caCert,
-      user: process.env.CCU_USER || "Admin",
-      password,
-      timeout: parseIntEnv("CCU_TIMEOUT", "10000"),
-      scriptTimeout: parseIntEnv("CCU_SCRIPT_TIMEOUT", "30000"),
-    },
+    ccu: defaultCcu,
+    profiles,
+    defaultProfile,
     mcp: {
       transport,
       port: mcpPort,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,14 +14,12 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { loadConfig } from "./config.js";
 import { createLogger } from "./logger.js";
-import { SessionManager } from "./ccu/session.js";
 import { RateLimiter } from "./middleware/rate-limiter.js";
-import { DeviceTypeCache } from "./cache/device-type-cache.js";
-import { Resolver } from "./middleware/resolver.js";
+import { TargetRegistry } from "./ccu/target-registry.js";
 import { ResourcePoller } from "./resources/poller.js";
 import { resolveAuthTokens } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
-import { createMcpServer } from "./server.js";
+import { createMcpServer, type ServerDeps } from "./server.js";
 import { extractBearerToken, normalizeClientIp } from "./utils.js";
 
 async function main(): Promise<void> {
@@ -30,21 +28,25 @@ async function main(): Promise<void> {
 
   logger.info("starting", {
     transport: config.mcp.transport,
+    profiles: config.profiles.map((p) => p.name),
+    activeProfile: config.defaultProfile,
     ccuHost: config.ccu.host,
     ccuPort: config.ccu.port,
     https: config.ccu.https,
   });
 
-  // Initialize CCU session
-  const session = new SessionManager(config.ccu, logger, config.cache.dir);
+  // Initialize all configured CCU targets (issue #69). Each has its own session,
+  // resolver, and per-target caches; `active` is the startup default.
   const rateLimiter = new RateLimiter(config.rateLimiter.burst, config.rateLimiter.rate);
+  const targets = new TargetRegistry(config, logger, config.cache.dir);
 
   // A failed login must not kill the server: the MCP transport starts anyway
   // (tool registration needs no CCU) and the session retries lazily on the
   // first CCU call. This keeps the server alive through CCU outages and lets
-  // it start before the CCU is reachable.
+  // it start before the CCU is reachable. Only the active target logs in eagerly;
+  // others log in lazily on first use / switch.
   try {
-    await session.login();
+    await targets.loginActive();
   } catch (err) {
     logger.warn("startup_degraded", {
       error: (err as Error).message,
@@ -52,16 +54,24 @@ async function main(): Promise<void> {
     });
   }
 
-  // Initialize device type cache
-  const deviceTypeCache = new DeviceTypeCache(config.cache.dir, config.cache.ttl, logger);
-  await deviceTypeCache.loadFromDisk();
-  deviceTypeCache.warm(session, rateLimiter).catch((err) => {
+  // Load each target's device-type cache; warm only the active one in background.
+  await targets.loadCaches();
+  targets.warmActive(rateLimiter).catch((err) => {
     logger.error("cache_warm_background_error", { error: (err as Error).message });
   });
 
-  // Create resolver and shared tool dependencies
-  const resolver = new Resolver();
-  const deps = { config, session, rateLimiter, logger, deviceTypeCache, resolver };
+  // Shared tool dependencies. session/resolver/deviceTypeCache are getters that
+  // resolve to the ACTIVE target each access, so a use_ccu() switch is picked up
+  // by the next tool call without touching tools that read deps.session etc.
+  const deps: ServerDeps = {
+    config,
+    targets,
+    get session() { return targets.active.session; },
+    get resolver() { return targets.active.resolver; },
+    get deviceTypeCache() { return targets.active.deviceTypeCache; },
+    rateLimiter,
+    logger,
+  };
 
   let poller: ResourcePoller;
   let closeTransports: () => Promise<void>;
@@ -73,7 +83,7 @@ async function main(): Promise<void> {
     await mcpServer.connect(transport);
     poller = new ResourcePoller(
       () => mcpServer.server.sendResourceListChanged(),
-      session, rateLimiter, logger, config.resourcePollInterval,
+      targets.active.session, rateLimiter, logger, config.resourcePollInterval,
     );
     poller.start();
     closeTransports = () => mcpServer.close();
@@ -136,7 +146,7 @@ async function main(): Promise<void> {
 
         // Health check endpoint
         if (req.url === "/health" && req.method === "GET") {
-          handleHealthRequest(req, res, { session, deviceTypeCache });
+          handleHealthRequest(req, res, { session: targets.active.session, deviceTypeCache: targets.active.deviceTypeCache });
           return;
         }
 
@@ -253,7 +263,7 @@ async function main(): Promise<void> {
           [...sessions.values()].map((s) => s.server.server.sendResourceListChanged()),
         );
       },
-      session, rateLimiter, logger, config.resourcePollInterval,
+      targets.active.session, rateLimiter, logger, config.resourcePollInterval,
     );
     poller.start();
     closeTransports = async () => {
@@ -287,9 +297,9 @@ async function main(): Promise<void> {
       poller.stop();
       rateLimiter.destroy();
       httpServer?.close();
-      await deviceTypeCache.saveToDisk();
-      await session.logout();
-      session.destroy();
+      await targets.saveCaches();
+      await targets.logoutAll();
+      targets.destroyAll();
       await closeTransports();
     } catch (err) {
       logger.error("shutdown_error", { error: (err as Error).message });

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ async function main(): Promise<void> {
     await mcpServer.connect(transport);
     poller = new ResourcePoller(
       () => mcpServer.server.sendResourceListChanged(),
-      targets.active.session, rateLimiter, logger, config.resourcePollInterval,
+      () => targets.active.session, rateLimiter, logger, config.resourcePollInterval,
     );
     poller.start();
     closeTransports = () => mcpServer.close();
@@ -263,7 +263,7 @@ async function main(): Promise<void> {
           [...sessions.values()].map((s) => s.server.server.sendResourceListChanged()),
         );
       },
-      targets.active.session, rateLimiter, logger, config.resourcePollInterval,
+      () => targets.active.session, rateLimiter, logger, config.resourcePollInterval,
     );
     poller.start();
     closeTransports = async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,39 @@ async function main(): Promise<void> {
       },
       logger,
     );
-    const sessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
+    // Bound the session map. Each MCP session pins a McpServer + transport that
+    // is removed only on transport.onclose (explicit DELETE / clean teardown).
+    // A client that initializes then drops its connection — or reconnects in a
+    // loop — would otherwise leak one pair per session forever. Cap the count
+    // and reclaim sessions idle past the timeout. Auth runs before session
+    // creation, so only valid-token holders reach here, but a single misbehaving
+    // authenticated client must still not grow this without bound.
+    const MAX_SESSIONS = 256;
+    const SESSION_IDLE_MS = 30 * 60_000; // 30 min without a request → reclaim
+    const sessions = new Map<
+      string,
+      { server: McpServer; transport: StreamableHTTPServerTransport; lastSeen: number }
+    >();
+
+    // Reclaim sessions whose last request predates `cutoff`. Returns how many
+    // were evicted. Shared by the periodic sweep and the at-capacity fast path.
+    const evictIdleSessions = (cutoff: number): number => {
+      let evicted = 0;
+      for (const [sid, s] of sessions) {
+        if (s.lastSeen < cutoff) {
+          sessions.delete(sid);
+          s.server.close().catch(() => {});
+          evicted++;
+        }
+      }
+      if (evicted > 0) logger.info("mcp_sessions_idle_evicted", { evicted, sessions: sessions.size });
+      return evicted;
+    };
+
+    // Periodic idle sweep. unref'd so it never holds the process open; cleared
+    // on shutdown via closeTransports.
+    const idleSweep = setInterval(() => evictIdleSessions(Date.now() - SESSION_IDLE_MS), 60_000);
+    idleSweep.unref();
 
     const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       try {
@@ -182,15 +214,32 @@ async function main(): Promise<void> {
           return;
         }
 
-        // Existing session: route to its transport (POST, GET/SSE, DELETE)
+        // Existing session: route to its transport (POST, GET/SSE, DELETE) and
+        // mark it active so the idle sweep doesn't reclaim a session in use.
         const sessionId = req.headers["mcp-session-id"];
-        if (typeof sessionId === "string" && sessions.has(sessionId)) {
-          await sessions.get(sessionId)!.transport.handleRequest(req, res);
+        const existing = typeof sessionId === "string" ? sessions.get(sessionId) : undefined;
+        if (existing) {
+          existing.lastSeen = Date.now();
+          await existing.transport.handleRequest(req, res);
           return;
         }
 
-        // No (known) session: create a fresh transport + server pair. The
-        // transport itself rejects non-initialize requests without a session.
+        // No (known) session: a fresh transport + server pair is about to be
+        // created. Enforce the cap first — try reclaiming idle sessions, and if
+        // still full, refuse with 503 so a flood of initialize requests can't
+        // grow the map without bound.
+        if (sessions.size >= MAX_SESSIONS) {
+          evictIdleSessions(Date.now() - SESSION_IDLE_MS);
+          if (sessions.size >= MAX_SESSIONS) {
+            logger.warn("mcp_sessions_at_capacity", { sessions: sessions.size, max: MAX_SESSIONS });
+            res.writeHead(503, { "Content-Type": "application/json", "Retry-After": "60" });
+            res.end(JSON.stringify({ error: "Server at session capacity, retry later" }));
+            return;
+          }
+        }
+
+        // Create a fresh transport + server pair. The transport itself rejects
+        // non-initialize requests without a session.
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           // Defense-in-depth against DNS rebinding: reject requests whose Host
@@ -205,7 +254,7 @@ async function main(): Promise<void> {
           allowedHosts: config.mcp.allowedHosts,
           allowedOrigins: config.mcp.allowedOrigins,
           onsessioninitialized: (sid) => {
-            sessions.set(sid, { server: sessionServer, transport });
+            sessions.set(sid, { server: sessionServer, transport, lastSeen: Date.now() });
             logger.info("mcp_session_started", { sessions: sessions.size });
           },
         });
@@ -267,6 +316,7 @@ async function main(): Promise<void> {
     );
     poller.start();
     closeTransports = async () => {
+      clearInterval(idleSweep);
       await Promise.allSettled([...sessions.values()].map((s) => s.server.close()));
       sessions.clear();
     };

--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -1,15 +1,24 @@
+import { CcuError } from "./error-mapper.js";
+
 export class RateLimiter {
   private tokens: number;
   private readonly maxTokens: number;
   private readonly refillRate: number; // tokens per second
+  private readonly maxQueue: number;
   private lastRefill: number;
   private waitQueue: Array<() => void> = [];
   private refillTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(maxBurst: number = 20, refillRate: number = 10) {
+  constructor(maxBurst: number = 20, refillRate: number = 10, maxQueue: number = 1000) {
     this.maxTokens = maxBurst;
     this.tokens = maxBurst;
     this.refillRate = refillRate;
+    // Backpressure bound: callers waiting on a token queue here. Without a cap a
+    // sustained flood (faster than refillRate) grows the queue — and the pending
+    // promises behind it — without limit. The cap is deliberately generous (a
+    // backstop, not normal-load shaping); past it acquire() rejects so a caller
+    // fails fast with a clear error instead of parking on an ever-growing queue.
+    this.maxQueue = maxQueue;
     this.lastRefill = Date.now();
 
     // Start refill timer only when there are queued requests
@@ -49,6 +58,18 @@ export class RateLimiter {
     if (this.tokens >= 1) {
       this.tokens -= 1;
       return;
+    }
+
+    // At capacity — refuse rather than queue unboundedly. RATE_LIMITED is not
+    // retriable (see retry.ts), so a flooded caller fails fast instead of
+    // looping back into the same full queue.
+    if (this.waitQueue.length >= this.maxQueue) {
+      throw new CcuError({
+        error: "RATE_LIMITED",
+        code: 0,
+        message: "Too many requests queued for the CCU; the server is overloaded.",
+        hint: "Reduce concurrent calls and retry shortly. Raise CCU_RATE_LIMIT_BURST/RATE if this is sustained legitimate load.",
+      });
     }
 
     // Wait for a token to become available

--- a/src/middleware/tool-handler.ts
+++ b/src/middleware/tool-handler.ts
@@ -1,0 +1,38 @@
+import type { Logger } from "../logger.js";
+import { CcuError } from "./error-mapper.js";
+
+type LogFields = Record<string, unknown>;
+
+/**
+ * Shared wrapper for tool handler bodies (review finding I-2). Collapses the
+ * boilerplate that every tool repeated by hand — start timer, run the body,
+ * emit one `tool_call` log (ok/error) with duration, and map a thrown
+ * `CcuError` to an MCP error result (re-throwing anything else) — into one
+ * place so logging and error mapping can't drift between tools.
+ *
+ * The body receives a `log` callback to contribute extra success-log fields
+ * (e.g. `{ address }`, `{ deviceCount }`); they're merged into the `ok` line.
+ * The handler stays `async (args) => runTool(name, logger, (log) => …)`, so the
+ * SDK still infers `args` from the tool's input schema.
+ */
+export async function runTool<R>(
+  tool: string,
+  logger: Logger,
+  body: (log: (fields: LogFields) => void) => Promise<R>,
+): Promise<R | ReturnType<CcuError["toMcpError"]>> {
+  const start = Date.now();
+  let extra: LogFields = {};
+  const log = (fields: LogFields): void => {
+    extra = { ...extra, ...fields };
+  };
+
+  try {
+    const result = await body(log);
+    logger.info("tool_call", { tool, duration_ms: Date.now() - start, status: "ok", ...extra });
+    return result;
+  } catch (err) {
+    logger.info("tool_call", { tool, duration_ms: Date.now() - start, status: "error" });
+    if (err instanceof CcuError) return err.toMcpError();
+    throw err;
+  }
+}

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -49,7 +49,9 @@ export function registerPrompts(server: McpServer): void {
     messages: [{ role: "user" as const, content: { type: "text" as const, text:
       "Run a diagnostic check on the HomeMatic system:\n" +
       "1. Use get_service_messages to find active issues (low battery, unreachable devices)\n" +
-      "2. Use get_system_info to check firmware and cache status\n" +
+      "2. Use get_system_info to check firmware and cache status — it also reports the running " +
+      "server's build identification (git branch/commit/tag and build time) under `build`, " +
+      "useful for confirming which version is deployed\n" +
       "3. Summarize findings with recommended actions."
     }}],
   }));

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -49,9 +49,10 @@ export function registerPrompts(server: McpServer): void {
     messages: [{ role: "user" as const, content: { type: "text" as const, text:
       "Run a diagnostic check on the HomeMatic system:\n" +
       "1. Use get_service_messages to find active issues (low battery, unreachable devices)\n" +
-      "2. Use get_system_info to check firmware and cache status — it also reports the running " +
-      "server's build identification (git branch/commit/tag and build time) under `build`, " +
-      "useful for confirming which version is deployed\n" +
+      "2. Use get_system_info to check firmware and cache status. It also reports the active login " +
+      "user and role (ADMIN/USER) — firmware/serial/address are ADMIN-only and show \"N/A\" for a " +
+      "non-admin login — plus the running server's build identification (git branch/commit/tag and " +
+      "build time) under `build`, useful for confirming which version is deployed\n" +
       "3. Summarize findings with recommended actions."
     }}],
   }));

--- a/src/resources/poller.ts
+++ b/src/resources/poller.ts
@@ -34,7 +34,11 @@ export class ResourcePoller {
     // Called when a polled resource changed. In stdio mode this notifies the
     // single server; in HTTP mode it fans out to all active MCP sessions.
     private readonly notifyChanged: () => Promise<void>,
-    private readonly session: SessionManager,
+    // Resolves the ACTIVE target's session on every cycle (not captured once),
+    // so the poller follows a use_ccu() switch — matching how the resources
+    // themselves read deps.session per-call. Capturing the startup session here
+    // would leave the poller watching the startup CCU after a switch.
+    private readonly getSession: () => SessionManager,
     private readonly rateLimiter: RateLimiter,
     private readonly logger: Logger,
     private readonly intervalMs: number,
@@ -75,7 +79,7 @@ export class ResourcePoller {
       try {
         await this.rateLimiter.acquire();
         const data = await withRetry(
-          () => this.session.call(resource.method),
+          () => this.getSession().call(resource.method),
           resource.method,
           this.logger,
         );

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -4,11 +4,14 @@ import { withRetry } from "../middleware/retry.js";
 import { VERSION } from "../utils.js";
 
 export function registerResources(server: McpServer, deps: ServerDeps): void {
-  const { session, rateLimiter, logger, deviceTypeCache } = deps;
+  const { rateLimiter, logger } = deps;
 
+  // Read deps.session / deps.deviceTypeCache per-call (they're getters for the
+  // ACTIVE target) so resources follow a use_ccu() switch instead of capturing
+  // the startup target at registration time.
   const ccuRead = async (method: string) => {
     await rateLimiter.acquire();
-    return withRetry(() => session.call(method), method, logger);
+    return withRetry(() => deps.session.call(method), method, logger);
   };
 
   server.registerResource("devices", "homematic://devices", { description: "All devices with channels" }, async () => ({
@@ -36,7 +39,7 @@ export function registerResources(server: McpServer, deps: ServerDeps): void {
   }));
 
   server.registerResource("device-types", "homematic://device-types", { description: "Cached device type schemas" }, async () => ({
-    contents: [{ uri: "homematic://device-types", text: JSON.stringify(deviceTypeCache.getAll(), null, 2), mimeType: "application/json" }],
+    contents: [{ uri: "homematic://device-types", text: JSON.stringify(deps.deviceTypeCache.getAll(), null, 2), mimeType: "application/json" }],
   }));
 
   server.registerResource("system", "homematic://system", { description: "CCU system info" }, async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,22 +5,32 @@ import type { RateLimiter } from "./middleware/rate-limiter.js";
 import type { Logger } from "./logger.js";
 import type { DeviceTypeCache } from "./cache/device-type-cache.js";
 import type { Resolver } from "./middleware/resolver.js";
+import type { TargetRegistry } from "./ccu/target-registry.js";
 import { registerDiscoveryTools } from "./tools/discovery.js";
 import { registerReadTools } from "./tools/read.js";
 import { registerControlTools } from "./tools/control.js";
 import { registerDiagnosticsTools } from "./tools/diagnostics.js";
 import { registerMetaTools } from "./tools/meta.js";
+import { registerTargetTools } from "./tools/targets.js";
 import { registerResources } from "./resources/registry.js";
 import { registerPrompts } from "./prompts/registry.js";
 import { VERSION } from "./utils.js";
 
 export interface ServerDeps {
   config: AppConfig;
-  session: SessionManager;
+  /** All configured CCU targets and the active pointer. */
+  targets: TargetRegistry;
+  /**
+   * The ACTIVE target's session/resolver/device-type cache. These are getters
+   * (see index.ts / _helpers.ts) that resolve to `targets.active.*` on each
+   * access, so a use_ccu() switch is picked up by the next tool call without
+   * touching any tool that reads `deps.session` etc.
+   */
+  readonly session: SessionManager;
+  readonly resolver: Resolver;
+  readonly deviceTypeCache: DeviceTypeCache;
   rateLimiter: RateLimiter;
   logger: Logger;
-  deviceTypeCache: DeviceTypeCache;
-  resolver: Resolver;
 }
 
 export function createMcpServer(deps: ServerDeps): McpServer {
@@ -44,6 +54,7 @@ export function createMcpServer(deps: ServerDeps): McpServer {
   registerControlTools(server, deps);
   registerDiagnosticsTools(server, deps);
   registerMetaTools(server, deps);
+  registerTargetTools(server, deps);
   registerResources(server, deps);
   registerPrompts(server);
 

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -4,21 +4,20 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult, parseValue, escapeHmScript } from "../utils.js";
 
-// Short-lived name→type cache (#9), shared so create/delete can invalidate it
-// and a freshly created/removed variable is reflected on the next set.
-interface SysVarTypeCacheHolder {
-  entry: { ts: number; types: Map<string, string> } | null;
-}
+// Optional `confirm` field for write tools: required (true) to authorize a write
+// against a `protected` CCU target (e.g. prod). Harmless on unprotected targets.
+const confirmField = z.boolean().optional()
+  .describe("Set true to authorize this write against a protected CCU target (e.g. prod). Unlocks writes to that target for the rest of the session.");
 
 export function registerControlTools(server: McpServer, deps: ServerDeps): void {
-  const sysVarTypeCache: SysVarTypeCacheHolder = { entry: null };
   registerSetValue(server, deps);
   registerPutParamset(server, deps);
-  registerSetSystemVariable(server, deps, sysVarTypeCache);
-  registerCreateSystemVariable(server, deps, sysVarTypeCache);
-  registerDeleteSystemVariable(server, deps, sysVarTypeCache);
+  registerSetSystemVariable(server, deps);
+  registerCreateSystemVariable(server, deps);
+  registerDeleteSystemVariable(server, deps);
   registerExecuteProgram(server, deps);
   registerAssignChannel(server, deps, "add");
   registerAssignChannel(server, deps, "remove");
@@ -39,6 +38,7 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
         value: z.union([z.string(), z.number(), z.boolean()]).describe("Value to set"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
         type: z.enum(["bool", "int", "double", "string"]).optional().describe("Value type override (auto-resolved if omitted)"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -51,6 +51,7 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
         const valueType = args.type ?? deps.resolver.resolveType(args.address, args.valueKey, deviceTypeCache) ?? inferType(args.value);
 
@@ -113,6 +114,7 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
         set: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
           .describe("Key-value pairs to write (e.g. {TEMPERATURE_WINDOW_OPEN: 5.0})"),
         interface: z.string().optional().describe("Interface name override"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -125,6 +127,7 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
         // CCU expects set as array of {name, type, value} objects
@@ -160,10 +163,10 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
 
 const SYSVAR_TYPE_TTL_MS = 30_000;
 
-function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCacheHolder: SysVarTypeCacheHolder): void {
-  // Short-lived name→type cache (shared via the holder): avoids fetching the
-  // full sysvar list on every write. create/delete clear it so new/removed
-  // variables are reflected immediately.
+function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
+  // Short-lived name→type cache (per active target): avoids fetching the full
+  // sysvar list on every write. create/delete clear it so new/removed variables
+  // are reflected immediately.
 
   server.registerTool(
     "set_system_variable",
@@ -174,6 +177,7 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCach
       inputSchema: {
         name: z.string().describe("Variable name (exact match)"),
         value: z.union([z.string(), z.number(), z.boolean()]).describe("Value to set"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -183,9 +187,11 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCach
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
+      const typeCacheHolder = deps.targets.active.sysVarTypeCache;
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         // Look up variable type (cached) to choose correct setter
         let method: string;
         let sysVarType: string | undefined;
@@ -219,7 +225,7 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCach
             await withRetry(
               () => session.call("ReGa.runScript", {
                 script: `var sv = dom.GetObject("${escapedName}"); if (sv) { sv.State("${escapedValue}"); }`,
-              }, deps.config.ccu.scriptTimeout),
+              }, deps.targets.active.profile.ccu.scriptTimeout),
               "ReGa.runScript",
               logger,
             );
@@ -262,7 +268,7 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps, typeCach
   );
 }
 
-function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeCacheHolder: SysVarTypeCacheHolder): void {
+function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void {
   server.registerTool(
     "create_system_variable",
     {
@@ -279,6 +285,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
         min: z.number().optional().describe("Minimum value (float only)"),
         max: z.number().optional().describe("Maximum value (float only)"),
         values: z.array(z.string()).optional().describe("Enum value labels in order (enum only, e.g. ['off','low','high'])"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -287,9 +294,11 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
+      const typeCacheHolder = deps.targets.active.sysVarTypeCache;
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         if (args.type === "enum" && (!args.values || args.values.length === 0)) {
           throw new CcuError({
             error: "INVALID_INPUT",
@@ -383,7 +392,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
 
         await rateLimiter.acquire();
         const createResult = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
@@ -421,7 +430,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps, typeC
   );
 }
 
-function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps, typeCacheHolder: SysVarTypeCacheHolder): void {
+function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void {
   server.registerTool(
     "delete_system_variable",
     {
@@ -429,6 +438,7 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps, typeC
       description: "Delete a system variable by name. Use list_system_variables to see existing names.",
       inputSchema: {
         name: z.string().describe("Variable name (exact match)"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -438,9 +448,11 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps, typeC
     },
     async (args) => {
       const { session, rateLimiter, logger } = deps;
+      const typeCacheHolder = deps.targets.active.sysVarTypeCache;
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         // Validate existence so an unknown name is a clean NOT_FOUND rather than
         // a silent no-op (deleteSysVarByName doesn't report a missing name).
         await rateLimiter.acquire();
@@ -494,6 +506,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
         channel: z.string().describe("Channel address (e.g. '000A1BE9A71F15:1')"),
         room: z.string().optional().describe("Room name (exact match)"),
         function: z.string().optional().describe("Function group name (exact match)"),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -506,6 +519,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         if (!args.room && !args.function) {
           throw new CcuError({
             error: "INVALID_INPUT",
@@ -613,6 +627,7 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
         "Use list_programs to find program IDs.",
       inputSchema: {
         id: z.string().describe("Program ID. Get from list_programs."),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -624,6 +639,7 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         // The CCU's Program.execute reports success even for nonexistent IDs
         // (issue #18) — validate against the program list first.
         await rateLimiter.acquire();

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -401,10 +401,11 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
     "delete_system_variable",
     {
       title: "Delete System Variable",
-      description: "Delete a system variable by name. Use list_system_variables to see existing names.",
+      description: "Delete a system variable by name. Use list_system_variables to see existing names. " +
+        "On a protected target, EVERY call needs confirm:true — the session unlock from other write tools does not apply.",
       inputSchema: {
         name: z.string().describe("Variable name (exact match)"),
-        confirm: confirmField,
+        confirm: z.boolean().optional().describe("Required true on EVERY call against a protected CCU target (e.g. prod) — deletion never rides on the session unlock."),
       },
       annotations: {
         destructiveHint: true,
@@ -415,7 +416,8 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
     async (args) => runTool("delete_system_variable", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
       const typeCacheHolder = deps.targets.active.sysVarTypeCache;
-      assertWritable(deps.targets.active, args.confirm);
+      // Destructive and unrecoverable — per-call confirm (#72)
+      assertWritable(deps.targets.active, args.confirm, { alwaysConfirm: true });
       // Validate existence so an unknown name is a clean NOT_FOUND rather than
       // a silent no-op (deleteSysVarByName doesn't report a missing name).
       await rateLimiter.acquire();

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -4,6 +4,7 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult, parseValue, escapeHmScript } from "../utils.js";
 
@@ -46,57 +47,49 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("set_value", deps.logger, async (log) => {
       const { session, rateLimiter, logger, deviceTypeCache } = deps;
-      const start = Date.now();
+      assertWritable(deps.targets.active, args.confirm);
+      const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
+      const valueType = args.type ?? deps.resolver.resolveType(args.address, args.valueKey, deviceTypeCache) ?? inferType(args.value);
 
+      // Read previous value (best-effort)
+      let previousValue: unknown = null;
       try {
-        assertWritable(deps.targets.active, args.confirm);
-        const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
-        const valueType = args.type ?? deps.resolver.resolveType(args.address, args.valueKey, deviceTypeCache) ?? inferType(args.value);
-
-        // Read previous value (best-effort)
-        let previousValue: unknown = null;
-        try {
-          await rateLimiter.acquire();
-          previousValue = await session.call("Interface.getValue", {
-            interface: iface,
-            address: args.address,
-            valueKey: args.valueKey,
-          });
-        } catch {
-          // Pre-read failed — continue with write
-        }
-
-        // Write new value
         await rateLimiter.acquire();
-        await withRetry(
-          () => session.call("Interface.setValue", {
-            interface: iface,
-            address: args.address,
-            valueKey: args.valueKey,
-            type: valueType,
-            value: args.value,
-          }),
-          "Interface.setValue",
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "set_value", duration_ms: Date.now() - start, status: "ok", address: args.address });
-        return toolResult({
+        previousValue = await session.call("Interface.getValue", {
+          interface: iface,
           address: args.address,
           valueKey: args.valueKey,
-          previousValue: parseValue(previousValue),
-          newValue: args.value,
-          interface: iface,
-          type: valueType,
         });
-      } catch (err) {
-        logger.info("tool_call", { tool: "set_value", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      } catch {
+        // Pre-read failed — continue with write
       }
-    },
+
+      // Write new value
+      await rateLimiter.acquire();
+      await withRetry(
+        () => session.call("Interface.setValue", {
+          interface: iface,
+          address: args.address,
+          valueKey: args.valueKey,
+          type: valueType,
+          value: args.value,
+        }),
+        "Interface.setValue",
+        logger,
+      );
+
+      log({ address: args.address });
+      return toolResult({
+        address: args.address,
+        valueKey: args.valueKey,
+        previousValue: parseValue(previousValue),
+        newValue: args.value,
+        interface: iface,
+        type: valueType,
+      });
+    }),
   );
 }
 
@@ -122,42 +115,33 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("put_paramset", deps.logger, async () => {
       const { session, rateLimiter, logger, deviceTypeCache } = deps;
-      const start = Date.now();
+      assertWritable(deps.targets.active, args.confirm);
+      const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
+      // CCU expects set as array of {name, type, value} objects
+      const paramArray = Object.entries(args.set).map(([name, value]) => {
+        // Try to resolve type from device type cache
+        let type = deps.resolver.resolveType(args.address, name, deviceTypeCache);
+        if (!type) type = inferType(value);
+        return { name, type, value: String(value) };
+      });
 
-        // CCU expects set as array of {name, type, value} objects
-        const paramArray = Object.entries(args.set).map(([name, value]) => {
-          // Try to resolve type from device type cache
-          let type = deps.resolver.resolveType(args.address, name, deviceTypeCache);
-          if (!type) type = inferType(value);
-          return { name, type, value: String(value) };
-        });
+      await rateLimiter.acquire();
+      await withRetry(
+        () => session.call("Interface.putParamset", {
+          interface: iface,
+          address: args.address,
+          paramsetKey: args.paramsetKey,
+          set: paramArray,
+        }),
+        "Interface.putParamset",
+        logger,
+      );
 
-        await rateLimiter.acquire();
-        await withRetry(
-          () => session.call("Interface.putParamset", {
-            interface: iface,
-            address: args.address,
-            paramsetKey: args.paramsetKey,
-            set: paramArray,
-          }),
-          "Interface.putParamset",
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "put_paramset", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult({ address: args.address, paramsetKey: args.paramsetKey, written: args.set });
-      } catch (err) {
-        logger.info("tool_call", { tool: "put_paramset", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      return toolResult({ address: args.address, paramsetKey: args.paramsetKey, written: args.set });
+    }),
   );
 }
 
@@ -185,86 +169,76 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("set_system_variable", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
       const typeCacheHolder = deps.targets.active.sysVarTypeCache;
-      const start = Date.now();
+      assertWritable(deps.targets.active, args.confirm);
+      // Look up variable type (cached) to choose correct setter
+      let method: string;
+      let sysVarType: string | undefined;
+      if (typeCacheHolder.entry && Date.now() - typeCacheHolder.entry.ts < SYSVAR_TYPE_TTL_MS) {
+        sysVarType = typeCacheHolder.entry.types.get(args.name);
+      }
+      if (sysVarType === undefined) {
+        await rateLimiter.acquire();
+        const allVars = await withRetry(
+          () => session.call("SysVar.getAll"),
+          "SysVar.getAll",
+          logger,
+        ) as Array<{ name: string; type: string }>;
+        typeCacheHolder.entry = { ts: Date.now(), types: new Map(allVars.map((v) => [v.name, v.type])) };
+        sysVarType = typeCacheHolder.entry.types.get(args.name);
+      }
 
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        // Look up variable type (cached) to choose correct setter
-        let method: string;
-        let sysVarType: string | undefined;
-        if (typeCacheHolder.entry && Date.now() - typeCacheHolder.entry.ts < SYSVAR_TYPE_TTL_MS) {
-          sysVarType = typeCacheHolder.entry.types.get(args.name);
-        }
-        if (sysVarType === undefined) {
+      if (sysVarType !== undefined) {
+        const varType = sysVarType.toUpperCase();
+        if (varType.includes("BOOL") || varType.includes("ALARM")) {
+          method = "SysVar.setBool";
+        } else if (varType.includes("FLOAT") || varType.includes("NUMBER") || varType.includes("INTEGER")) {
+          method = "SysVar.setFloat";
+        } else if (varType.includes("ENUM") || varType.includes("LIST")) {
+          method = "SysVar.setFloat"; // Enums use numeric index
+        } else if (varType.includes("STRING")) {
+          // String variables: use ReGa.runScript as there's no SysVar.setString API
           await rateLimiter.acquire();
-          const allVars = await withRetry(
-            () => session.call("SysVar.getAll"),
-            "SysVar.getAll",
+          const escapedName = escapeHmScript(String(args.name));
+          const escapedValue = escapeHmScript(String(args.value));
+          await withRetry(
+            () => session.call("ReGa.runScript", {
+              script: `var sv = dom.GetObject("${escapedName}"); if (sv) { sv.State("${escapedValue}"); }`,
+            }, deps.targets.active.profile.ccu.scriptTimeout),
+            "ReGa.runScript",
             logger,
-          ) as Array<{ name: string; type: string }>;
-          typeCacheHolder.entry = { ts: Date.now(), types: new Map(allVars.map((v) => [v.name, v.type])) };
-          sysVarType = typeCacheHolder.entry.types.get(args.name);
-        }
-
-        if (sysVarType !== undefined) {
-          const varType = sysVarType.toUpperCase();
-          if (varType.includes("BOOL") || varType.includes("ALARM")) {
-            method = "SysVar.setBool";
-          } else if (varType.includes("FLOAT") || varType.includes("NUMBER") || varType.includes("INTEGER")) {
-            method = "SysVar.setFloat";
-          } else if (varType.includes("ENUM") || varType.includes("LIST")) {
-            method = "SysVar.setFloat"; // Enums use numeric index
-          } else if (varType.includes("STRING")) {
-            // String variables: use ReGa.runScript as there's no SysVar.setString API
-            await rateLimiter.acquire();
-            const escapedName = escapeHmScript(String(args.name));
-            const escapedValue = escapeHmScript(String(args.value));
-            await withRetry(
-              () => session.call("ReGa.runScript", {
-                script: `var sv = dom.GetObject("${escapedName}"); if (sv) { sv.State("${escapedValue}"); }`,
-              }, deps.targets.active.profile.ccu.scriptTimeout),
-              "ReGa.runScript",
-              logger,
-            );
-            logger.info("tool_call", { tool: "set_system_variable", duration_ms: Date.now() - start, status: "ok" });
-            return toolResult({ name: args.name, value: args.value, method: "ReGa.runScript (string)" });
-          } else {
-            logger.warn("sysvar_unknown_type", { name: args.name, type: sysVarType });
-            throw new CcuError({
-              error: "INVALID_INPUT",
-              code: 0,
-              message: `System variable "${args.name}" has unsupported type: ${sysVarType}`,
-              hint: "Supported types are bool/alarm, float/integer, enum/list, and string.",
-            });
-          }
+          );
+          return toolResult({ name: args.name, value: args.value, method: "ReGa.runScript (string)" });
         } else {
-          logger.warn("sysvar_not_found", { name: args.name });
+          logger.warn("sysvar_unknown_type", { name: args.name, type: sysVarType });
           throw new CcuError({
-            error: "NOT_FOUND",
+            error: "INVALID_INPUT",
             code: 0,
-            message: `System variable not found: ${args.name}`,
-            hint: "Call list_system_variables to see available variables (name must match exactly).",
+            message: `System variable "${args.name}" has unsupported type: ${sysVarType}`,
+            hint: "Supported types are bool/alarm, float/integer, enum/list, and string.",
           });
         }
-
-        await rateLimiter.acquire();
-        await withRetry(
-          () => session.call(method, { name: args.name, value: args.value }),
-          method,
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "set_system_variable", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult({ name: args.name, value: args.value, method });
-      } catch (err) {
-        logger.info("tool_call", { tool: "set_system_variable", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      } else {
+        logger.warn("sysvar_not_found", { name: args.name });
+        throw new CcuError({
+          error: "NOT_FOUND",
+          code: 0,
+          message: `System variable not found: ${args.name}`,
+          hint: "Call list_system_variables to see available variables (name must match exactly).",
+        });
       }
-    },
+
+      await rateLimiter.acquire();
+      await withRetry(
+        () => session.call(method, { name: args.name, value: args.value }),
+        method,
+        logger,
+      );
+
+      return toolResult({ name: args.name, value: args.value, method });
+    }),
   );
 }
 
@@ -292,141 +266,133 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("create_system_variable", deps.logger, async (log) => {
       const { session, rateLimiter, logger } = deps;
       const typeCacheHolder = deps.targets.active.sysVarTypeCache;
-      const start = Date.now();
-
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        if (args.type === "enum" && (!args.values || args.values.length === 0)) {
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: "An enum system variable requires a non-empty 'values' list.",
-            hint: "Pass values, e.g. [\"off\", \"low\", \"high\"].",
-          });
-        }
-
-        // Reject duplicates up front (creating over an existing name corrupts it).
-        await rateLimiter.acquire();
-        const existing = await withRetry(
-          () => session.call("SysVar.getAll"),
-          "SysVar.getAll",
-          logger,
-        ) as Array<{ name: string }>;
-        if (existing.some((v) => v.name === args.name)) {
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: `System variable already exists: ${args.name}`,
-            hint: "Pick a unique name, or use set_system_variable to change the existing one.",
-          });
-        }
-
-        // Create via ReGa (no SysVar.createString exists, and this keeps all four
-        // types on one code path). Ordering matters and was verified live: set
-        // ValueType + Name + type-specifics, Add(sv.ID()), and only THEN set
-        // ValueUnit/DPInfo — setting those *before* Add makes the CCU store the
-        // variable under a deduplicated " N" name (silent rename). The script
-        // returns the actual stored name so we never report a name we didn't get.
-        const name = escapeHmScript(args.name);
-        const info = escapeHmScript(args.description ?? "");
-        const unit = escapeHmScript(args.unit ?? "");
-        let typeSetup: string;
-        switch (args.type) {
-          case "bool":
-            typeSetup =
-              'sv.ValueType(ivtBinary);\n' +
-              'sv.ValueSubType(istBool);\n' +
-              `sv.Name("${name}");\n` +
-              'sv.ValueName0("false");\n' +
-              'sv.ValueName1("true");\n' +
-              'sv.State(false);';
-            break;
-          case "float": {
-            const min = Number.isFinite(args.min) ? args.min : 0;
-            const max = Number.isFinite(args.max) ? args.max : 100;
-            typeSetup =
-              'sv.ValueType(ivtFloat);\n' +
-              `sv.Name("${name}");\n` +
-              `sv.ValueMin(${min});\n` +
-              `sv.ValueMax(${max});\n` +
-              'sv.State(0);';
-            break;
-          }
-          case "enum": {
-            const list = escapeHmScript((args.values ?? []).join(";"));
-            typeSetup =
-              'sv.ValueType(ivtInteger);\n' +
-              'sv.ValueSubType(istEnum);\n' +
-              `sv.Name("${name}");\n` +
-              `sv.ValueList("${list}");\n` +
-              'sv.State(0);';
-            break;
-          }
-          case "string":
-          default:
-            typeSetup =
-              'sv.ValueType(ivtString);\n' +
-              `sv.Name("${name}");\n` +
-              'sv.State("");';
-            break;
-        }
-
-        // ValueUnit applies to float only; DPInfo (description) to all. Both go
-        // AFTER Add (see comment above).
-        const postAdd =
-          (args.type === "float" ? `sv.ValueUnit("${unit}");\n` : "") +
-          `sv.DPInfo("${info}");`;
-
-        const script =
-          `object oSysVars = dom.GetObject(ID_SYSTEM_VARIABLES);\n` +
-          `object sv = dom.CreateObject(OT_VARDP);\n` +
-          `${typeSetup}\n` +
-          `sv.Internal(false);\n` +
-          `oSysVars.Add(sv.ID());\n` +
-          `${postAdd}\n` +
-          `dom.RTUpdate(false);\n` +
-          `WriteLine(sv.Name());`;
-
-        await rateLimiter.acquire();
-        const createResult = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
-          "ReGa.runScript",
-          logger,
-        );
-
-        // The script echoes the ACTUAL stored name. The CCU silently dedups a
-        // requested name against existing similar names (e.g. "X" becomes "X 1"
-        // when an "X 2" already exists), which the exact-match pre-check above
-        // can't see. If we didn't get the name we asked for, undo it and report
-        // the collision rather than leaving a surprise variable behind.
-        const actualName = typeof createResult === "string" && createResult.trim()
-          ? createResult.trim()
-          : args.name;
-        if (actualName !== args.name) {
-          try {
-            await rateLimiter.acquire();
-            await session.call("SysVar.deleteSysVarByName", { name: actualName });
-          } catch { /* best-effort cleanup of the unintended object */ }
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: `System variable name unavailable: "${args.name}" (the CCU would store it as "${actualName}")`,
-            hint: "Pick a different name — the CCU deduplicates against existing similar names.",
-          });
-        }
-
-        typeCacheHolder.entry = null; // new variable must be visible to the next set
-        logger.info("tool_call", { tool: "create_system_variable", duration_ms: Date.now() - start, status: "ok", type: args.type });
-        return toolResult({ name: actualName, type: args.type, created: true });
-      } catch (err) {
-        logger.info("tool_call", { tool: "create_system_variable", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      assertWritable(deps.targets.active, args.confirm);
+      if (args.type === "enum" && (!args.values || args.values.length === 0)) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: "An enum system variable requires a non-empty 'values' list.",
+          hint: "Pass values, e.g. [\"off\", \"low\", \"high\"].",
+        });
       }
-    },
+
+      // Reject duplicates up front (creating over an existing name corrupts it).
+      await rateLimiter.acquire();
+      const existing = await withRetry(
+        () => session.call("SysVar.getAll"),
+        "SysVar.getAll",
+        logger,
+      ) as Array<{ name: string }>;
+      if (existing.some((v) => v.name === args.name)) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: `System variable already exists: ${args.name}`,
+          hint: "Pick a unique name, or use set_system_variable to change the existing one.",
+        });
+      }
+
+      // Create via ReGa (no SysVar.createString exists, and this keeps all four
+      // types on one code path). Ordering matters and was verified live: set
+      // ValueType + Name + type-specifics, Add(sv.ID()), and only THEN set
+      // ValueUnit/DPInfo — setting those *before* Add makes the CCU store the
+      // variable under a deduplicated " N" name (silent rename). The script
+      // returns the actual stored name so we never report a name we didn't get.
+      const name = escapeHmScript(args.name);
+      const info = escapeHmScript(args.description ?? "");
+      const unit = escapeHmScript(args.unit ?? "");
+      let typeSetup: string;
+      switch (args.type) {
+        case "bool":
+          typeSetup =
+            'sv.ValueType(ivtBinary);\n' +
+            'sv.ValueSubType(istBool);\n' +
+            `sv.Name("${name}");\n` +
+            'sv.ValueName0("false");\n' +
+            'sv.ValueName1("true");\n' +
+            'sv.State(false);';
+          break;
+        case "float": {
+          const min = Number.isFinite(args.min) ? args.min : 0;
+          const max = Number.isFinite(args.max) ? args.max : 100;
+          typeSetup =
+            'sv.ValueType(ivtFloat);\n' +
+            `sv.Name("${name}");\n` +
+            `sv.ValueMin(${min});\n` +
+            `sv.ValueMax(${max});\n` +
+            'sv.State(0);';
+          break;
+        }
+        case "enum": {
+          const list = escapeHmScript((args.values ?? []).join(";"));
+          typeSetup =
+            'sv.ValueType(ivtInteger);\n' +
+            'sv.ValueSubType(istEnum);\n' +
+            `sv.Name("${name}");\n` +
+            `sv.ValueList("${list}");\n` +
+            'sv.State(0);';
+          break;
+        }
+        case "string":
+        default:
+          typeSetup =
+            'sv.ValueType(ivtString);\n' +
+            `sv.Name("${name}");\n` +
+            'sv.State("");';
+          break;
+      }
+
+      // ValueUnit applies to float only; DPInfo (description) to all. Both go
+      // AFTER Add (see comment above).
+      const postAdd =
+        (args.type === "float" ? `sv.ValueUnit("${unit}");\n` : "") +
+        `sv.DPInfo("${info}");`;
+
+      const script =
+        `object oSysVars = dom.GetObject(ID_SYSTEM_VARIABLES);\n` +
+        `object sv = dom.CreateObject(OT_VARDP);\n` +
+        `${typeSetup}\n` +
+        `sv.Internal(false);\n` +
+        `oSysVars.Add(sv.ID());\n` +
+        `${postAdd}\n` +
+        `dom.RTUpdate(false);\n` +
+        `WriteLine(sv.Name());`;
+
+      await rateLimiter.acquire();
+      const createResult = await withRetry(
+        () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
+        "ReGa.runScript",
+        logger,
+      );
+
+      // The script echoes the ACTUAL stored name. The CCU silently dedups a
+      // requested name against existing similar names (e.g. "X" becomes "X 1"
+      // when an "X 2" already exists), which the exact-match pre-check above
+      // can't see. If we didn't get the name we asked for, undo it and report
+      // the collision rather than leaving a surprise variable behind.
+      const actualName = typeof createResult === "string" && createResult.trim()
+        ? createResult.trim()
+        : args.name;
+      if (actualName !== args.name) {
+        try {
+          await rateLimiter.acquire();
+          await session.call("SysVar.deleteSysVarByName", { name: actualName });
+        } catch { /* best-effort cleanup of the unintended object */ }
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: `System variable name unavailable: "${args.name}" (the CCU would store it as "${actualName}")`,
+          hint: "Pick a different name — the CCU deduplicates against existing similar names.",
+        });
+      }
+
+      typeCacheHolder.entry = null; // new variable must be visible to the next set
+      log({ type: args.type });
+      return toolResult({ name: actualName, type: args.type, created: true });
+    }),
   );
 }
 
@@ -446,46 +412,37 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("delete_system_variable", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
       const typeCacheHolder = deps.targets.active.sysVarTypeCache;
-      const start = Date.now();
-
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        // Validate existence so an unknown name is a clean NOT_FOUND rather than
-        // a silent no-op (deleteSysVarByName doesn't report a missing name).
-        await rateLimiter.acquire();
-        const existing = await withRetry(
-          () => session.call("SysVar.getAll"),
-          "SysVar.getAll",
-          logger,
-        ) as Array<{ name: string }>;
-        if (!existing.some((v) => v.name === args.name)) {
-          throw new CcuError({
-            error: "NOT_FOUND",
-            code: 0,
-            message: `System variable not found: ${args.name}`,
-            hint: "Call list_system_variables to see available variables (name must match exactly).",
-          });
-        }
-
-        await rateLimiter.acquire();
-        await withRetry(
-          () => session.call("SysVar.deleteSysVarByName", { name: args.name }),
-          "SysVar.deleteSysVarByName",
-          logger,
-        );
-
-        typeCacheHolder.entry = null; // removed variable must not linger in the cache
-        logger.info("tool_call", { tool: "delete_system_variable", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult({ name: args.name, deleted: true });
-      } catch (err) {
-        logger.info("tool_call", { tool: "delete_system_variable", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      assertWritable(deps.targets.active, args.confirm);
+      // Validate existence so an unknown name is a clean NOT_FOUND rather than
+      // a silent no-op (deleteSysVarByName doesn't report a missing name).
+      await rateLimiter.acquire();
+      const existing = await withRetry(
+        () => session.call("SysVar.getAll"),
+        "SysVar.getAll",
+        logger,
+      ) as Array<{ name: string }>;
+      if (!existing.some((v) => v.name === args.name)) {
+        throw new CcuError({
+          error: "NOT_FOUND",
+          code: 0,
+          message: `System variable not found: ${args.name}`,
+          hint: "Call list_system_variables to see available variables (name must match exactly).",
+        });
       }
-    },
+
+      await rateLimiter.acquire();
+      await withRetry(
+        () => session.call("SysVar.deleteSysVarByName", { name: args.name }),
+        "SysVar.deleteSysVarByName",
+        logger,
+      );
+
+      typeCacheHolder.entry = null; // removed variable must not linger in the cache
+      return toolResult({ name: args.name, deleted: true });
+    }),
   );
 }
 
@@ -514,106 +471,97 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool(toolName, deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
+      assertWritable(deps.targets.active, args.confirm);
+      if (!args.room && !args.function) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: "Provide a room and/or a function to assign the channel to.",
+          hint: "Pass room and/or function by name (see list_rooms / list_functions).",
+        });
+      }
 
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        if (!args.room && !args.function) {
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: "Provide a room and/or a function to assign the channel to.",
-            hint: "Pass room and/or function by name (see list_rooms / list_functions).",
-          });
-        }
+      // Resolve the channel address → channel ID (the membership APIs take IDs).
+      await rateLimiter.acquire();
+      const devices = await withRetry(
+        () => session.call("Device.listAllDetail"),
+        "Device.listAllDetail",
+        logger,
+      ) as CcuDevice[];
+      deps.resolver.updateDeviceList(devices);
+      let channelId: string | undefined;
+      for (const d of devices) {
+        const ch = d.channels.find((c) => c.address === args.channel);
+        if (ch) { channelId = ch.id; break; }
+      }
+      if (!channelId) {
+        throw new CcuError({
+          error: "NOT_FOUND",
+          code: 0,
+          message: `Channel not found: ${args.channel}`,
+          hint: "Call list_devices to find valid channel addresses.",
+        });
+      }
 
-        // Resolve the channel address → channel ID (the membership APIs take IDs).
+      const applied: Array<{ kind: "room" | "function"; name: string }> = [];
+
+      if (args.room) {
         await rateLimiter.acquire();
-        const devices = await withRetry(
-          () => session.call("Device.listAllDetail"),
-          "Device.listAllDetail",
+        const rooms = await withRetry(
+          () => session.call("Room.getAll"),
+          "Room.getAll",
           logger,
-        ) as CcuDevice[];
-        deps.resolver.updateDeviceList(devices);
-        let channelId: string | undefined;
-        for (const d of devices) {
-          const ch = d.channels.find((c) => c.address === args.channel);
-          if (ch) { channelId = ch.id; break; }
-        }
-        if (!channelId) {
+        ) as Array<{ id: string; name: string }>;
+        const room = rooms.find((r) => r.name === args.room);
+        if (!room) {
           throw new CcuError({
             error: "NOT_FOUND",
             code: 0,
-            message: `Channel not found: ${args.channel}`,
-            hint: "Call list_devices to find valid channel addresses.",
+            message: `Room not found: ${args.room}`,
+            hint: `Valid rooms: ${rooms.map((r) => r.name).join(", ")}`,
           });
         }
-
-        const applied: Array<{ kind: "room" | "function"; name: string }> = [];
-
-        if (args.room) {
-          await rateLimiter.acquire();
-          const rooms = await withRetry(
-            () => session.call("Room.getAll"),
-            "Room.getAll",
-            logger,
-          ) as Array<{ id: string; name: string }>;
-          const room = rooms.find((r) => r.name === args.room);
-          if (!room) {
-            throw new CcuError({
-              error: "NOT_FOUND",
-              code: 0,
-              message: `Room not found: ${args.room}`,
-              hint: `Valid rooms: ${rooms.map((r) => r.name).join(", ")}`,
-            });
-          }
-          await rateLimiter.acquire();
-          await withRetry(
-            () => session.call(mode === "add" ? "Room.addChannel" : "Room.removeChannel", { id: room.id, channelId }),
-            "Room.modifyChannel",
-            logger,
-          );
-          applied.push({ kind: "room", name: room.name });
-        }
-
-        if (args.function) {
-          await rateLimiter.acquire();
-          const functions = await withRetry(
-            () => session.call("Subsection.getAll"),
-            "Subsection.getAll",
-            logger,
-          ) as Array<{ id: string; name: string }>;
-          const fn = functions.find((f) => f.name === args.function);
-          if (!fn) {
-            throw new CcuError({
-              error: "NOT_FOUND",
-              code: 0,
-              message: `Function not found: ${args.function}`,
-              hint: `Valid functions: ${functions.map((f) => f.name).join(", ")}`,
-            });
-          }
-          await rateLimiter.acquire();
-          await withRetry(
-            () => session.call(mode === "add" ? "Subsection.addChannel" : "Subsection.removeChannel", { id: fn.id, channelId }),
-            "Subsection.modifyChannel",
-            logger,
-          );
-          applied.push({ kind: "function", name: fn.name });
-        }
-
-        logger.info("tool_call", { tool: toolName, duration_ms: Date.now() - start, status: "ok" });
-        return toolResult({
-          channel: args.channel,
-          [mode === "add" ? "assignedTo" : "removedFrom"]: applied,
-        });
-      } catch (err) {
-        logger.info("tool_call", { tool: toolName, duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+        await rateLimiter.acquire();
+        await withRetry(
+          () => session.call(mode === "add" ? "Room.addChannel" : "Room.removeChannel", { id: room.id, channelId }),
+          "Room.modifyChannel",
+          logger,
+        );
+        applied.push({ kind: "room", name: room.name });
       }
-    },
+
+      if (args.function) {
+        await rateLimiter.acquire();
+        const functions = await withRetry(
+          () => session.call("Subsection.getAll"),
+          "Subsection.getAll",
+          logger,
+        ) as Array<{ id: string; name: string }>;
+        const fn = functions.find((f) => f.name === args.function);
+        if (!fn) {
+          throw new CcuError({
+            error: "NOT_FOUND",
+            code: 0,
+            message: `Function not found: ${args.function}`,
+            hint: `Valid functions: ${functions.map((f) => f.name).join(", ")}`,
+          });
+        }
+        await rateLimiter.acquire();
+        await withRetry(
+          () => session.call(mode === "add" ? "Subsection.addChannel" : "Subsection.removeChannel", { id: fn.id, channelId }),
+          "Subsection.modifyChannel",
+          logger,
+        );
+        applied.push({ kind: "function", name: fn.name });
+      }
+
+      return toolResult({
+        channel: args.channel,
+        [mode === "add" ? "assignedTo" : "removedFrom"]: applied,
+      });
+    }),
   );
 }
 
@@ -634,43 +582,34 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("execute_program", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
+      assertWritable(deps.targets.active, args.confirm);
+      // The CCU's Program.execute reports success even for nonexistent IDs
+      // (issue #18) — validate against the program list first.
+      await rateLimiter.acquire();
+      const programs = await withRetry(
+        () => session.call("Program.getAll"),
+        "Program.getAll",
+        logger,
+      ) as Array<{ id: string; name: string }>;
 
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        // The CCU's Program.execute reports success even for nonexistent IDs
-        // (issue #18) — validate against the program list first.
-        await rateLimiter.acquire();
-        const programs = await withRetry(
-          () => session.call("Program.getAll"),
-          "Program.getAll",
-          logger,
-        ) as Array<{ id: string; name: string }>;
-
-        const program = programs.find((p) => String(p.id) === args.id);
-        if (!program) {
-          throw new CcuError({
-            error: "NOT_FOUND",
-            code: 0,
-            message: `Program not found: ${args.id}`,
-            hint: "Call list_programs to see available programs and their IDs.",
-          });
-        }
-
-        await rateLimiter.acquire();
-        // No retry — Program.execute is not idempotent
-        await session.call("Program.execute", { id: args.id });
-
-        logger.info("tool_call", { tool: "execute_program", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult({ id: args.id, name: program.name, executed: true });
-      } catch (err) {
-        logger.info("tool_call", { tool: "execute_program", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      const program = programs.find((p) => String(p.id) === args.id);
+      if (!program) {
+        throw new CcuError({
+          error: "NOT_FOUND",
+          code: 0,
+          message: `Program not found: ${args.id}`,
+          hint: "Call list_programs to see available programs and their IDs.",
+        });
       }
-    },
+
+      await rateLimiter.acquire();
+      // No retry — Program.execute is not idempotent
+      await session.call("Program.execute", { id: args.id });
+
+      return toolResult({ id: args.id, name: program.name, executed: true });
+    }),
   );
 }
 

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -4,6 +4,7 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
@@ -95,7 +96,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
 
         await rateLimiter.acquire();
         const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
@@ -136,6 +137,7 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
       inputSchema: {
         id: z.string().optional().describe("Alarm id from get_service_messages (confirm a single message)"),
         address: z.string().optional().describe("Channel address — confirm all active messages on this channel (e.g. '000A1BE9A71F15:0')"),
+        confirm: z.boolean().optional().describe("Set true to authorize this write against a protected CCU target (e.g. prod)."),
       },
       annotations: {
         destructiveHint: true,
@@ -148,6 +150,7 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         if (!args.id && !args.address) {
           throw new CcuError({
             error: "INVALID_INPUT",
@@ -205,7 +208,7 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
 
         await rateLimiter.acquire();
         const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
@@ -246,6 +249,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       description: "Get CCU system information: firmware version, serial number, addresses.",
       outputSchema: {
         serverVersion: z.string().optional(),
+        target: z.string().optional().describe("Active CCU target name"),
         version: z.unknown().optional(),
         serial: z.unknown().optional(),
         address: z.unknown().optional(),
@@ -260,7 +264,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
-        const results: Record<string, unknown> = { serverVersion: VERSION };
+        const results: Record<string, unknown> = { serverVersion: VERSION, target: deps.targets.active.profile.name };
 
         const calls: Array<{ key: string; method: string }> = [
           { key: "version", method: "CCU.getVersion" },

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -247,15 +247,21 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
     {
       title: "Get System Info",
       description:
-        "Get CCU system information: firmware version, serial number, addresses. Also reports the " +
-        "running server's build identification (git branch/commit/tag and build time) under `build`.",
+        "Get CCU system information: firmware version, serial number, addresses. Reports the active " +
+        "login user and inferred role (ADMIN/USER) — note that version/serial/address are ADMIN-only " +
+        "on the CCU, so they show \"N/A\" for a non-admin (USER) login. Also reports the running " +
+        "server's build identification (git branch/commit/tag and build time) under `build`.",
       outputSchema: {
         serverVersion: z.string().optional(),
         target: z.string().optional().describe("Active CCU target name"),
-        version: z.unknown().optional(),
-        serial: z.unknown().optional(),
-        address: z.unknown().optional(),
-        hmipAddress: z.unknown().optional(),
+        user: z.string().optional().describe("Configured login user for the active target"),
+        role: z.enum(["ADMIN", "USER", "UNKNOWN"]).optional()
+          .describe("Access role inferred from which CCU methods answer: ADMIN if admin-only calls succeed, USER if logged in without admin rights, UNKNOWN if not connected"),
+        version: z.unknown().optional().describe("Firmware version, or \"N/A\" if unavailable (ADMIN-only)"),
+        serial: z.unknown().optional().describe("Serial number, or \"N/A\" if unavailable (ADMIN-only)"),
+        address: z.unknown().optional().describe("BidCos address, or \"N/A\" if unavailable (ADMIN-only)"),
+        hmipAddress: z.unknown().optional().describe("HmIP address, or \"N/A\" if unavailable (ADMIN-only)"),
+        accessNote: z.string().optional().describe("Present when ADMIN-only fields are unavailable, explaining why"),
         cacheTypes: z.number().optional(),
         cacheWarming: z.boolean().optional(),
         build: z.object({
@@ -274,8 +280,16 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
-        const results: Record<string, unknown> = { serverVersion: VERSION, target: deps.targets.active.profile.name };
+        const active = deps.targets.active;
+        const results: Record<string, unknown> = {
+          serverVersion: VERSION,
+          target: active.profile.name,
+          user: active.profile.ccu.user,
+        };
 
+        // These four are LEVEL ADMIN on the CCU (verified in OCCU methods.conf),
+        // so they only return real values for an admin session. We use that as a
+        // capability probe: any non-empty result => the login has admin rights.
         const calls: Array<{ key: string; method: string }> = [
           { key: "version", method: "CCU.getVersion" },
           { key: "serial", method: "CCU.getSerial" },
@@ -283,13 +297,31 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
           { key: "hmipAddress", method: "CCU.getHmIPAddress" },
         ];
 
+        let anyAdminOk = false;
         for (const { key, method } of calls) {
           try {
             await rateLimiter.acquire();
-            results[key] = await session.call(method);
+            const value = await session.call(method);
+            if (value !== null && value !== undefined && value !== "") {
+              results[key] = value;
+              anyAdminOk = true;
+            } else {
+              results[key] = "N/A"; // empty/no value rather than null
+            }
           } catch {
-            results[key] = null;
+            results[key] = "N/A"; // permission denied or call failed
           }
+        }
+
+        // Infer role: admin-only calls answered => ADMIN; otherwise logged in but
+        // without those rights => USER; not logged in / unreachable => UNKNOWN.
+        const loggedIn = active.session.isLoggedIn();
+        results.role = anyAdminOk ? "ADMIN" : (loggedIn ? "USER" : "UNKNOWN");
+        if (!anyAdminOk && loggedIn) {
+          results.accessNote =
+            `Firmware version, serial and addresses are ADMIN-only on the CCU; ` +
+            `'${active.profile.ccu.user}' is a non-admin (USER) login, so those show "N/A". ` +
+            `Use an ADMIN account to see them.`;
         }
 
         results.cacheTypes = deviceTypeCache.size();

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -5,7 +5,7 @@ import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
 import { assertWritable } from "../ccu/target-registry.js";
-import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION } from "../utils.js";
+import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION, loadBuildInfo } from "../utils.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
   registerGetServiceMessages(server, deps);
@@ -246,7 +246,9 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
     "get_system_info",
     {
       title: "Get System Info",
-      description: "Get CCU system information: firmware version, serial number, addresses.",
+      description:
+        "Get CCU system information: firmware version, serial number, addresses. Also reports the " +
+        "running server's build identification (git branch/commit/tag and build time) under `build`.",
       outputSchema: {
         serverVersion: z.string().optional(),
         target: z.string().optional().describe("Active CCU target name"),
@@ -256,6 +258,14 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
         hmipAddress: z.unknown().optional(),
         cacheTypes: z.number().optional(),
         cacheWarming: z.boolean().optional(),
+        build: z.object({
+          branch: z.string().nullable().describe("Git branch (null if detached or not a git checkout)"),
+          commit: z.string().nullable().describe("Short commit SHA"),
+          tag: z.string().nullable().describe("Tag if HEAD is exactly on one, else null"),
+          describe: z.string().nullable().describe("git describe --tags --dirty --always"),
+          dirty: z.boolean().nullable().describe("true if the working tree had uncommitted changes at build time"),
+          builtAt: z.string().nullable().describe("ISO timestamp of the build"),
+        }).optional().describe("Build identification of the running server (stamped at build time)"),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
@@ -284,6 +294,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
 
         results.cacheTypes = deviceTypeCache.size();
         results.cacheWarming = deviceTypeCache.isWarming();
+        results.build = loadBuildInfo();
 
         logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "ok" });
         return structuredResult(results as Record<string, unknown>);

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -48,7 +48,10 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
             string sId;
             foreach(sId, svcs.EnumIDs()) {
               object svc = dom.GetObject(sId);
-              if (svc && svc.IsTypeOf(OT_ALARMDP) && svc.AlState() == asOncoming) {
+              ! HM Script has NO operator precedence (right-to-left evaluation,
+              ! see issue #74) — null-check first, parenthesize comparisons.
+              if (svc) {
+              if (svc.IsTypeOf(OT_ALARMDP) && (svc.AlState() == asOncoming)) {
                 if (!first) { Write(","); } first = false;
                 ! Parse address from alarm name: AL-<address>.<dpName>
                 string alName = svc.Name();
@@ -72,6 +75,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
                 Write(',"address":"' # chAddr # '"');
                 Write(',"timestamp":"' # svc.AlOccurrenceTime() # '"');
                 Write('}');
+              }
               }
             }
           }
@@ -161,9 +165,12 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
         }
 
         // Enumerate active alarms (same OT_ALARMDP objects get_service_messages
-        // lists), AlConfirm() the ones matching the requested id/address, and
+        // lists), AlReceipt() the ones matching the requested id/address, and
         // report what was confirmed. Confirming in ReGa avoids a second round
         // trip and means we only ever confirm currently-active alarms.
+        // AlReceipt() is what the WebUI itself uses (OCCU functions.fn::ReceiptAlarm);
+        // there is no AlConfirm() in ReGa — an unknown method aborts the whole
+        // script at parse time with EMPTY output (issue #74).
         const wantId = escapeHmScript(args.id ?? "");
         const wantAddr = escapeHmScript(args.address ?? "");
         const script = `
@@ -176,7 +183,11 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
             string sId;
             foreach(sId, svcs.EnumIDs()) {
               object svc = dom.GetObject(sId);
-              if (svc && svc.IsTypeOf(OT_ALARMDP) && svc.AlState() == asOncoming) {
+              ! HM Script has NO operator precedence (right-to-left evaluation,
+              ! see issue #74) — null-check first, parenthesize comparisons.
+              ! Unparenthesized 'a != "" && b == c' mis-groups and is ALWAYS true.
+              if (svc) {
+              if (svc.IsTypeOf(OT_ALARMDP) && (svc.AlState() == asOncoming)) {
                 string alName = svc.Name();
                 string chAddr = "";
                 string dpName = "";
@@ -190,16 +201,17 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
                   }
                 }
                 boolean match = false;
-                if (wantId != "" && sId == wantId) { match = true; }
-                if (wantAddr != "" && chAddr == wantAddr) { match = true; }
+                if ((wantId != "") && (sId == wantId)) { match = true; }
+                if ((wantAddr != "") && (chAddr == wantAddr)) { match = true; }
                 if (match) {
-                  svc.AlConfirm();
+                  svc.AlReceipt();
                   if (!first) { Write(","); } first = false;
                   ! JSON-escape user-controlled names (backslash first, then quote)
                   dpName = dpName.Replace("\\\\", "\\\\\\\\");
                   dpName = dpName.Replace("\\"", "\\\\\\"");
                   Write('{"id":"' # sId # '","type":"' # dpName # '","address":"' # chAddr # '"}');
                 }
+              }
               }
             }
           }

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -4,6 +4,7 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION, loadBuildInfo } from "../utils.js";
 
@@ -30,11 +31,8 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
       outputSchema: { messages: z.array(z.unknown()).describe("Active alarms: {id, type, address, channelName, timestamp}") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => {
+    async () => runTool("get_service_messages", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-
-      try {
         // Two single passes instead of a nested per-alarm channel scan: emit the
         // alarms first while collecting their addresses, then resolve channel
         // names in ONE sweep over all channels (sentinel-comma Find, as in
@@ -114,14 +112,8 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
           }));
         }
 
-        logger.info("tool_call", { tool: "get_service_messages", duration_ms: Date.now() - start, status: "ok" });
         return structuredResult({ messages: Array.isArray(messages) ? messages : [] }, messages);
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_service_messages", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+    }),
   );
 }
 
@@ -145,11 +137,8 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args) => runTool("acknowledge_service_messages", deps.logger, async (log) => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-
-      try {
         assertWritable(deps.targets.active, args.confirm);
         if (!args.id && !args.address) {
           throw new CcuError({
@@ -230,14 +219,9 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
           });
         }
 
-        logger.info("tool_call", { tool: "acknowledge_service_messages", duration_ms: Date.now() - start, status: "ok", count: confirmed.length });
+        log({ count: confirmed.length });
         return toolResult({ confirmed, count: confirmed.length });
-      } catch (err) {
-        logger.info("tool_call", { tool: "acknowledge_service_messages", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+    }),
   );
 }
 
@@ -275,67 +259,58 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => {
-      const { session, rateLimiter, logger, deviceTypeCache } = deps;
-      const start = Date.now();
+    async () => runTool("get_system_info", deps.logger, async () => {
+      const { session, rateLimiter, deviceTypeCache } = deps;
+      const active = deps.targets.active;
+      const results: Record<string, unknown> = {
+        serverVersion: VERSION,
+        target: active.profile.name,
+        user: active.profile.ccu.user,
+      };
 
-      try {
-        const active = deps.targets.active;
-        const results: Record<string, unknown> = {
-          serverVersion: VERSION,
-          target: active.profile.name,
-          user: active.profile.ccu.user,
-        };
+      // These four are LEVEL ADMIN on the CCU (verified in OCCU methods.conf),
+      // so they only return real values for an admin session. We use that as a
+      // capability probe: any non-empty result => the login has admin rights.
+      const calls: Array<{ key: string; method: string }> = [
+        { key: "version", method: "CCU.getVersion" },
+        { key: "serial", method: "CCU.getSerial" },
+        { key: "address", method: "CCU.getAddress" },
+        { key: "hmipAddress", method: "CCU.getHmIPAddress" },
+      ];
 
-        // These four are LEVEL ADMIN on the CCU (verified in OCCU methods.conf),
-        // so they only return real values for an admin session. We use that as a
-        // capability probe: any non-empty result => the login has admin rights.
-        const calls: Array<{ key: string; method: string }> = [
-          { key: "version", method: "CCU.getVersion" },
-          { key: "serial", method: "CCU.getSerial" },
-          { key: "address", method: "CCU.getAddress" },
-          { key: "hmipAddress", method: "CCU.getHmIPAddress" },
-        ];
-
-        let anyAdminOk = false;
-        for (const { key, method } of calls) {
-          try {
-            await rateLimiter.acquire();
-            const value = await session.call(method);
-            if (value !== null && value !== undefined && value !== "") {
-              results[key] = value;
-              anyAdminOk = true;
-            } else {
-              results[key] = "N/A"; // empty/no value rather than null
-            }
-          } catch {
-            results[key] = "N/A"; // permission denied or call failed
+      let anyAdminOk = false;
+      for (const { key, method } of calls) {
+        try {
+          await rateLimiter.acquire();
+          const value = await session.call(method);
+          if (value !== null && value !== undefined && value !== "") {
+            results[key] = value;
+            anyAdminOk = true;
+          } else {
+            results[key] = "N/A"; // empty/no value rather than null
           }
+        } catch {
+          results[key] = "N/A"; // permission denied or call failed
         }
-
-        // Infer role: admin-only calls answered => ADMIN; otherwise logged in but
-        // without those rights => USER; not logged in / unreachable => UNKNOWN.
-        const loggedIn = active.session.isLoggedIn();
-        results.role = anyAdminOk ? "ADMIN" : (loggedIn ? "USER" : "UNKNOWN");
-        if (!anyAdminOk && loggedIn) {
-          results.accessNote =
-            `Firmware version, serial and addresses are ADMIN-only on the CCU; ` +
-            `'${active.profile.ccu.user}' is a non-admin (USER) login, so those show "N/A". ` +
-            `Use an ADMIN account to see them.`;
-        }
-
-        results.cacheTypes = deviceTypeCache.size();
-        results.cacheWarming = deviceTypeCache.isWarming();
-        results.build = loadBuildInfo();
-
-        logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult(results as Record<string, unknown>);
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_system_info", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
       }
-    },
+
+      // Infer role: admin-only calls answered => ADMIN; otherwise logged in but
+      // without those rights => USER; not logged in / unreachable => UNKNOWN.
+      const loggedIn = active.session.isLoggedIn();
+      results.role = anyAdminOk ? "ADMIN" : (loggedIn ? "USER" : "UNKNOWN");
+      if (!anyAdminOk && loggedIn) {
+        results.accessNote =
+          `Firmware version, serial and addresses are ADMIN-only on the CCU; ` +
+          `'${active.profile.ccu.user}' is a non-admin (USER) login, so those show "N/A". ` +
+          `Use an ADMIN account to see them.`;
+      }
+
+      results.cacheTypes = deviceTypeCache.size();
+      results.cacheWarming = deviceTypeCache.isWarming();
+      results.build = loadBuildInfo();
+
+      return structuredResult(results as Record<string, unknown>);
+    }),
   );
 }
 
@@ -358,11 +333,8 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("get_rssi", deps.logger, async (log) => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-
-      try {
         // Device list → address→{name,interface}. Same call list_devices uses;
         // also refresh the resolver so later interface lookups are warm.
         await rateLimiter.acquire();
@@ -487,14 +459,9 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
           bidcosInterfaces = [];
         }
 
-        logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "ok", devices: deviceEntries.length });
+        log({ devices: deviceEntries.length });
         return structuredResult({ devices: deviceEntries, interfaces: bidcosInterfaces });
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_rssi", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+    }),
   );
 }
 

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -4,7 +4,12 @@ import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { resolveTarget } from "../ccu/target-registry.js";
 import { toolResult, structuredResult } from "../utils.js";
+
+// Optional per-call target override (route one read to a named CCU).
+const targetField = z.string().optional()
+  .describe("CCU target to read from (default: active). See list_ccu_targets.");
 
 export function registerDiscoveryTools(server: McpServer, deps: ServerDeps): void {
   registerListDevices(server, deps);
@@ -31,15 +36,17 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
         function: z.string().optional().describe("Filter by function group name (exact match)"),
         type: z.string().optional().describe("Filter by device type (exact match, e.g. 'HmIP-eTRV-2')"),
         name: z.string().optional().describe("Filter by device/channel name (substring, case-insensitive)"),
+        target: targetField,
       },
       outputSchema: { devices: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
       const start = Date.now();
 
       try {
+        const { session, resolver } = resolveTarget(deps.targets, args.target);
         await rateLimiter.acquire();
         const result = await withRetry(
           () => session.call("Device.listAllDetail"),
@@ -50,7 +57,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
         let devices = result as CcuDevice[];
 
         // Update resolver's device list
-        deps.resolver.updateDeviceList(devices);
+        resolver.updateDeviceList(devices);
 
         if (args.room || args.function) {
           const channelIds = new Set<string>();
@@ -287,13 +294,23 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
         "Served from cache (instant). Use list_devices first to find device types.",
       inputSchema: {
         deviceType: z.string().describe("Device type name (e.g. 'HmIP-eTRV-2', 'HmIP-SWDO-I'). Get from list_devices."),
+        target: targetField,
       },
       outputSchema: { deviceType: z.string().optional().describe("Echoed device type; other keys hold the channel/datapoint schema or a not-found hint") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
-      const { session, rateLimiter, logger, deviceTypeCache } = deps;
+      const { rateLimiter, logger } = deps;
       const start = Date.now();
+
+      let target;
+      try {
+        target = resolveTarget(deps.targets, args.target);
+      } catch (err) {
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+      const { session, resolver, deviceTypeCache } = target;
 
       let cached = deviceTypeCache.get(args.deviceType);
 
@@ -303,7 +320,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
       }
 
       // Cache miss — try live query if we can find a device instance
-      const devices = deps.resolver.getDeviceList();
+      const devices = resolver.getDeviceList();
       if (devices) {
         const device = devices.find((d) => d.type === args.deviceType);
         if (device) {

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -2,10 +2,10 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
-import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { runTool } from "../middleware/tool-handler.js";
 import { resolveTarget } from "../ccu/target-registry.js";
-import { toolResult, structuredResult } from "../utils.js";
+import { structuredResult } from "../utils.js";
 
 // Optional per-call target override (route one read to a named CCU).
 const targetField = z.string().optional()
@@ -41,97 +41,89 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
       outputSchema: { devices: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("list_devices", deps.logger, async (log) => {
       const { rateLimiter, logger } = deps;
-      const start = Date.now();
+      const { session, resolver } = resolveTarget(deps.targets, args.target);
+      await rateLimiter.acquire();
+      const result = await withRetry(
+        () => session.call("Device.listAllDetail"),
+        "Device.listAllDetail",
+        logger,
+      );
 
-      try {
-        const { session, resolver } = resolveTarget(deps.targets, args.target);
-        await rateLimiter.acquire();
-        const result = await withRetry(
-          () => session.call("Device.listAllDetail"),
-          "Device.listAllDetail",
-          logger,
-        );
+      let devices = result as CcuDevice[];
 
-        let devices = result as CcuDevice[];
+      // Update resolver's device list
+      resolver.updateDeviceList(devices);
 
-        // Update resolver's device list
-        resolver.updateDeviceList(devices);
+      if (args.room || args.function) {
+        const channelIds = new Set<string>();
 
-        if (args.room || args.function) {
-          const channelIds = new Set<string>();
-
-          if (args.room) {
-            await rateLimiter.acquire();
-            const rooms = await withRetry(
-              () => session.call("Room.getAll"),
-              "Room.getAll",
-              logger,
-            ) as Array<{ id: string; name: string; channelIds: string[] }>;
-            const room = rooms.find((r) => r.name === args.room);
-            if (room) for (const id of room.channelIds) channelIds.add(id);
-          }
-
-          if (args.function) {
-            await rateLimiter.acquire();
-            const functions = await withRetry(
-              () => session.call("Subsection.getAll"),
-              "Subsection.getAll",
-              logger,
-            ) as Array<{ id: string; name: string; channelIds: string[] }>;
-            const func = functions.find((f) => f.name === args.function);
-            if (func) for (const id of func.channelIds) channelIds.add(id);
-          }
-
-          devices = channelIds.size > 0
-            ? devices.filter((d) => d.channels.some((ch) => channelIds.has(ch.id)))
-            : [];
+        if (args.room) {
+          await rateLimiter.acquire();
+          const rooms = await withRetry(
+            () => session.call("Room.getAll"),
+            "Room.getAll",
+            logger,
+          ) as Array<{ id: string; name: string; channelIds: string[] }>;
+          const room = rooms.find((r) => r.name === args.room);
+          if (room) for (const id of room.channelIds) channelIds.add(id);
         }
 
-        if (args.type) devices = devices.filter((d) => d.type === args.type);
-
-        if (args.name) {
-          const needle = args.name.toLowerCase();
-          devices = devices.filter(
-            (d) =>
-              d.name.toLowerCase().includes(needle) ||
-              d.channels.some((ch) => ch.name.toLowerCase().includes(needle)),
-          );
+        if (args.function) {
+          await rateLimiter.acquire();
+          const functions = await withRetry(
+            () => session.call("Subsection.getAll"),
+            "Subsection.getAll",
+            logger,
+          ) as Array<{ id: string; name: string; channelIds: string[] }>;
+          const func = functions.find((f) => f.name === args.function);
+          if (func) for (const id of func.channelIds) channelIds.add(id);
         }
 
-        const hasFilter = args.room || args.function || args.type || args.name;
-
-        // Compact format when unfiltered (summary only), full details when filtered
-        // Hide 50-channel virtual receivers (HM-RCV-50, HmIP-RCV-50) in compact mode
-        const HIDDEN_TYPES = new Set(["HM-RCV-50", "HmIP-RCV-50"]);
-        const output = hasFilter
-          ? devices
-          : devices
-            .filter((d) => !HIDDEN_TYPES.has(d.type))
-            .map((d) => ({
-              id: d.id,
-              name: d.name,
-              address: d.address,
-              interface: d.interface,
-              type: d.type,
-              channelCount: d.channels.length,
-              channels: d.channels.map((ch) => ({
-                address: ch.address,
-                name: ch.name,
-                index: ch.index,
-                channelType: ch.channelType,
-              })),
-            }));
-
-        logger.info("tool_call", { tool: "list_devices", duration_ms: Date.now() - start, status: "ok", deviceCount: devices.length });
-        return structuredResult({ devices: Array.isArray(output) ? output : [] }, output);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_devices", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+        devices = channelIds.size > 0
+          ? devices.filter((d) => d.channels.some((ch) => channelIds.has(ch.id)))
+          : [];
       }
-    },
+
+      if (args.type) devices = devices.filter((d) => d.type === args.type);
+
+      if (args.name) {
+        const needle = args.name.toLowerCase();
+        devices = devices.filter(
+          (d) =>
+            d.name.toLowerCase().includes(needle) ||
+            d.channels.some((ch) => ch.name.toLowerCase().includes(needle)),
+        );
+      }
+
+      const hasFilter = args.room || args.function || args.type || args.name;
+
+      // Compact format when unfiltered (summary only), full details when filtered
+      // Hide 50-channel virtual receivers (HM-RCV-50, HmIP-RCV-50) in compact mode
+      const HIDDEN_TYPES = new Set(["HM-RCV-50", "HmIP-RCV-50"]);
+      const output = hasFilter
+        ? devices
+        : devices
+          .filter((d) => !HIDDEN_TYPES.has(d.type))
+          .map((d) => ({
+            id: d.id,
+            name: d.name,
+            address: d.address,
+            interface: d.interface,
+            type: d.type,
+            channelCount: d.channels.length,
+            channels: d.channels.map((ch) => ({
+              address: ch.address,
+              name: ch.name,
+              index: ch.index,
+              channelType: ch.channelType,
+            })),
+          }));
+
+      log({ deviceCount: devices.length });
+      return structuredResult({ devices: Array.isArray(output) ? output : [] }, output);
+    }),
   );
 }
 
@@ -144,20 +136,12 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
       outputSchema: { interfaces: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => {
+    async () => runTool("list_interfaces", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-      try {
-        await rateLimiter.acquire();
-        const result = await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger);
-        logger.info("tool_call", { tool: "list_interfaces", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult({ interfaces: Array.isArray(result) ? result : [] }, result);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_interfaces", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      await rateLimiter.acquire();
+      const result = await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger);
+      return structuredResult({ interfaces: Array.isArray(result) ? result : [] }, result);
+    }),
   );
 }
 
@@ -170,20 +154,12 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
       outputSchema: { rooms: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => {
+    async () => runTool("list_rooms", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-      try {
-        await rateLimiter.acquire();
-        const result = await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger);
-        logger.info("tool_call", { tool: "list_rooms", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult({ rooms: Array.isArray(result) ? result : [] }, result);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_rooms", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      await rateLimiter.acquire();
+      const result = await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger);
+      return structuredResult({ rooms: Array.isArray(result) ? result : [] }, result);
+    }),
   );
 }
 
@@ -196,20 +172,12 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
       outputSchema: { functions: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => {
+    async () => runTool("list_functions", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-      try {
-        await rateLimiter.acquire();
-        const result = await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger);
-        logger.info("tool_call", { tool: "list_functions", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult({ functions: Array.isArray(result) ? result : [] }, result);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_functions", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      await rateLimiter.acquire();
+      const result = await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger);
+      return structuredResult({ functions: Array.isArray(result) ? result : [] }, result);
+    }),
   );
 }
 
@@ -225,26 +193,18 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
       outputSchema: { programs: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("list_programs", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-      try {
-        await rateLimiter.acquire();
-        let programs = await withRetry(() => session.call("Program.getAll"), "Program.getAll", logger) as Array<{ name: string }>;
+      await rateLimiter.acquire();
+      let programs = await withRetry(() => session.call("Program.getAll"), "Program.getAll", logger) as Array<{ name: string }>;
 
-        if (args.name) {
-          const needle = args.name.toLowerCase();
-          programs = programs.filter((p) => p.name.toLowerCase().includes(needle));
-        }
-
-        logger.info("tool_call", { tool: "list_programs", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult({ programs: Array.isArray(programs) ? programs : [] }, programs);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_programs", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      if (args.name) {
+        const needle = args.name.toLowerCase();
+        programs = programs.filter((p) => p.name.toLowerCase().includes(needle));
       }
-    },
+
+      return structuredResult({ programs: Array.isArray(programs) ? programs : [] }, programs);
+    }),
   );
 }
 
@@ -260,26 +220,18 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
       outputSchema: { systemVariables: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("list_system_variables", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
-      try {
-        await rateLimiter.acquire();
-        let sysvars = await withRetry(() => session.call("SysVar.getAll"), "SysVar.getAll", logger) as Array<{ name: string }>;
+      await rateLimiter.acquire();
+      let sysvars = await withRetry(() => session.call("SysVar.getAll"), "SysVar.getAll", logger) as Array<{ name: string }>;
 
-        if (args.name) {
-          const needle = args.name.toLowerCase();
-          sysvars = sysvars.filter((v) => v.name.toLowerCase().includes(needle));
-        }
-
-        logger.info("tool_call", { tool: "list_system_variables", duration_ms: Date.now() - start, status: "ok" });
-        return structuredResult({ systemVariables: Array.isArray(sysvars) ? sysvars : [] }, sysvars);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_system_variables", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      if (args.name) {
+        const needle = args.name.toLowerCase();
+        sysvars = sysvars.filter((v) => v.name.toLowerCase().includes(needle));
       }
-    },
+
+      return structuredResult({ systemVariables: Array.isArray(sysvars) ? sysvars : [] }, sysvars);
+    }),
   );
 }
 
@@ -299,27 +251,20 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
       outputSchema: { deviceType: z.string().optional().describe("Echoed device type; other keys hold the channel/datapoint schema or a not-found hint") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
-      const { rateLimiter, logger } = deps;
-      const start = Date.now();
-
-      let target;
-      try {
-        target = resolveTarget(deps.targets, args.target);
-      } catch (err) {
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-      const { session, resolver, deviceTypeCache } = target;
+    async (args) => runTool("describe_device_type", deps.logger, async (log) => {
+      const { rateLimiter } = deps;
+      // resolveTarget may throw NOT_FOUND for an unknown target — runTool maps it.
+      const { session, resolver, deviceTypeCache } = resolveTarget(deps.targets, args.target);
 
       let cached = deviceTypeCache.get(args.deviceType);
 
       if (cached) {
-        logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: true });
+        log({ cached: true });
         return structuredResult({ deviceType: args.deviceType, ...cached });
       }
 
       // Cache miss — try live query if we can find a device instance
+      log({ cached: false });
       const devices = resolver.getDeviceList();
       if (devices) {
         const device = devices.find((d) => d.type === args.deviceType);
@@ -331,7 +276,6 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
               session, rateLimiter,
             );
             if (cached) {
-              logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: false });
               return structuredResult({ deviceType: args.deviceType, ...cached });
             }
           } catch {
@@ -340,13 +284,12 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
         }
       }
 
-      logger.info("tool_call", { tool: "describe_device_type", duration_ms: Date.now() - start, status: "ok", cached: false });
       return structuredResult({
         deviceType: args.deviceType,
         message: "Device type not in cache. Cache may still be warming. Try again shortly or call list_devices first.",
         availableTypes: Object.keys(deviceTypeCache.getAll()),
       });
-    },
+    }),
   );
 }
 
@@ -365,79 +308,71 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
       outputSchema: { links: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("list_links", deps.logger, async (log) => {
       const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
+      // Channel address → name map; SENDER/RECEIVER from getLinks are channel addresses.
+      await rateLimiter.acquire();
+      const devices = await withRetry(
+        () => session.call("Device.listAllDetail"),
+        "Device.listAllDetail",
+        logger,
+      ) as CcuDevice[];
+      deps.resolver.updateDeviceList(devices);
+      const channelName = new Map<string, string>();
+      for (const d of devices) for (const ch of d.channels) channelName.set(ch.address, ch.name);
 
-      try {
-        // Channel address → name map; SENDER/RECEIVER from getLinks are channel addresses.
-        await rateLimiter.acquire();
-        const devices = await withRetry(
-          () => session.call("Device.listAllDetail"),
-          "Device.listAllDetail",
-          logger,
-        ) as CcuDevice[];
-        deps.resolver.updateDeviceList(devices);
-        const channelName = new Map<string, string>();
-        for (const d of devices) for (const ch of d.channels) channelName.set(ch.address, ch.name);
+      // Auto-iterate all interfaces (BidCos-RF, HmIP-RF, …) like the cache warmer.
+      await rateLimiter.acquire();
+      const interfaces = await withRetry(
+        () => session.call("Interface.listInterfaces"),
+        "Interface.listInterfaces",
+        logger,
+      ) as Array<{ name: string }>;
 
-        // Auto-iterate all interfaces (BidCos-RF, HmIP-RF, …) like the cache warmer.
-        await rateLimiter.acquire();
-        const interfaces = await withRetry(
-          () => session.call("Interface.listInterfaces"),
-          "Interface.listInterfaces",
-          logger,
-        ) as Array<{ name: string }>;
+      // Match a channel address against the filter: exact channel, or any
+      // channel of the given device address (so a device-level filter works).
+      const matchesAddr = (chAddr: string): boolean => {
+        if (!args.address) return true;
+        return chAddr === args.address || chAddr.split(":")[0] === args.address;
+      };
 
-        // Match a channel address against the filter: exact channel, or any
-        // channel of the given device address (so a device-level filter works).
-        const matchesAddr = (chAddr: string): boolean => {
-          if (!args.address) return true;
-          return chAddr === args.address || chAddr.split(":")[0] === args.address;
-        };
-
-        const links: Array<Record<string, unknown>> = [];
-        for (const iface of interfaces) {
-          let raw: unknown;
-          try {
-            await rateLimiter.acquire();
-            raw = await withRetry(
-              () => session.call("Interface.getLinks", { interface: iface.name, address: args.address ?? "", flags: 0 }),
-              "Interface.getLinks",
-              logger,
-            );
-          } catch {
-            continue; // interface doesn't expose getLinks
-          }
-          if (!Array.isArray(raw)) continue;
-
-          for (const l of raw as Array<Record<string, unknown>>) {
-            // JSON-RPC getLinks returns lowercase fields (see occu
-            // .../interface/getlinks.tcl): sender, receiver, name, description, flags.
-            const sender = String(l.sender ?? "");
-            const receiver = String(l.receiver ?? "");
-            // Re-filter client-side in case the interface ignores the address arg.
-            if (!matchesAddr(sender) && !matchesAddr(receiver)) continue;
-            links.push({
-              sender,
-              senderName: channelName.get(sender) ?? "",
-              receiver,
-              receiverName: channelName.get(receiver) ?? "",
-              name: l.name ?? "",
-              description: l.description ?? "",
-              flags: l.flags ?? 0,
-              interface: iface.name,
-            });
-          }
+      const links: Array<Record<string, unknown>> = [];
+      for (const iface of interfaces) {
+        let raw: unknown;
+        try {
+          await rateLimiter.acquire();
+          raw = await withRetry(
+            () => session.call("Interface.getLinks", { interface: iface.name, address: args.address ?? "", flags: 0 }),
+            "Interface.getLinks",
+            logger,
+          );
+        } catch {
+          continue; // interface doesn't expose getLinks
         }
+        if (!Array.isArray(raw)) continue;
 
-        logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "ok", links: links.length });
-        return structuredResult({ links }, links);
-      } catch (err) {
-        logger.info("tool_call", { tool: "list_links", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+        for (const l of raw as Array<Record<string, unknown>>) {
+          // JSON-RPC getLinks returns lowercase fields (see occu
+          // .../interface/getlinks.tcl): sender, receiver, name, description, flags.
+          const sender = String(l.sender ?? "");
+          const receiver = String(l.receiver ?? "");
+          // Re-filter client-side in case the interface ignores the address arg.
+          if (!matchesAddr(sender) && !matchesAddr(receiver)) continue;
+          links.push({
+            sender,
+            senderName: channelName.get(sender) ?? "",
+            receiver,
+            receiverName: channelName.get(receiver) ?? "",
+            name: l.name ?? "",
+            description: l.description ?? "",
+            flags: l.flags ?? 0,
+            interface: iface.name,
+          });
+        }
       }
-    },
+
+      log({ links: links.length });
+      return structuredResult({ links }, links);
+    }),
   );
 }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { CcuError } from "../middleware/error-mapper.js";
+import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult } from "../utils.js";
 
 export function registerMetaTools(server: McpServer, deps: ServerDeps): void {
@@ -36,6 +37,17 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 3. \`get_value\` / \`get_values\` / \`get_paramset\` → read current state
 4. \`set_value\` / \`put_paramset\` → change state (returns previous value)
 
+## CCU Targets (prod / dev)
+This server can be configured with several named CCU targets (profiles). One is
+"active" at a time; tools run against it.
+- \`list_ccu_targets\` — see configured targets (name, host, user, protected/active)
+- \`get_connection_info\` — confirm which target is active (do this before a write!)
+- \`use_ccu\` — switch the active target
+- Read tools accept an optional \`target\` arg to read from another target for one
+  call without switching (e.g. compare prod vs dev).
+- A \`protected\` target (e.g. prod) refuses writes unless you pass \`confirm: true\`
+  once — that unlocks writes to it for the rest of the session.
+
 ## Tips
 - Use \`list_devices\` with room/function filters to reduce output
 - Use \`get_values\` with room filter instead of multiple \`get_value\` calls
@@ -49,6 +61,7 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 **Read:** get_value, get_values, get_paramset
 **Control:** set_value, put_paramset, set_system_variable, create_system_variable, delete_system_variable, assign_channel, unassign_channel, execute_program
 **Diagnostics:** get_service_messages, acknowledge_service_messages, get_rssi, get_system_info
+**Targets:** list_ccu_targets, get_connection_info, use_ccu
 **Meta:** help, run_script
 `;
 
@@ -163,8 +176,23 @@ Returns: {devices: [{address, name, interface, links: [{peer, peerName, rssiDevi
 rssiDevice/rssiPeer are dBm (higher = better); null means no measurement. Use to diagnose flaky devices.`,
 
   run_script: `Execute arbitrary HomeMatic Script. NOT idempotent — never auto-retried.
-Args: script (string)
+Args: script (string), confirm? (true to write to a protected target)
 Returns: Script output`,
+
+  list_ccu_targets: `List configured CCU targets (profiles) you can switch between.
+Args: none
+Returns: {targets: [{name, host, port, user, https, protected, readonly, active, loggedIn}], active}
+Never exposes passwords.`,
+
+  get_connection_info: `Report the active CCU target (host, user, https, protected/readonly, login state).
+Args: none
+Returns: {name, host, port, user, https, protected, readonly, active, loggedIn, writesUnlocked}
+Use before a write to confirm WHERE it will run.`,
+
+  use_ccu: `Switch the active CCU target. Subsequent calls run against it.
+Args: profile (string — see list_ccu_targets)
+Returns: the new active connection info
+For a one-off read elsewhere, prefer the per-call \`target\` arg on read tools instead.`,
 
   help: `Context-aware help. No args = guide, tool name = tool docs, device type = schema.
 Args: topic? (string)`,
@@ -222,6 +250,7 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
         "Use for anything the other tools don't cover.",
       inputSchema: {
         script: z.string().describe("HomeMatic Script to execute"),
+        confirm: z.boolean().optional().describe("Set true to authorize this script against a protected CCU target (e.g. prod)."),
       },
       annotations: {
         destructiveHint: true,
@@ -233,9 +262,10 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
       const start = Date.now();
 
       try {
+        assertWritable(deps.targets.active, args.confirm);
         await rateLimiter.acquire();
         // No retry — scripts are not idempotent
-        const result = await session.call("ReGa.runScript", { script: args.script }, deps.config.ccu.scriptTimeout);
+        const result = await session.call("ReGa.runScript", { script: args.script }, deps.targets.active.profile.ccu.scriptTimeout);
 
         logger.info("tool_call", { tool: "run_script", duration_ms: Date.now() - start, status: "ok" });
         return toolResult(result);

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -47,6 +47,10 @@ This server can be configured with several named CCU targets (profiles). One is
   call without switching (e.g. compare prod vs dev).
 - A \`protected\` target (e.g. prod) refuses writes unless you pass \`confirm: true\`
   once — that unlocks writes to it for the rest of the session.
+- Exception: \`run_script\` and \`delete_system_variable\` require \`confirm: true\`
+  on EVERY call against a protected target. They never ride on the session
+  unlock (scripts bypass all typed-tool guards; deletion is unrecoverable),
+  and confirming them does not unlock the session for other writes.
 
 ## Tips
 - Use \`list_devices\` with room/function filters to reduce output
@@ -139,7 +143,7 @@ Returns: {name, type, created: true}
 INVALID_INPUT if the name already exists (or enum without values). Use set_system_variable to write it.`,
 
   delete_system_variable: `Delete a system variable by name.
-Args: name (string, exact match)
+Args: name (string, exact match), confirm (REQUIRED true on every call against a protected target — never rides on the session unlock)
 Returns: {name, deleted: true}
 NOT_FOUND if the name doesn't exist.`,
 
@@ -176,7 +180,7 @@ Returns: {devices: [{address, name, interface, links: [{peer, peerName, rssiDevi
 rssiDevice/rssiPeer are dBm (higher = better); null means no measurement. Use to diagnose flaky devices.`,
 
   run_script: `Execute arbitrary HomeMatic Script. NOT idempotent — never auto-retried.
-Args: script (string), confirm? (true to write to a protected target)
+Args: script (string), confirm (REQUIRED true on every call against a protected target — scripts bypass all typed-tool guards and never ride on the session unlock)
 Returns: Script output`,
 
   list_ccu_targets: `List configured CCU targets (profiles) you can switch between.
@@ -247,10 +251,11 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
       description:
         "Execute arbitrary HomeMatic Script on the CCU. " +
         "NOT idempotent — will not be auto-retried. " +
-        "Use for anything the other tools don't cover.",
+        "Use for anything the other tools don't cover. " +
+        "On a protected target, EVERY call needs confirm:true — the session unlock from other write tools does not apply.",
       inputSchema: {
         script: z.string().describe("HomeMatic Script to execute"),
-        confirm: z.boolean().optional().describe("Set true to authorize this script against a protected CCU target (e.g. prod)."),
+        confirm: z.boolean().optional().describe("Required true on EVERY call against a protected CCU target (e.g. prod) — scripts never ride on the session unlock."),
       },
       annotations: {
         destructiveHint: true,
@@ -259,7 +264,8 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => runTool("run_script", deps.logger, async () => {
       const { session, rateLimiter } = deps;
-      assertWritable(deps.targets.active, args.confirm);
+      // Scripts bypass every guard the typed tools enforce — per-call confirm (#72)
+      assertWritable(deps.targets.active, args.confirm, { alwaysConfirm: true });
       await rateLimiter.acquire();
       // No retry — scripts are not idempotent
       const result = await session.call("ReGa.runScript", { script: args.script }, deps.targets.active.profile.ccu.scriptTimeout);

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
-import { CcuError } from "../middleware/error-mapper.js";
+import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult } from "../utils.js";
 
@@ -257,23 +257,14 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
         openWorldHint: true,
       },
     },
-    async (args) => {
-      const { session, rateLimiter, logger } = deps;
-      const start = Date.now();
+    async (args) => runTool("run_script", deps.logger, async () => {
+      const { session, rateLimiter } = deps;
+      assertWritable(deps.targets.active, args.confirm);
+      await rateLimiter.acquire();
+      // No retry — scripts are not idempotent
+      const result = await session.call("ReGa.runScript", { script: args.script }, deps.targets.active.profile.ccu.scriptTimeout);
 
-      try {
-        assertWritable(deps.targets.active, args.confirm);
-        await rateLimiter.acquire();
-        // No retry — scripts are not idempotent
-        const result = await session.call("ReGa.runScript", { script: args.script }, deps.targets.active.profile.ccu.scriptTimeout);
-
-        logger.info("tool_call", { tool: "run_script", duration_ms: Date.now() - start, status: "ok" });
-        return toolResult(result);
-      } catch (err) {
-        logger.info("tool_call", { tool: "run_script", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      return toolResult(result);
+    }),
   );
 }

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -3,7 +3,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { resolveTarget } from "../ccu/target-registry.js";
 import { toolResult, structuredResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
+
+// Optional per-call target override for read tools: route this one read to a
+// named CCU without switching the active target (handy for prod-vs-dev compares).
+const targetField = z.string().optional()
+  .describe("CCU target to read from (default: active). See list_ccu_targets.");
 
 export function registerReadTools(server: McpServer, deps: ServerDeps): void {
   registerGetValue(server, deps);
@@ -24,6 +30,7 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
         address: z.string().describe("Channel address (e.g. '000A1BE9A71F15:1')"),
         valueKey: z.string().describe("Datapoint name (e.g. 'STATE', 'LEVEL', 'ACTUAL_TEMPERATURE')"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
+        target: targetField,
       },
       outputSchema: {
         address: z.string(),
@@ -33,11 +40,12 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
       const start = Date.now();
 
       try {
-        const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
+        const { session, resolver } = resolveTarget(deps.targets, args.target);
+        const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
         await rateLimiter.acquire();
         const value = await withRetry(
@@ -73,6 +81,7 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         channels: z.array(z.string()).optional().describe("Array of channel addresses to read"),
         room: z.string().optional().describe("Room name — read all channels in this room"),
         function: z.string().optional().describe("Function name — read all channels in this function group"),
+        target: targetField,
       },
       outputSchema: {
         values: z.array(z.unknown()).describe("One entry per channel: {address, name, datapoints}"),
@@ -80,10 +89,12 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
       const start = Date.now();
 
       try {
+        const t = resolveTarget(deps.targets, args.target);
+        const { session } = t;
         // Build HM Script to collect values
         let script: string;
 
@@ -108,7 +119,7 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
 
         await rateLimiter.acquire();
         const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.config.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, t.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
@@ -207,6 +218,7 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
         address: z.string().describe("Channel address (e.g. '000A1BE9A71F15:1')"),
         paramsetKey: z.enum(["VALUES", "MASTER", "LINK"]).describe("Paramset to read"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
+        target: targetField,
       },
       outputSchema: {
         address: z.string(),
@@ -216,11 +228,12 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
       const start = Date.now();
 
       try {
-        const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
+        const { session, resolver } = resolveTarget(deps.targets, args.target);
+        const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
         await rateLimiter.acquire();
         const result = await withRetry(

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -107,14 +107,14 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         } else if (args.function) {
           script = buildGetValuesScript(`"${escapeHmScript(args.function)}"`, "function");
         } else {
-          return {
-            isError: true,
-            content: [{ type: "text" as const, text: JSON.stringify({
-              error: "INVALID_INPUT",
-              message: "Provide either channels, room, or function parameter.",
-              hint: "At least one filter is required to avoid reading all devices.",
-            }) }],
-          };
+          // Route through CcuError like every other tool (the catch below maps
+          // it via toMcpError) instead of hand-building an isError result.
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: "Provide either channels, room, or function parameter.",
+            hint: "At least one filter is required to avoid reading all devices.",
+          });
         }
 
         await rateLimiter.acquire();

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -3,8 +3,9 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
+import { runTool } from "../middleware/tool-handler.js";
 import { resolveTarget } from "../ccu/target-registry.js";
-import { toolResult, structuredResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
+import { structuredResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
 
 // Optional per-call target override for read tools: route this one read to a
 // named CCU without switching the active target (handy for prod-vs-dev compares).
@@ -39,33 +40,25 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("get_value", deps.logger, async (log) => {
       const { rateLimiter, logger } = deps;
-      const start = Date.now();
+      const { session, resolver } = resolveTarget(deps.targets, args.target);
+      const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
-      try {
-        const { session, resolver } = resolveTarget(deps.targets, args.target);
-        const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
+      await rateLimiter.acquire();
+      const value = await withRetry(
+        () => session.call("Interface.getValue", {
+          interface: iface,
+          address: args.address,
+          valueKey: args.valueKey,
+        }),
+        "Interface.getValue",
+        logger,
+      );
 
-        await rateLimiter.acquire();
-        const value = await withRetry(
-          () => session.call("Interface.getValue", {
-            interface: iface,
-            address: args.address,
-            valueKey: args.valueKey,
-          }),
-          "Interface.getValue",
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "get_value", duration_ms: Date.now() - start, status: "ok", address: args.address });
-        return structuredResult({ address: args.address, valueKey: args.valueKey, value: parseValue(value) });
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_value", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      log({ address: args.address });
+      return structuredResult({ address: args.address, valueKey: args.valueKey, value: parseValue(value) });
+    }),
   );
 }
 
@@ -88,52 +81,43 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("get_values", deps.logger, async () => {
       const { rateLimiter, logger } = deps;
-      const start = Date.now();
+      const t = resolveTarget(deps.targets, args.target);
+      const { session } = t;
+      // Build HM Script to collect values
+      let script: string;
 
-      try {
-        const t = resolveTarget(deps.targets, args.target);
-        const { session } = t;
-        // Build HM Script to collect values
-        let script: string;
-
-        if (args.channels && args.channels.length > 0) {
-          // Comma-delimited with sentinel commas for exact matching via Find()
-          const addrList = "," + args.channels.map((a) => escapeHmScript(a)).join(",") + ",";
-          script = buildGetValuesScript(`"${addrList}"`, "addresses");
-        } else if (args.room) {
-          script = buildGetValuesScript(`"${escapeHmScript(args.room)}"`, "room");
-        } else if (args.function) {
-          script = buildGetValuesScript(`"${escapeHmScript(args.function)}"`, "function");
-        } else {
-          // Route through CcuError like every other tool (the catch below maps
-          // it via toMcpError) instead of hand-building an isError result.
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: "Provide either channels, room, or function parameter.",
-            hint: "At least one filter is required to avoid reading all devices.",
-          });
-        }
-
-        await rateLimiter.acquire();
-        const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, t.profile.ccu.scriptTimeout),
-          "ReGa.runScript",
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "get_values", duration_ms: Date.now() - start, status: "ok" });
-        const data = typeof result === "string" ? tryParseJson(result) : result;
-        // Wrap the array for structuredContent; keep the bare array as the text block.
-        return structuredResult({ values: Array.isArray(data) ? data : [] }, data);
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_values", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
+      if (args.channels && args.channels.length > 0) {
+        // Comma-delimited with sentinel commas for exact matching via Find()
+        const addrList = "," + args.channels.map((a) => escapeHmScript(a)).join(",") + ",";
+        script = buildGetValuesScript(`"${addrList}"`, "addresses");
+      } else if (args.room) {
+        script = buildGetValuesScript(`"${escapeHmScript(args.room)}"`, "room");
+      } else if (args.function) {
+        script = buildGetValuesScript(`"${escapeHmScript(args.function)}"`, "function");
+      } else {
+        // Route through CcuError like every other tool (runTool maps it via
+        // toMcpError) instead of hand-building an isError result.
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: "Provide either channels, room, or function parameter.",
+          hint: "At least one filter is required to avoid reading all devices.",
+        });
       }
-    },
+
+      await rateLimiter.acquire();
+      const result = await withRetry(
+        () => session.call("ReGa.runScript", { script }, t.profile.ccu.scriptTimeout),
+        "ReGa.runScript",
+        logger,
+      );
+
+      const data = typeof result === "string" ? tryParseJson(result) : result;
+      // Wrap the array for structuredContent; keep the bare array as the text block.
+      return structuredResult({ values: Array.isArray(data) ? data : [] }, data);
+    }),
   );
 }
 
@@ -227,37 +211,28 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async (args) => {
+    async (args) => runTool("get_paramset", deps.logger, async () => {
       const { rateLimiter, logger } = deps;
-      const start = Date.now();
+      const { session, resolver } = resolveTarget(deps.targets, args.target);
+      const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
-      try {
-        const { session, resolver } = resolveTarget(deps.targets, args.target);
-        const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
+      await rateLimiter.acquire();
+      const result = await withRetry(
+        () => session.call("Interface.getParamset", {
+          interface: iface,
+          address: args.address,
+          paramsetKey: args.paramsetKey,
+        }),
+        "Interface.getParamset",
+        logger,
+      );
 
-        await rateLimiter.acquire();
-        const result = await withRetry(
-          () => session.call("Interface.getParamset", {
-            interface: iface,
-            address: args.address,
-            paramsetKey: args.paramsetKey,
-          }),
-          "Interface.getParamset",
-          logger,
-        );
-
-        logger.info("tool_call", { tool: "get_paramset", duration_ms: Date.now() - start, status: "ok" });
-        // Parse values to native types if result is a flat object
-        const params = (typeof result === "object" && result !== null && !Array.isArray(result))
-          ? parseValues(result as Record<string, unknown>)
-          : result;
-        return structuredResult({ address: args.address, paramsetKey: args.paramsetKey, params });
-      } catch (err) {
-        logger.info("tool_call", { tool: "get_paramset", duration_ms: Date.now() - start, status: "error" });
-        if (err instanceof CcuError) return err.toMcpError();
-        throw err;
-      }
-    },
+      // Parse values to native types if result is a flat object
+      const params = (typeof result === "object" && result !== null && !Array.isArray(result))
+        ? parseValues(result as Record<string, unknown>)
+        : result;
+      return structuredResult({ address: args.address, paramsetKey: args.paramsetKey, params });
+    }),
   );
 }
 

--- a/src/tools/targets.ts
+++ b/src/tools/targets.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ServerDeps } from "../server.js";
+import type { Target } from "../ccu/target-registry.js";
+import { CcuError } from "../middleware/error-mapper.js";
+import { structuredResult } from "../utils.js";
+
+export function registerTargetTools(server: McpServer, deps: ServerDeps): void {
+  registerListTargets(server, deps);
+  registerGetConnectionInfo(server, deps);
+  registerUseCcu(server, deps);
+}
+
+// Identity view of a target — NEVER includes the password.
+function targetInfo(t: Target, activeName: string) {
+  return {
+    name: t.profile.name,
+    host: t.profile.ccu.host,
+    port: t.profile.ccu.port,
+    user: t.profile.ccu.user,
+    https: t.profile.ccu.https,
+    protected: t.profile.protected,
+    readonly: t.profile.readonly,
+    active: t.profile.name === activeName,
+    loggedIn: t.session.isLoggedIn(),
+    writesUnlocked: t.unlocked,
+  };
+}
+
+function registerListTargets(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "list_ccu_targets",
+    {
+      title: "List CCU Targets",
+      description:
+        "List all configured CCU targets (profiles) you can switch between with use_ccu — name, host, " +
+        "user, whether protected/read-only, which is active, and login state. Never exposes passwords.",
+      outputSchema: {
+        targets: z.array(z.unknown()).describe("Configured targets: {name, host, port, user, https, protected, readonly, active, loggedIn}"),
+        active: z.string().describe("Name of the currently active target"),
+      },
+      // Local-only: reads in-memory config; never reaches a CCU.
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async () => {
+      const activeName = deps.targets.active.profile.name;
+      const targets = deps.targets.list().map((t) => targetInfo(t, activeName));
+      return structuredResult({ targets, active: activeName }, { targets, active: activeName });
+    },
+  );
+}
+
+function registerGetConnectionInfo(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "get_connection_info",
+    {
+      title: "Get Connection Info",
+      description:
+        "Report which CCU target is currently active — host, user, https, protected/read-only flags, and " +
+        "login state. Use this to confirm WHERE a command will run (especially before a write). No password.",
+      outputSchema: {
+        name: z.string(),
+        host: z.string(),
+        port: z.number(),
+        user: z.string(),
+        https: z.boolean(),
+        protected: z.boolean(),
+        readonly: z.boolean(),
+        active: z.boolean(),
+        loggedIn: z.boolean(),
+        writesUnlocked: z.boolean(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async () => {
+      const active = deps.targets.active;
+      return structuredResult(targetInfo(active, active.profile.name));
+    },
+  );
+}
+
+function registerUseCcu(server: McpServer, deps: ServerDeps): void {
+  server.registerTool(
+    "use_ccu",
+    {
+      title: "Switch CCU Target",
+      description:
+        "Switch the active CCU target. All subsequent tool calls go to this target until switched again " +
+        "(use the per-call `target` arg on read tools for a one-off without switching). Returns the new " +
+        "active connection info. Login happens lazily on the first call.",
+      inputSchema: {
+        profile: z.string().describe("Target name (see list_ccu_targets)"),
+      },
+      outputSchema: {
+        name: z.string(),
+        host: z.string(),
+        port: z.number(),
+        user: z.string(),
+        https: z.boolean(),
+        protected: z.boolean(),
+        readonly: z.boolean(),
+        active: z.boolean(),
+        loggedIn: z.boolean(),
+        writesUnlocked: z.boolean(),
+      },
+      annotations: { readOnlyHint: false, openWorldHint: false },
+    },
+    async (args) => {
+      try {
+        const t = deps.targets.use(args.profile);
+        deps.logger.info("ccu_target_switched", { target: t.profile.name });
+        return structuredResult(targetInfo(t, t.profile.name));
+      } catch (err) {
+        if (err instanceof CcuError) return err.toMcpError();
+        throw err;
+      }
+    },
+  );
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,35 @@ const _require = createRequire(import.meta.url);
 /** Server version — read from package.json at runtime, single source of truth. */
 export const VERSION: string = (_require("../package.json") as { version: string }).version;
 
+/** Git build identification, stamped into dist/build-info.json at build time. */
+export interface BuildInfo {
+  branch: string | null;
+  commit: string | null;
+  tag: string | null;
+  describe: string | null;
+  dirty: boolean | null;
+  builtAt: string | null;
+}
+
+/**
+ * Load the build identification written by scripts/gen-build-info.mjs. Best-effort:
+ * if the file is missing (server run straight from an unbuilt checkout) every
+ * field is null rather than throwing. Tries the compiled location first
+ * (dist/build-info.json, next to utils.js) then the source-tree fallback
+ * (../dist/build-info.json) so unit tests importing from src/ still find it.
+ */
+export function loadBuildInfo(): BuildInfo {
+  const fallback: BuildInfo = { branch: null, commit: null, tag: null, describe: null, dirty: null, builtAt: null };
+  for (const rel of ["./build-info.json", "../dist/build-info.json"]) {
+    try {
+      return { ...fallback, ...(_require(rel) as Partial<BuildInfo>) };
+    } catch {
+      // try the next location
+    }
+  }
+  return fallback;
+}
+
 /**
  * Escape a string for safe interpolation into HomeMatic Script double-quoted strings.
  * Verified against a live CCU (issue #16): \\ \" \n are real ReGa escapes; # needs

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -133,7 +133,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, sid);
     expect(res.status).toBe(200);
     const msg = await parseSse(res);
-    expect(msg.result.tools.length).toBe(25);
+    expect(msg.result.tools.length).toBe(28);
   });
 
   it("returns a structured tool error (not a crash) when a tool needs the CCU", async () => {
@@ -251,7 +251,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
       const res = await mcpPost(mcpPort, { jsonrpc: "2.0", id: i, method: "tools/list", params: {} }, sid);
       expect(res.status).toBe(200);
       const msg = await parseSse(res);
-      expect(msg.result.tools.length).toBe(25);
+      expect(msg.result.tools.length).toBe(28);
     }
   });
 

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { SessionManager } from "../../src/ccu/session.js";
 import { RateLimiter } from "../../src/middleware/rate-limiter.js";
-import { DeviceTypeCache } from "../../src/cache/device-type-cache.js";
-import { Resolver } from "../../src/middleware/resolver.js";
+import { TargetRegistry } from "../../src/ccu/target-registry.js";
 import { createLogger } from "../../src/logger.js";
 import { createMcpServer, type ServerDeps } from "../../src/server.js";
+import type { AppConfig } from "../../src/config.js";
 import { escapeHmScript } from "../../src/utils.js";
 import { callTool, parseToolResult } from "../unit/_helpers.js";
 import type { CcuConfig } from "../../src/ccu/types.js";
@@ -32,35 +31,39 @@ describeIf("MCP tools against live CCU", () => {
   };
 
   const logger = createLogger();
-  let session: SessionManager;
+  let targets: TargetRegistry;
   let server: McpServer;
   let deps: ServerDeps;
   let tempDir: string;
 
   beforeAll(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "debmatic-tools-live-"));
-    session = new SessionManager(config, logger, tempDir);
-    await session.login();
+    const appConfig: AppConfig = {
+      ccu: config,
+      profiles: [{ name: "default", protected: false, readonly: false, ccu: config }],
+      defaultProfile: "default",
+      mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
+      cache: { dir: tempDir, ttl: 86400 },
+      rateLimiter: { burst: 20, rate: 10 },
+      resourcePollInterval: 3600,
+    };
+    targets = new TargetRegistry(appConfig, logger, tempDir);
+    await targets.loginActive();
     deps = {
-      config: {
-        ccu: config,
-        mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
-        cache: { dir: tempDir, ttl: 86400 },
-        rateLimiter: { burst: 20, rate: 10 },
-        resourcePollInterval: 3600,
-      },
-      session,
+      config: appConfig,
+      targets,
+      get session() { return targets.active.session; },
+      get resolver() { return targets.active.resolver; },
+      get deviceTypeCache() { return targets.active.deviceTypeCache; },
       rateLimiter: new RateLimiter(20, 10),
       logger,
-      deviceTypeCache: new DeviceTypeCache(tempDir, 86400, logger),
-      resolver: new Resolver(),
     };
     server = createMcpServer(deps);
   }, 30_000);
 
   afterAll(async () => {
-    await session.logout();
-    session.destroy();
+    await targets.logoutAll();
+    targets.destroyAll();
     deps.rateLimiter.destroy();
     await rm(tempDir, { recursive: true, force: true });
   });

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -113,7 +113,7 @@ describeIf("MCP tools against live CCU", () => {
     expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
   }, 30_000);
 
-  // Exercises the real ReGa enumeration + AlConfirm path without mutating the
+  // Exercises the real ReGa enumeration + AlReceipt path without mutating the
   // user's CCU: a bogus id matches no active alarm → empty confirmed → NOT_FOUND.
   // We deliberately do NOT auto-confirm a real active alarm (it would silently
   // dismiss the user's warnings during a test run).
@@ -122,6 +122,51 @@ describeIf("MCP tools against live CCU", () => {
     expect(result.isError).toBe(true);
     expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
   }, 30_000);
+
+  // Full acknowledge round-trip against the real ReGa (issue #74): create a
+  // throwaway alarm datapoint, raise it to asOncoming, register it in
+  // ID_SERVICES, confirm it through the tool, then clean everything up. This
+  // is the test that would have caught AlConfirm(): ReGa aborts a script
+  // containing an unknown method at PARSE time with empty output, so the
+  // NOT_FOUND test above passes even when the script never ran.
+  it("acknowledge_service_messages confirms a synthetic alarm end-to-end (issue #74)", async () => {
+    const ALARM_NAME = "AL-MCP_LIVE_TEST:0.ISSUE_74";
+    const setup = parseToolResult(await callTool(server, "run_script", {
+      script: `
+        object al = dom.CreateObject(OT_ALARMDP, "${ALARM_NAME}");
+        al.ValueType(ivtBinary);
+        al.ValueSubType(istAlarm);
+        al.AlArm(true);
+        al.State(true);
+        dom.GetObject(ID_SERVICES).Add(al.ID());
+        Write('{"id":"' # al.ID() # '","state":' # al.AlState() # '}');
+      `,
+    })) as { id: string; state: number };
+    expect(setup.state).toBe(1); // asOncoming
+
+    try {
+      const result = parseToolResult(await callTool(server, "acknowledge_service_messages", {
+        id: setup.id,
+      })) as { confirmed: Array<{ id: string }>; count: number };
+      expect(result.count).toBe(1);
+      expect(result.confirmed[0].id).toBe(setup.id);
+
+      // the alarm must actually have left the asOncoming state
+      const after = parseToolResult(await callTool(server, "run_script", {
+        script: `Write(dom.GetObject("${setup.id}").AlState());`,
+      }));
+      expect(after).not.toBe("1");
+    } finally {
+      await callTool(server, "run_script", {
+        script: `
+          dom.GetObject(ID_SERVICES).Remove("${setup.id}");
+          dom.DeleteObject("${setup.id}");
+          object leftover = dom.GetObject("${ALARM_NAME}");
+          if (leftover) { Write("LEFTOVER"); } else { Write("clean"); }
+        `,
+      });
+    }
+  }, 60_000);
 
   it("acknowledge_service_messages rejects an empty request with INVALID_INPUT", async () => {
     const result: any = await callTool(server, "acknowledge_service_messages", {});

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -4,33 +4,107 @@ import { Logger } from "../../src/logger.js";
 import { RateLimiter } from "../../src/middleware/rate-limiter.js";
 import { DeviceTypeCache } from "../../src/cache/device-type-cache.js";
 import { Resolver } from "../../src/middleware/resolver.js";
+import type { Target, TargetRegistry } from "../../src/ccu/target-registry.js";
+import { CcuError } from "../../src/middleware/error-mapper.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+type SessionCall = (method: string, params?: Record<string, unknown>, timeout?: number) => Promise<unknown>;
+
+interface TargetSpec {
+  name?: string;
+  protected?: boolean;
+  readonly?: boolean;
+  password?: string;
+  sessionCall?: SessionCall;
+}
+
+function makeSession(sessionCall?: SessionCall) {
+  return {
+    call: sessionCall ?? vi.fn(async () => []),
+    login: vi.fn(async () => {}),
+    logout: vi.fn(async () => {}),
+    isLoggedIn: vi.fn(() => true),
+    getSessionId: vi.fn(() => "test-session"),
+    callNoSession: vi.fn(async () => null),
+    destroy: vi.fn(),
+  } as any;
+}
+
+function makeTarget(spec: TargetSpec): Target {
+  const name = spec.name ?? "default";
+  return {
+    profile: {
+      name,
+      protected: spec.protected ?? false,
+      readonly: spec.readonly ?? false,
+      ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: spec.password ?? "pw", timeout: 5000, scriptTimeout: 10000 },
+    },
+    session: makeSession(spec.sessionCall),
+    resolver: new Resolver(),
+    deviceTypeCache: new DeviceTypeCache("/tmp/nonexistent-test", 86400, new Logger("error"), `device-type-cache.${name}.json`),
+    sysVarTypeCache: { entry: null },
+    unlocked: false,
+  };
+}
+
+// Minimal in-memory stand-in for TargetRegistry (real one builds live sessions).
+class FakeRegistry {
+  private readonly byName = new Map<string, Target>();
+  private readonly order: string[] = [];
+  private activeKey: string;
+  constructor(targets: Target[]) {
+    for (const t of targets) {
+      this.byName.set(t.profile.name.toLowerCase(), t);
+      this.order.push(t.profile.name);
+    }
+    this.activeKey = targets[0]!.profile.name.toLowerCase();
+  }
+  get active(): Target { return this.byName.get(this.activeKey)!; }
+  getByName(name: string): Target | undefined { return this.byName.get(name.toLowerCase()); }
+  has(name: string): boolean { return this.byName.has(name.toLowerCase()); }
+  list(): Target[] { return this.order.map((n) => this.byName.get(n.toLowerCase())!); }
+  use(name: string): Target {
+    const t = this.getByName(name);
+    if (!t) throw new CcuError({ error: "NOT_FOUND", code: 0, message: `Unknown CCU target: ${name}`, hint: "Call list_ccu_targets." });
+    this.activeKey = t.profile.name.toLowerCase();
+    return t;
+  }
+}
+
 export function createMockDeps(overrides?: {
-  sessionCall?: (method: string, params?: Record<string, unknown>, timeout?: number) => Promise<unknown>;
+  sessionCall?: SessionCall;
+  /** Mark the (single default) target protected. */
+  protected?: boolean;
+  /** Mark the (single default) target read-only. */
+  readonly?: boolean;
+  /** Build a multi-target registry instead of the single default target. */
+  targets?: TargetSpec[];
 }): ServerDeps {
   const rateLimiter = new RateLimiter(1000, 1000); // effectively unlimited for tests
+  const specs: TargetSpec[] = overrides?.targets ?? [{
+    name: "default",
+    protected: overrides?.protected,
+    readonly: overrides?.readonly,
+    sessionCall: overrides?.sessionCall,
+  }];
+  const registry = new FakeRegistry(specs.map(makeTarget));
+
   return {
     config: {
-      ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
+      ccu: registry.active.profile.ccu,
+      profiles: registry.list().map((t) => t.profile),
+      defaultProfile: registry.active.profile.name,
       mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,
     },
-    session: {
-      call: overrides?.sessionCall ?? vi.fn(async () => []),
-      login: vi.fn(async () => {}),
-      logout: vi.fn(async () => {}),
-      isLoggedIn: vi.fn(() => true),
-      getSessionId: vi.fn(() => "test-session"),
-      callNoSession: vi.fn(async () => null),
-      destroy: vi.fn(),
-    } as any,
+    targets: registry as unknown as TargetRegistry,
+    get session() { return registry.active.session; },
+    get resolver() { return registry.active.resolver; },
+    get deviceTypeCache() { return registry.active.deviceTypeCache; },
     rateLimiter,
     logger: new Logger("error"),
-    deviceTypeCache: new DeviceTypeCache("/tmp/nonexistent-test", 86400, new Logger("error")),
-    resolver: new Resolver(),
   };
 }
 

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -40,6 +40,11 @@ describe("loadConfig", () => {
     delete process.env.MCP_TLS_KEY;
     delete process.env.MCP_ALLOW_PLAINTEXT;
     delete process.env.LOG_LEVEL;
+    delete process.env.CCU_PROFILES;
+    delete process.env.CCU_DEFAULT_PROFILE;
+    for (const k of Object.keys(process.env)) {
+      if (/^CCU_(PROD|DEV|STAGING)_/.test(k)) delete process.env[k];
+    }
   });
 
   afterEach(() => {
@@ -319,5 +324,88 @@ describe("loadConfig", () => {
     expect(() => loadConfig()).toThrow(/MCP_AUTH_TOKEN_TTL_DAYS must be a positive number/);
     process.env.MCP_AUTH_TOKEN_TTL_DAYS = "soon";
     expect(() => loadConfig()).toThrow(/MCP_AUTH_TOKEN_TTL_DAYS must be a positive number/);
+  });
+
+  // Issue #69: multiple named CCU targets (profiles)
+  describe("CCU profiles", () => {
+    it("flat config (no CCU_PROFILES) yields a single 'default' profile, ccu alias intact", () => {
+      process.env.CCU_HOST = "debmatic";
+      process.env.CCU_PASSWORD = "secret";
+      const config = loadConfig();
+      expect(config.profiles).toHaveLength(1);
+      expect(config.profiles[0]!.name).toBe("default");
+      expect(config.profiles[0]!.protected).toBe(false);
+      expect(config.profiles[0]!.readonly).toBe(false);
+      expect(config.defaultProfile).toBe("default");
+      // ccu stays an alias of the default profile (back-compat)
+      expect(config.ccu).toBe(config.profiles[0]!.ccu);
+      expect(config.ccu.host).toBe("debmatic");
+      expect(config.ccu.password).toBe("secret");
+    });
+
+    it("builds one profile per CCU_PROFILES entry from CCU_<NAME>_* vars", () => {
+      process.env.CCU_PROFILES = "prod,dev";
+      process.env.CCU_DEFAULT_PROFILE = "prod";
+      process.env.CCU_PROD_HOST = "debmatic";
+      process.env.CCU_PROD_USER = "claude";
+      process.env.CCU_PROD_PASSWORD = "topsecret";
+      process.env.CCU_PROD_HTTPS = "true";
+      process.env.CCU_PROD_PROTECTED = "true";
+      process.env.CCU_DEV_HOST = "127.0.0.1";
+      process.env.CCU_DEV_PORT = "18080";
+      // dev password intentionally unset (OpenCCU default empty)
+
+      const config = loadConfig();
+      expect(config.profiles.map((p) => p.name)).toEqual(["prod", "dev"]);
+      expect(config.defaultProfile).toBe("prod");
+      expect(config.ccu.host).toBe("debmatic"); // alias = default (prod)
+
+      const prod = config.profiles[0]!;
+      expect(prod.protected).toBe(true);
+      expect(prod.ccu.user).toBe("claude");
+      expect(prod.ccu.https).toBe(true);
+      expect(prod.ccu.port).toBe(443); // https default
+
+      const dev = config.profiles[1]!;
+      expect(dev.protected).toBe(false);
+      expect(dev.ccu.host).toBe("127.0.0.1");
+      expect(dev.ccu.port).toBe(18080);
+      expect(dev.ccu.user).toBe("Admin"); // default
+      expect(dev.ccu.password).toBe(""); // empty allowed
+      expect(dev.ccu.https).toBe(false);
+    });
+
+    it("defaults the active profile to the first listed when CCU_DEFAULT_PROFILE is unset", () => {
+      process.env.CCU_PROFILES = "dev,prod";
+      process.env.CCU_DEV_HOST = "127.0.0.1";
+      process.env.CCU_PROD_HOST = "debmatic";
+      expect(loadConfig().defaultProfile).toBe("dev");
+    });
+
+    it("throws if a profile is missing its HOST", () => {
+      process.env.CCU_PROFILES = "prod";
+      // no CCU_PROD_HOST
+      expect(() => loadConfig()).toThrow(/profile "prod" is missing CCU_PROD_HOST/);
+    });
+
+    it("throws if CCU_DEFAULT_PROFILE names an unknown profile", () => {
+      process.env.CCU_PROFILES = "prod";
+      process.env.CCU_PROD_HOST = "debmatic";
+      process.env.CCU_DEFAULT_PROFILE = "dev";
+      expect(() => loadConfig()).toThrow(/CCU_DEFAULT_PROFILE="dev" is not one of CCU_PROFILES/);
+    });
+
+    it("rejects duplicate profile names", () => {
+      process.env.CCU_PROFILES = "prod,Prod";
+      process.env.CCU_PROD_HOST = "debmatic";
+      expect(() => loadConfig()).toThrow(/lists "Prod" more than once/);
+    });
+
+    it("reads per-profile READONLY flag", () => {
+      process.env.CCU_PROFILES = "prod";
+      process.env.CCU_PROD_HOST = "debmatic";
+      process.env.CCU_PROD_READONLY = "true";
+      expect(loadConfig().profiles[0]!.readonly).toBe(true);
+    });
   });
 });

--- a/test/unit/device-type-cache.test.ts
+++ b/test/unit/device-type-cache.test.ts
@@ -230,4 +230,30 @@ describe("warm edge cases (coverage round)", () => {
     expect(param).toMatchObject({ type: "FLOAT", operations: 7, min: 0, max: 1.01, unit: "%", valueList: ["a", "b"] });
     await new Promise((r) => setTimeout(r, 25)); // let background save finish
   });
+
+  // Issue #69: per-target caches must use distinct files so prod/dev don't mix.
+  it("uses a per-instance filename and keeps separate caches isolated on disk", async () => {
+    const prod = new DeviceTypeCache(tempDir, 86400, logger, "device-type-cache.prod.json");
+    const dev = new DeviceTypeCache(tempDir, 86400, logger, "device-type-cache.dev.json");
+
+    (prod as any).cache.set("HmIP-PROD", { interface: "HmIP-RF", channels: {} });
+    (dev as any).cache.set("HmIP-DEV", { interface: "HmIP-RF", channels: {} });
+    await prod.saveToDisk();
+    await dev.saveToDisk();
+
+    expect(JSON.parse(await readFile(join(tempDir, "device-type-cache.prod.json"), "utf-8")).types).toHaveProperty("HmIP-PROD");
+    expect(JSON.parse(await readFile(join(tempDir, "device-type-cache.dev.json"), "utf-8")).types).toHaveProperty("HmIP-DEV");
+
+    const prod2 = new DeviceTypeCache(tempDir, 86400, logger, "device-type-cache.prod.json");
+    await prod2.loadFromDisk();
+    expect(prod2.has("HmIP-PROD")).toBe(true);
+    expect(prod2.has("HmIP-DEV")).toBe(false);
+  });
+
+  it("defaults to the historical filename for back-compat", async () => {
+    const cache = new DeviceTypeCache(tempDir, 86400, logger);
+    (cache as any).cache.set("HmIP-X", { interface: "HmIP-RF", channels: {} });
+    await cache.saveToDisk();
+    expect(JSON.parse(await readFile(join(tempDir, "device-type-cache.json"), "utf-8")).types).toHaveProperty("HmIP-X");
+  });
 });

--- a/test/unit/rate-limiter.test.ts
+++ b/test/unit/rate-limiter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { RateLimiter } from "../../src/middleware/rate-limiter.js";
+import { CcuError } from "../../src/middleware/error-mapper.js";
 
 describe("RateLimiter", () => {
   let limiter: RateLimiter;
@@ -29,6 +30,26 @@ describe("RateLimiter", () => {
 
     // Should have waited a bit (at least one refill cycle of 100ms)
     expect(elapsed).toBeGreaterThanOrEqual(50);
+  });
+
+  it("rejects with RATE_LIMITED once the wait queue is full", async () => {
+    // 0 tokens, no refill, queue capped at 2: the first 2 acquires park, the
+    // 3rd exceeds the cap and must reject rather than grow the queue.
+    limiter = new RateLimiter(0, 0, 2);
+
+    const queued1 = limiter.acquire();
+    const queued2 = limiter.acquire();
+
+    await expect(limiter.acquire()).rejects.toBeInstanceOf(CcuError);
+    await limiter.acquire().catch((err) => {
+      expect(err).toBeInstanceOf(CcuError);
+      expect((err as CcuError).structured.error).toBe("RATE_LIMITED");
+    });
+
+    // The two genuinely-queued waiters are still pending; destroy releases them
+    // so the test doesn't leak unsettled promises.
+    limiter.destroy();
+    await Promise.all([queued1, queued2]);
   });
 
   it("destroy releases waiting requests", async () => {

--- a/test/unit/resource-poller.test.ts
+++ b/test/unit/resource-poller.test.ts
@@ -18,7 +18,7 @@ describe("ResourcePoller", () => {
 
   it("start sets interval and stop clears it", () => {
     const mocks = createMocks();
-    const poller = new ResourcePoller(mocks.notify, mocks.session, mocks.rateLimiter, logger, 30);
+    const poller = new ResourcePoller(mocks.notify, () => mocks.session, mocks.rateLimiter, logger, 30);
     poller.start();
     poller.stop();
     // No throw, timer cleaned up
@@ -27,7 +27,7 @@ describe("ResourcePoller", () => {
   it("does not emit event on first poll (no previous hash)", async () => {
     const mocks = createMocks();
     mocks.session.call.mockResolvedValue([{ id: "1" }]);
-    const poller = new ResourcePoller(mocks.notify, mocks.session, mocks.rateLimiter, logger, 10);
+    const poller = new ResourcePoller(mocks.notify, () => mocks.session, mocks.rateLimiter, logger, 10);
     poller.start();
 
     await vi.advanceTimersByTimeAsync(10_000);
@@ -44,7 +44,7 @@ describe("ResourcePoller", () => {
       return [{ data: callCount }]; // different on each call
     });
 
-    const poller = new ResourcePoller(mocks.notify, mocks.session, mocks.rateLimiter, logger, 10);
+    const poller = new ResourcePoller(mocks.notify, () => mocks.session, mocks.rateLimiter, logger, 10);
     poller.start();
 
     // First poll — sets baseline hashes
@@ -61,7 +61,7 @@ describe("ResourcePoller", () => {
     const mocks = createMocks();
     mocks.session.call.mockResolvedValue([{ data: "static" }]);
 
-    const poller = new ResourcePoller(mocks.notify, mocks.session, mocks.rateLimiter, logger, 10);
+    const poller = new ResourcePoller(mocks.notify, () => mocks.session, mocks.rateLimiter, logger, 10);
     poller.start();
 
     await vi.advanceTimersByTimeAsync(10_000); // first poll
@@ -80,7 +80,7 @@ describe("ResourcePoller", () => {
       return [];
     });
 
-    const poller = new ResourcePoller(mocks.notify, mocks.session, mocks.rateLimiter, logger, 10);
+    const poller = new ResourcePoller(mocks.notify, () => mocks.session, mocks.rateLimiter, logger, 10);
     poller.start();
 
     await vi.advanceTimersByTimeAsync(10_000);
@@ -92,7 +92,7 @@ describe("ResourcePoller", () => {
 
   it("acquires rate limiter before each resource poll", async () => {
     const mocks = createMocks();
-    const poller = new ResourcePoller(mocks.notify, mocks.session, mocks.rateLimiter, logger, 10);
+    const poller = new ResourcePoller(mocks.notify, () => mocks.session, mocks.rateLimiter, logger, 10);
     poller.start();
 
     await vi.advanceTimersByTimeAsync(10_000);
@@ -110,7 +110,7 @@ describe("ResourcePoller backoff and notify failure (coverage round)", () => {
   it("applies exponential backoff after consecutive failures and resets on success", async () => {
     const mocks = createMocks();
     mocks.session.call.mockRejectedValue(new Error("ccu down"));
-    const poller = new ResourcePoller(mocks.notify, mocks.session, mocks.rateLimiter, logger, 10);
+    const poller = new ResourcePoller(mocks.notify, () => mocks.session, mocks.rateLimiter, logger, 10);
     poller.start();
 
     await vi.advanceTimersByTimeAsync(10_000); // first cycle fails
@@ -133,7 +133,7 @@ describe("ResourcePoller backoff and notify failure (coverage round)", () => {
     let value = 0;
     mocks.session.call.mockImplementation(async () => [{ v: value }]);
     mocks.notify.mockRejectedValue(new Error("no transport"));
-    const poller = new ResourcePoller(mocks.notify, mocks.session, mocks.rateLimiter, logger, 10);
+    const poller = new ResourcePoller(mocks.notify, () => mocks.session, mocks.rateLimiter, logger, 10);
     poller.start();
 
     await vi.advanceTimersByTimeAsync(10_000); // baseline hashes
@@ -142,6 +142,67 @@ describe("ResourcePoller backoff and notify failure (coverage round)", () => {
     expect(mocks.notify).toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(10_000); // still polling
     expect((poller as any).consecutiveFailures).toBe(0);
+    poller.stop();
+  });
+});
+
+// Regression for the multi-CCU poller binding (#73): the poller must resolve
+// the ACTIVE target's session on every cycle, so a use_ccu() switch is followed
+// instead of forever polling the startup target.
+describe("ResourcePoller follows the active target (multi-CCU)", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("polls the session returned by the provider on each cycle, not a captured one", async () => {
+    const notify = vi.fn(async () => {});
+    const rateLimiter = { acquire: vi.fn(async () => {}) } as any;
+    const sessionA = { call: vi.fn(async () => [{ ccu: "A" }]) } as any;
+    const sessionB = { call: vi.fn(async () => [{ ccu: "B" }]) } as any;
+
+    // Mutable "active" pointer, like targets.active in index.ts.
+    let active = sessionA;
+    const poller = new ResourcePoller(notify, () => active, rateLimiter, logger, 10);
+    poller.start();
+
+    // First cycle hits A.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sessionA.call).toHaveBeenCalled();
+    expect(sessionB.call).not.toHaveBeenCalled();
+
+    // Switch the active target (use_ccu) — the next cycle must hit B, not A.
+    const aCallsAtSwitch = sessionA.call.mock.calls.length;
+    active = sessionB;
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(sessionB.call).toHaveBeenCalled();
+    // A is no longer polled after the switch.
+    expect(sessionA.call.mock.calls.length).toBe(aCallsAtSwitch);
+    poller.stop();
+  });
+
+  it("notifies on a change to the now-active target after a switch", async () => {
+    const notify = vi.fn(async () => {});
+    const rateLimiter = { acquire: vi.fn(async () => {}) } as any;
+    // A is static; B changes between cycles.
+    const sessionA = { call: vi.fn(async () => [{ ccu: "A", static: true }]) } as any;
+    let bValue = 0;
+    const sessionB = { call: vi.fn(async () => [{ ccu: "B", v: bValue }]) } as any;
+
+    let active = sessionA;
+    const poller = new ResourcePoller(notify, () => active, rateLimiter, logger, 10);
+    poller.start();
+
+    await vi.advanceTimersByTimeAsync(10_000); // baseline on A
+    expect(notify).not.toHaveBeenCalled();
+
+    // Switch to B; first B cycle re-baselines against B's data.
+    active = sessionB;
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // Now change B and poll again — the change on the active target must notify.
+    bValue = 1;
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(notify).toHaveBeenCalled();
     poller.stop();
   });
 });

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -1,35 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { createMcpServer } from "../../src/server.js";
-import { Logger } from "../../src/logger.js";
-import { RateLimiter } from "../../src/middleware/rate-limiter.js";
-import { DeviceTypeCache } from "../../src/cache/device-type-cache.js";
-import { Resolver } from "../../src/middleware/resolver.js";
-
-// Minimal mock deps — we're testing that registration doesn't throw, not calling tools
-function createMockDeps() {
-  return {
-    config: {
-      ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: "pw", timeout: 5000, scriptTimeout: 10000 },
-      mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
-      cache: { dir: "/tmp", ttl: 86400 },
-      rateLimiter: { burst: 20, rate: 10 },
-      resourcePollInterval: 60,
-    },
-    session: {
-      call: async () => [],
-      login: async () => {},
-      logout: async () => {},
-      isLoggedIn: () => true,
-      getSessionId: () => "test",
-      callNoSession: async () => null,
-      destroy: () => {},
-    } as any,
-    rateLimiter: new RateLimiter(20, 10),
-    logger: new Logger("error"),
-    deviceTypeCache: new DeviceTypeCache("/tmp", 86400, new Logger("error")),
-    resolver: new Resolver(),
-  };
-}
+import { createMockDeps } from "./_helpers.js";
 
 describe("MCP Server Registration", () => {
   it("creates server without errors", () => {
@@ -39,7 +10,7 @@ describe("MCP Server Registration", () => {
     deps.rateLimiter.destroy();
   });
 
-  it("registers all 18 tools", () => {
+  it("registers all tools", () => {
     const deps = createMockDeps();
     const server = createMcpServer(deps);
 
@@ -53,6 +24,7 @@ describe("MCP Server Registration", () => {
       "delete_system_variable",
       "describe_device_type",
       "execute_program",
+      "get_connection_info",
       "get_paramset",
       "get_rssi",
       "get_service_messages",
@@ -60,6 +32,7 @@ describe("MCP Server Registration", () => {
       "get_value",
       "get_values",
       "help",
+      "list_ccu_targets",
       "list_devices",
       "list_functions",
       "list_interfaces",
@@ -72,9 +45,10 @@ describe("MCP Server Registration", () => {
       "set_system_variable",
       "set_value",
       "unassign_channel",
+      "use_ccu",
     ]);
 
-    expect(Object.keys(tools).length).toBe(25);
+    expect(Object.keys(tools).length).toBe(28);
     deps.rateLimiter.destroy();
   });
 
@@ -131,7 +105,8 @@ describe("Tool annotations", () => {
   ];
   const WRITE_TOOLS = ["acknowledge_service_messages", "assign_channel", "create_system_variable", "delete_system_variable", "execute_program", "put_paramset", "run_script", "set_system_variable", "set_value", "unassign_channel"];
   const IDEMPOTENT_WRITES = ["acknowledge_service_messages", "assign_channel", "delete_system_variable", "put_paramset", "set_system_variable", "set_value", "unassign_channel"];
-  const LOCAL_TOOLS = ["help"]; // everything else reaches the external CCU
+  // help + the target-management tools are local-only (never reach a CCU).
+  const LOCAL_TOOLS = ["help", "list_ccu_targets", "get_connection_info", "use_ccu"];
 
   type Ann = {
     title?: string; readOnlyHint?: boolean; destructiveHint?: boolean;

--- a/test/unit/target-registry.test.ts
+++ b/test/unit/target-registry.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { TargetRegistry, resolveTarget, assertWritable } from "../../src/ccu/target-registry.js";
+import { Logger } from "../../src/logger.js";
+import type { AppConfig } from "../../src/config.js";
+import type { CcuProfile } from "../../src/ccu/types.js";
+import { CcuError } from "../../src/middleware/error-mapper.js";
+
+const logger = new Logger("error");
+
+function profile(name: string, opts?: Partial<Pick<CcuProfile, "protected" | "readonly">>): CcuProfile {
+  return {
+    name,
+    protected: opts?.protected ?? false,
+    readonly: opts?.readonly ?? false,
+    ccu: { host: `${name}-host`, port: 80, https: false, tlsVerify: false, user: "Admin", password: "", timeout: 5000, scriptTimeout: 10000 },
+  };
+}
+
+function appConfig(profiles: CcuProfile[], defaultProfile: string, cacheDir: string): AppConfig {
+  return {
+    ccu: profiles.find((p) => p.name === defaultProfile)!.ccu,
+    profiles,
+    defaultProfile,
+    mcp: { transport: "stdio", port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
+    cache: { dir: cacheDir, ttl: 86400 },
+    rateLimiter: { burst: 20, rate: 10 },
+    resourcePollInterval: 60,
+  };
+}
+
+describe("TargetRegistry", () => {
+  let tempDir: string;
+  beforeEach(async () => { tempDir = await mkdtemp(join(tmpdir(), "ccu-registry-")); });
+  afterEach(async () => { await rm(tempDir, { recursive: true, force: true }); });
+
+  it("builds one target per profile and makes the default active", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod", { protected: true }), profile("dev")], "prod", tempDir), logger, tempDir);
+    expect(reg.list().map((t) => t.profile.name)).toEqual(["prod", "dev"]);
+    expect(reg.active.profile.name).toBe("prod");
+    expect(reg.active.profile.protected).toBe(true);
+  });
+
+  it("getByName / has are case-insensitive; unknown is undefined", () => {
+    const reg = new TargetRegistry(appConfig([profile("Prod"), profile("dev")], "Prod", tempDir), logger, tempDir);
+    expect(reg.getByName("prod")!.profile.name).toBe("Prod");
+    expect(reg.has("DEV")).toBe(true);
+    expect(reg.getByName("nope")).toBeUndefined();
+    expect(reg.has("nope")).toBe(false);
+  });
+
+  it("use() switches the active target and returns it", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
+    const t = reg.use("dev");
+    expect(t.profile.name).toBe("dev");
+    expect(reg.active.profile.name).toBe("dev");
+  });
+
+  it("use() on an unknown target throws a NOT_FOUND CcuError", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod")], "prod", tempDir), logger, tempDir);
+    expect(() => reg.use("ghost")).toThrowError(CcuError);
+    try { reg.use("ghost"); } catch (e) { expect((e as CcuError).structured.error).toBe("NOT_FOUND"); }
+  });
+
+  it("each target gets its own resolver, caches, and sysvar holder", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
+    const [prod, dev] = reg.list();
+    expect(prod!.resolver).not.toBe(dev!.resolver);
+    expect(prod!.deviceTypeCache).not.toBe(dev!.deviceTypeCache);
+    expect(prod!.sysVarTypeCache).not.toBe(dev!.sysVarTypeCache);
+    expect(prod!.unlocked).toBe(false);
+  });
+
+  it("saveCaches writes a distinct file per target; default keeps the legacy name", async () => {
+    const reg = new TargetRegistry(appConfig([profile("default"), profile("dev")], "default", tempDir), logger, tempDir);
+    const [def, dev] = reg.list();
+    (def!.deviceTypeCache as any).cache.set("HmIP-DEF", { interface: "HmIP-RF", channels: {} });
+    (dev!.deviceTypeCache as any).cache.set("HmIP-DEV", { interface: "HmIP-RF", channels: {} });
+    await reg.saveCaches();
+    const files = (await readdir(tempDir)).sort();
+    expect(files).toContain("device-type-cache.json");      // legacy name for "default"
+    expect(files).toContain("device-type-cache.dev.json");  // suffixed for "dev"
+  });
+});
+
+describe("resolveTarget", () => {
+  let tempDir: string;
+  beforeEach(async () => { tempDir = await mkdtemp(join(tmpdir(), "ccu-resolve-")); });
+  afterEach(async () => { await rm(tempDir, { recursive: true, force: true }); });
+
+  it("returns the active target when no name is given", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
+    expect(resolveTarget(reg).profile.name).toBe("prod");
+  });
+
+  it("returns the named target without switching active", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
+    expect(resolveTarget(reg, "dev").profile.name).toBe("dev");
+    expect(reg.active.profile.name).toBe("prod"); // unchanged
+  });
+
+  it("throws NOT_FOUND for an unknown name", () => {
+    const reg = new TargetRegistry(appConfig([profile("prod")], "prod", tempDir), logger, tempDir);
+    expect(() => resolveTarget(reg, "ghost")).toThrowError(/Unknown CCU target/);
+  });
+});
+
+describe("assertWritable", () => {
+  let tempDir: string;
+  beforeEach(async () => { tempDir = await mkdtemp(join(tmpdir(), "ccu-guard-")); });
+  afterEach(async () => { await rm(tempDir, { recursive: true, force: true }); });
+
+  function target(opts?: Partial<Pick<CcuProfile, "protected" | "readonly">>) {
+    const reg = new TargetRegistry(appConfig([profile("t", opts)], "t", tempDir), logger, tempDir);
+    return reg.active;
+  }
+
+  it("allows writes to an unprotected target", () => {
+    expect(() => assertWritable(target(), undefined)).not.toThrow();
+  });
+
+  it("refuses a read-only target even with confirm", () => {
+    expect(() => assertWritable(target({ readonly: true }), true)).toThrowError(/read-only/);
+  });
+
+  it("refuses a protected target without confirm, then unlocks with confirm:true", () => {
+    const t = target({ protected: true });
+    expect(() => assertWritable(t, undefined)).toThrowError(/protected/);
+    expect(t.unlocked).toBe(false);
+    // confirm unlocks for the session
+    expect(() => assertWritable(t, true)).not.toThrow();
+    expect(t.unlocked).toBe(true);
+    // subsequent writes no longer need confirm
+    expect(() => assertWritable(t, undefined)).not.toThrow();
+  });
+});

--- a/test/unit/target-registry.test.ts
+++ b/test/unit/target-registry.test.ts
@@ -80,8 +80,23 @@ describe("TargetRegistry", () => {
     (dev!.deviceTypeCache as any).cache.set("HmIP-DEV", { interface: "HmIP-RF", channels: {} });
     await reg.saveCaches();
     const files = (await readdir(tempDir)).sort();
-    expect(files).toContain("device-type-cache.json");      // legacy name for "default"
-    expect(files).toContain("device-type-cache.dev.json");  // suffixed for "dev"
+    expect(files).toContain("device-type-cache.json"); // legacy name for "default"
+    // Named profiles get a readable slug plus a short hash of the name.
+    expect(files.some((f) => /^device-type-cache\.dev-[0-9a-f]{8}\.json$/.test(f))).toBe(true);
+  });
+
+  it("names differing only by punctuation get distinct cache files (no collision)", async () => {
+    // "my-ccu" and "my.ccu" both slugify to "my-ccu"; without the name hash they
+    // would share one device-type-cache file and cross-contaminate two CCUs.
+    const reg = new TargetRegistry(appConfig([profile("my-ccu"), profile("my.ccu")], "my-ccu", tempDir), logger, tempDir);
+    const [a, b] = reg.list();
+    (a!.deviceTypeCache as any).cache.set("HmIP-A", { interface: "HmIP-RF", channels: {} });
+    (b!.deviceTypeCache as any).cache.set("HmIP-B", { interface: "HmIP-RF", channels: {} });
+    await reg.saveCaches();
+    const files = (await readdir(tempDir)).filter((f) => f.startsWith("device-type-cache."));
+    // Two distinct files written, not one shared file.
+    expect(files.length).toBe(2);
+    expect(new Set(files).size).toBe(2);
   });
 });
 

--- a/test/unit/target-registry.test.ts
+++ b/test/unit/target-registry.test.ts
@@ -150,4 +150,29 @@ describe("assertWritable", () => {
     // subsequent writes no longer need confirm
     expect(() => assertWritable(t, undefined)).not.toThrow();
   });
+
+  // Issue #72: high-blast-radius tools (run_script, delete_system_variable)
+  // never ride on the session unlock — every call needs its own confirm.
+  it("alwaysConfirm ignores the session unlock: each call needs confirm:true", () => {
+    const t = target({ protected: true });
+    assertWritable(t, true); // ordinary write unlocks the session
+    expect(t.unlocked).toBe(true);
+    // ...but an alwaysConfirm tool still refuses without its own confirm
+    expect(() => assertWritable(t, undefined, { alwaysConfirm: true })).toThrowError(/EVERY call/);
+    expect(() => assertWritable(t, true, { alwaysConfirm: true })).not.toThrow();
+    // and refuses again on the next call — no per-call carryover
+    expect(() => assertWritable(t, undefined, { alwaysConfirm: true })).toThrowError(/EVERY call/);
+  });
+
+  it("a confirmed alwaysConfirm call does not unlock the session for other writes", () => {
+    const t = target({ protected: true });
+    expect(() => assertWritable(t, true, { alwaysConfirm: true })).not.toThrow();
+    expect(t.unlocked).toBe(false);
+    expect(() => assertWritable(t, undefined)).toThrowError(/protected/);
+  });
+
+  it("alwaysConfirm is a no-op gate on unprotected targets and still refuses readonly", () => {
+    expect(() => assertWritable(target(), undefined, { alwaysConfirm: true })).not.toThrow();
+    expect(() => assertWritable(target({ readonly: true }), true, { alwaysConfirm: true })).toThrowError(/read-only/);
+  });
 });

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -237,7 +237,7 @@ describe("get_system_info handler", () => {
     cleanupDeps(deps);
   });
 
-  it("returns null for individual call failures", async () => {
+  it("shows N/A for individual call failures", async () => {
     const { server, deps } = createTestServer({
       sessionCall: vi.fn().mockImplementation(async (method: string) => {
         if (method === "CCU.getSerial") throw new Error("fail");
@@ -247,7 +247,35 @@ describe("get_system_info handler", () => {
 
     const result = parseToolResult(await callTool(server, "get_system_info")) as any;
     expect(result.version).toBe("ok");
-    expect(result.serial).toBe(null);
+    expect(result.serial).toBe("N/A");
+    cleanupDeps(deps);
+  });
+
+  it("reports user and ADMIN role when admin-only calls succeed", async () => {
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockResolvedValue("ok"),
+    });
+
+    const result = parseToolResult(await callTool(server, "get_system_info")) as any;
+    expect(result.user).toBe("Admin");
+    expect(result.role).toBe("ADMIN");
+    expect(result.accessNote).toBeUndefined();
+    cleanupDeps(deps);
+  });
+
+  it("reports USER role with N/A fields and an accessNote when admin-only calls are denied", async () => {
+    const { server, deps } = createTestServer({
+      // Every ADMIN-gated CCU.* call is denied — mimics a non-admin login.
+      sessionCall: vi.fn().mockRejectedValue(new Error("access denied")),
+    });
+
+    const result = parseToolResult(await callTool(server, "get_system_info")) as any;
+    expect(result.role).toBe("USER");
+    expect(result.version).toBe("N/A");
+    expect(result.serial).toBe("N/A");
+    expect(result.address).toBe("N/A");
+    expect(result.hmipAddress).toBe("N/A");
+    expect(result.accessNote).toMatch(/ADMIN-only/);
     cleanupDeps(deps);
   });
 });
@@ -262,8 +290,8 @@ describe("error and edge paths (coverage round)", () => {
     });
     const result = parseToolResult(await callTool(server, "get_system_info")) as any;
     expect(result.version).toBe("3.85.7");
-    expect(result.serial).toBeNull();
-    expect(result.hmipAddress).toBeNull();
+    expect(result.serial).toBe("N/A");
+    expect(result.hmipAddress).toBe("N/A");
     cleanupDeps(deps);
   });
 

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -223,6 +223,20 @@ describe("get_system_info handler", () => {
     cleanupDeps(deps);
   });
 
+  it("includes a build identification block", async () => {
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockResolvedValue("ok"),
+    });
+
+    const result = parseToolResult(await callTool(server, "get_system_info")) as any;
+    // Shape is always present; values are null off a git checkout, populated on one.
+    expect(result.build).toBeTypeOf("object");
+    for (const key of ["branch", "commit", "tag", "describe", "dirty", "builtAt"]) {
+      expect(result.build).toHaveProperty(key);
+    }
+    cleanupDeps(deps);
+  });
+
   it("returns null for individual call failures", async () => {
     const { server, deps } = createTestServer({
       sessionCall: vi.fn().mockImplementation(async (method: string) => {

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -106,14 +106,21 @@ describe("acknowledge_service_messages handler", () => {
     cleanupDeps(deps);
   });
 
-  it("generates a script that confirms (AlConfirm) and escapes the requested id/address", async () => {
+  it("generates a script that confirms (AlReceipt) and escapes the requested id/address", async () => {
     const sessionCall = vi.fn().mockResolvedValue(JSON.stringify({ confirmed: [{ id: "1", type: "x", address: 'A":0' }] }));
     const { server, deps } = createTestServer({ sessionCall });
 
     await callTool(server, "acknowledge_service_messages", { address: 'A":0' });
     const script = sessionCall.mock.calls[0][1].script as string;
-    expect(script).toContain("AlConfirm()");
+    // AlReceipt() is the real ReGa method (issue #74) — AlConfirm() does not
+    // exist and would abort the whole script at parse time with empty output.
+    expect(script).toContain("AlReceipt()");
+    expect(script).not.toContain("AlConfirm");
     expect(script).toContain("OT_ALARMDP");
+    // HM Script has no operator precedence: comparisons combined with && must
+    // be individually parenthesized or the condition mis-groups (issue #74).
+    expect(script).toContain('if ((wantId != "") && (sId == wantId))');
+    expect(script).toContain('if ((wantAddr != "") && (chAddr == wantAddr))');
     // the embedded address literal is escaped (quote -> \")
     expect(script).toContain('string wantAddr = "A\\":0";');
     cleanupDeps(deps);

--- a/test/unit/tools-targets.test.ts
+++ b/test/unit/tools-targets.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
+import type { ServerDeps } from "../../src/server.js";
+
+describe("CCU target tools (issue #69)", () => {
+  let deps: ServerDeps;
+  afterEach(() => deps && cleanupDeps(deps));
+
+  function twoTargets() {
+    return createTestServer({
+      targets: [
+        { name: "prod", protected: true, password: "PROD-SECRET", sessionCall: async () => "prod-ok" },
+        { name: "dev", sessionCall: async () => "dev-ok" },
+      ],
+    });
+  }
+
+  it("list_ccu_targets lists all targets, marks the active one, never leaks passwords", async () => {
+    const t = twoTargets(); deps = t.deps;
+    const res = parseToolResult(await callTool(t.server, "list_ccu_targets")) as any;
+    expect(res.active).toBe("prod");
+    expect(res.targets.map((x: any) => x.name)).toEqual(["prod", "dev"]);
+    const prod = res.targets.find((x: any) => x.name === "prod");
+    expect(prod.active).toBe(true);
+    expect(prod.protected).toBe(true);
+    expect(prod).not.toHaveProperty("password");
+    // Hard redaction guard: the password must not appear anywhere in the output.
+    expect(JSON.stringify(res)).not.toContain("PROD-SECRET");
+  });
+
+  it("get_connection_info reports the active target", async () => {
+    const t = twoTargets(); deps = t.deps;
+    const res = parseToolResult(await callTool(t.server, "get_connection_info")) as any;
+    expect(res.name).toBe("prod");
+    expect(res.active).toBe(true);
+    expect(res.protected).toBe(true);
+    expect(JSON.stringify(res)).not.toContain("PROD-SECRET");
+  });
+
+  it("use_ccu switches the active target and routes later calls to it", async () => {
+    const t = twoTargets(); deps = t.deps;
+    const switched = parseToolResult(await callTool(t.server, "use_ccu", { profile: "dev" })) as any;
+    expect(switched.name).toBe("dev");
+    expect(switched.active).toBe(true);
+
+    // get_connection_info now reflects dev
+    const info = parseToolResult(await callTool(t.server, "get_connection_info")) as any;
+    expect(info.name).toBe("dev");
+
+    // a read now hits the dev session
+    const val = parseToolResult(await callTool(t.server, "get_value", { address: "ABC:1", valueKey: "STATE", interface: "X" })) as any;
+    expect(val.value).toBe("dev-ok");
+  });
+
+  it("use_ccu on an unknown target returns a NOT_FOUND error", async () => {
+    const t = twoTargets(); deps = t.deps;
+    const res: any = await callTool(t.server, "use_ccu", { profile: "nope" });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res)).toContain("NOT_FOUND");
+  });
+
+  it("per-call target reads another target without switching the active one", async () => {
+    const t = twoTargets(); deps = t.deps;
+    // active is prod; read dev via the per-call target override
+    const val = parseToolResult(await callTool(t.server, "get_value", { address: "ABC:1", valueKey: "STATE", interface: "X", target: "dev" })) as any;
+    expect(val.value).toBe("dev-ok");
+    // active is still prod
+    const info = parseToolResult(await callTool(t.server, "get_connection_info")) as any;
+    expect(info.name).toBe("prod");
+  });
+});
+
+describe("protected-target write guard (issue #69)", () => {
+  let deps: ServerDeps;
+  afterEach(() => deps && cleanupDeps(deps));
+
+  it("refuses a write to a protected target without confirm:true", async () => {
+    const t = createTestServer({ protected: true, sessionCall: async () => "ok" });
+    deps = t.deps;
+    const res: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res)).toContain("protected");
+  });
+
+  it("allows the write with confirm:true and stays unlocked for the session", async () => {
+    let writes = 0;
+    const t = createTestServer({
+      protected: true,
+      sessionCall: async (method: string) => { if (method === "Interface.setValue") writes++; return null; },
+    });
+    deps = t.deps;
+
+    const ok: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true, interface: "X", type: "bool", confirm: true });
+    expect(ok.isError).toBeFalsy();
+    expect(writes).toBe(1);
+
+    // second write needs no confirm (unlocked for this session)
+    const ok2: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: false, interface: "X", type: "bool" });
+    expect(ok2.isError).toBeFalsy();
+    expect(writes).toBe(2);
+  });
+
+  it("a read-only target refuses writes even with confirm:true", async () => {
+    const t = createTestServer({ readonly: true, sessionCall: async () => null });
+    deps = t.deps;
+    const res: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true, interface: "X", type: "bool", confirm: true });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res)).toContain("read-only");
+  });
+
+  it("an unprotected target writes without confirm", async () => {
+    let writes = 0;
+    const t = createTestServer({
+      sessionCall: async (method: string) => { if (method === "Interface.setValue") writes++; return null; },
+    });
+    deps = t.deps;
+    const ok: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true, interface: "X", type: "bool" });
+    expect(ok.isError).toBeFalsy();
+    expect(writes).toBe(1);
+  });
+});

--- a/test/unit/tools-targets.test.ts
+++ b/test/unit/tools-targets.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
 import type { ServerDeps } from "../../src/server.js";
 
@@ -117,5 +117,66 @@ describe("protected-target write guard (issue #69)", () => {
     const ok: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true, interface: "X", type: "bool" });
     expect(ok.isError).toBeFalsy();
     expect(writes).toBe(1);
+  });
+});
+
+// Issue #72: run_script and delete_system_variable never ride on the session
+// unlock — these tests pin the TOOL-level wiring (assertWritable's
+// alwaysConfirm semantics themselves are covered in target-registry.test.ts).
+describe("per-call confirm for high-impact tools (issue #72)", () => {
+  let deps: ServerDeps;
+  afterEach(() => deps && cleanupDeps(deps));
+
+  async function unlockSession(server: any) {
+    // an ordinary confirmed write unlocks the session for typed tools
+    const ok: any = await callTool(server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true, interface: "X", type: "bool", confirm: true });
+    expect(ok.isError).toBeFalsy();
+  }
+
+  it("run_script refuses without confirm even after the session is unlocked", async () => {
+    const sessionCall = vi.fn().mockResolvedValue("out");
+    const t = createTestServer({ protected: true, sessionCall });
+    deps = t.deps;
+    await unlockSession(t.server);
+
+    const refused: any = await callTool(t.server, "run_script", { script: 'Write("x");' });
+    expect(refused.isError).toBe(true);
+    expect(JSON.stringify(refused)).toContain("EVERY call");
+    expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "ReGa.runScript")).toBe(false);
+
+    // with its own confirm it runs — and the NEXT call is gated again
+    const ok: any = await callTool(t.server, "run_script", { script: 'Write("x");', confirm: true });
+    expect(ok.isError).toBeFalsy();
+    const again: any = await callTool(t.server, "run_script", { script: 'Write("y");' });
+    expect(again.isError).toBe(true);
+  });
+
+  it("delete_system_variable refuses without confirm even after the session is unlocked", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) =>
+      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : null);
+    const t = createTestServer({ protected: true, sessionCall });
+    deps = t.deps;
+    await unlockSession(t.server);
+
+    const refused: any = await callTool(t.server, "delete_system_variable", { name: "Urlaub" });
+    expect(refused.isError).toBe(true);
+    expect(JSON.stringify(refused)).toContain("EVERY call");
+    expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "SysVar.deleteSysVarByName")).toBe(false);
+
+    const ok: any = await callTool(t.server, "delete_system_variable", { name: "Urlaub", confirm: true });
+    expect(ok.isError).toBeFalsy();
+  });
+
+  it("a confirmed run_script does not unlock the session for typed writes", async () => {
+    const sessionCall = vi.fn().mockResolvedValue("out");
+    const t = createTestServer({ protected: true, sessionCall });
+    deps = t.deps;
+
+    const ok: any = await callTool(t.server, "run_script", { script: 'Write("x");', confirm: true });
+    expect(ok.isError).toBeFalsy();
+
+    const gated: any = await callTool(t.server, "set_value", { address: "ABC:1", valueKey: "STATE", value: true, interface: "X", type: "bool" });
+    expect(gated.isError).toBe(true);
+    expect(JSON.stringify(gated)).toContain("protected");
   });
 });


### PR DESCRIPTION
## ccu-mcp v1.6.0 — multi-CCU targets, service-message fix, protected-write hardening

Full release notes go on the GitHub Release (draft ready). Highlights:

- **Multiple named CCU targets (profiles)** — `CCU_PROFILES` env config, `use_ccu` / `list_ccu_targets` / `get_connection_info` tools, per-call `target` on read tools, `protected`/`readonly` policy flags with confirm-gated writes.
- **`acknowledge_service_messages` actually works now** — `AlConfirm()` → `AlReceipt()` plus HM Script operator-precedence fixes; live round-trip test added. Thanks @mdzio.
- **Per-call confirm for high-impact tools** — `run_script` and `delete_system_variable` never ride on the session unlock.
- **`get_system_info`**: build identification (branch/commit/tag/builtAt) and login role (ADMIN/USER) with graceful N/A for admin-only fields.
- **HTTP hardening**: bounded session map (cap + idle eviction + 503) and rate-limiter queue; shared `runTool` wrapper.
- Docs: multi-profile configuration, per-call confirm exception, tool list (28 tools), `server.json`/compose env references.

Closes #69
Closes #72
Closes #73
Closes #74