### PR TITLE
Release v1.7.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,8 +86,10 @@ MCP_AUTH_TOKEN=
 # the overlap. Applies to the explicit MCP_AUTH_TOKEN path only.
 MCP_AUTH_TOKEN_PREVIOUS=
 # Lifetime of the AUTO-GENERATED token, in days (fractional allowed). Unset =
-# never expires. Past expiry the token auto-rotates on the next startup; the old
-# one stays valid for MCP_AUTH_TOKEN_GRACE_HOURS. Ignored when MCP_AUTH_TOKEN is set.
+# never expires. The server auto-rotates it AT RUNTIME shortly before expiry
+# (new token announced on stderr; also on startup if it expired while down);
+# the old one stays valid for MCP_AUTH_TOKEN_GRACE_HOURS. Ignored when
+# MCP_AUTH_TOKEN is set.
 MCP_AUTH_TOKEN_TTL_DAYS=
 # Overlap (hours) after an auto-rotation during which the just-replaced token is
 # still accepted, so in-flight clients survive the swap. Default 24.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions current (Dependabot bumps the pin +
+  # the version comment together, so pinning doesn't rot).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  # npm deps: security + version updates against the committed lockfile.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      # Third-party actions pinned to a commit SHA (supply-chain hardening):
+      # a retargeted mutable tag can't inject code into CI. Dependabot bumps
+      # the SHA + comment together.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "npm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
-## v1.7.0 — Unreleased
+## v1.7.0 — 2026-07-04
 
 Execution-safety audit release: seven adversarial review rounds plus two
 fresh-context regression rounds over the whole codebase (~100 verified fixes),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,18 @@ instead of looping through re-login.
 
 **Miscellaneous.**
 
+- The HTTP MCP endpoint is served on `/` (and `/mcp`) only; unknown paths now
+  return 404 instead of answering the full protocol. Point clients at the
+  bare server URL as documented.
+- A persisted CCU session is only restored when the configured credentials
+  still match (session.json carries a credential hash) — after a password
+  change the server does a fresh login instead of silently renewing the old
+  session forever. Existing session files trigger one fresh login after
+  upgrade.
+- `set_system_variable` verifies bool/float/enum writes found their target
+  (one extra read per write): the CCU's setters report success even for a
+  variable deleted moments earlier.
+
 - Device-type cache format is v2 (enum `valueList` is now a proper label
   array); the old cache is discarded and re-warmed once after upgrade.
 - `list_devices` with both `room` and `function` filters as AND (was OR).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,155 @@
+# Changelog
+
+All notable changes to ccu-mcp are documented here. Each release is a tag
+`vX.Y.Z` on `main`.
+
+## v1.7.0 — Unreleased
+
+Execution-safety audit release: seven adversarial review rounds plus two
+fresh-context regression rounds over the whole codebase (~100 verified fixes),
+validated live against a production debmatic CCU (398/398 tests) and an
+OpenCCU QA VM. CCU behavior was verified against the OCCU TCL sources, not
+assumptions.
+
+### Behavior changes (read before upgrading)
+
+**Config validation now fails startup loudly** where it used to silently
+misbehave. Check your env before upgrading:
+
+- `MCP_TRANSPORT` must be exactly `http` or `stdio` (case-insensitive); a typo
+  used to silently select HTTP and hang stdio clients.
+- `CCU_TLS_FINGERPRINT` / `CCU_CA_CERT` / `CCU_TLS_VERIFY` on a profile with
+  `CCU_HTTPS` unset/false is now a startup error — those settings were
+  silently ignored while credentials traveled over plaintext.
+- `CCU_DEFAULT_PROFILE` without `CCU_PROFILES` is now a startup error (it was
+  silently meaningless).
+- Profile names that collide on the same env prefix (`prod-a` / `prod.a` both
+  read `CCU_PROD_A_*`) are now rejected.
+
+**HTTP multi-client isolation.** The active target (`use_ccu`) and the
+protected-target `confirm:true` unlock are now **per MCP session**. One
+client's target switch or confirmation no longer affects any other connected
+client — every client session confirms its own writes against a protected
+target.
+
+**`/health` responses.** Unauthenticated requests get `200 {"status":"ok"}`
+(liveness only). The full `healthy`/`degraded` status with checks requires the
+bearer token — the old pre-auth response told unauthenticated scanners whether
+the configured CCU admin credentials currently work. The Docker HEALTHCHECK is
+unaffected. Update external monitors that keyed on the unauthenticated
+`degraded`/503 signal to send the token.
+
+**Stricter write validation** (errors instead of silent corruption):
+
+- Bool system variables are transmitted as numeric 0/1 — the CCU's `setbool`
+  string-compares `"false" >= 1` lexicographically and stored **true** for
+  `false`. Non-boolean values for bool variables are rejected.
+- Enum (LIST) variables accept a 0-based index or one of the enum's labels;
+  out-of-range or unknown values are rejected (they used to be stored as
+  garbage with a success response). Numeric input is always an index.
+- Numeric (NUMBER) variables reject non-numeric values (the CCU stored 0 and
+  reported success).
+- Enum labels containing `;` (the CCU's value-list separator) are rejected in
+  `create_system_variable`; `min`/`max` magnitudes that stringify to exponent
+  notation are rejected (ReGa cannot parse them).
+
+**ReGa script failures are errors now.** `get_values`,
+`get_service_messages`, `acknowledge_service_messages`,
+`set_system_variable` (string), and `create_system_variable` used to treat
+the CCU's empty/unparseable script output as an empty **success** —
+`get_service_messages` could report "no active alarms" during a script
+failure. All now return a structured `CCU_ERROR`. Same for `execute_program`
+when the CCU answers `false`, and for any CCU list response that is not an
+array.
+
+**Retry semantics.** One-shot ACTION datapoints (`PRESS_SHORT`, `STOP`, …)
+are never auto-retried on timeout (a delivered-but-slow request could fire
+the trigger twice) — including when the device-type cache cannot prove the
+parameter is not an ACTION. MASTER paramset writes always retry. Retry
+attempts now also consume rate-limiter tokens.
+
+**MCP protocol.**
+
+- Requests with an unknown/expired `Mcp-Session-Id` get the spec-mandated
+  `404 Session not found` (was `400`, which clients treated as fatal and never
+  re-initialized after idle eviction or a server restart).
+- `resources/subscribe` and `resources/unsubscribe` are implemented (per MCP
+  session, unknown URIs rejected); content changes are announced via
+  `notifications/resources/updated` to subscribers. The semantically wrong
+  `list_changed` broadcast for content changes is gone.
+- Request bodies over 4 MB are refused with `413`.
+- Sessions with an open SSE stream are not idle-evicted; half-open dead
+  streams are detected via TCP keep-alive.
+
+**Auth token lifecycle.** With `MCP_AUTH_TOKEN_TTL_DAYS` set, the
+auto-generated token now rotates **at runtime** (it used to rotate only at
+startup, so a server whose uptime passed the TTL locked out all clients until
+a manual restart). Rotation and recovery honor the grace overlap; the token
+`.env` file preserves operator-added lines on rewrite.
+
+**Error categories.** A pinned-certificate mismatch surfaces as a dedicated,
+non-retriable `TLS_ERROR` with the mismatch detail (it used to collapse into
+a retried, generic `UNREACHABLE: fetch failed`). Network errors include the
+underlying cause. A CCU login failure surfaces as `AUTH` with a hint covering
+both possible causes (wrong credentials / too many sessions); a
+privilege-denied call on a valid session reports the missing privilege level
+instead of looping through re-login.
+
+**Miscellaneous.**
+
+- Device-type cache format is v2 (enum `valueList` is now a proper label
+  array); the old cache is discarded and re-warmed once after upgrade.
+- `list_devices` with both `room` and `function` filters as AND (was OR).
+- `put_paramset` resolves parameter types against the paramset being written
+  (MASTER params were typed against the VALUES schema).
+- All read tools accept the per-call `target` argument; the `help` tool now
+  documents `target` and `confirm` accurately.
+- stdio mode shuts down gracefully on stdin EOF (logs out the CCU session and
+  saves caches; it used to leak the session when the client closed the pipe).
+- The default DNS-rebinding host allowlist includes `[::1]:<port>`; the
+  README documents that `MCP_ALLOWED_HOSTS` is required for remote clients.
+- `parseValue` preserves numeric strings that would lose precision as
+  strings; values keep exact round-trips.
+- Node.js ≥ 24 (documented; `engines` already required it).
+
+### Added
+
+- `resources/subscribe` / `unsubscribe` with `notifications/resources/updated`
+  (all CCU-backed list resources are change-polled, including
+  `homematic://interfaces`).
+- Runtime auth-token rotation with grace overlap and unwritable-data-dir
+  recovery.
+- `TLS_ERROR` error category.
+- Per-call `target` argument on the remaining read tools
+  (`list_rooms`, `list_functions`, `list_interfaces`, `list_programs`,
+  `list_system_variables`, `list_links`, `get_rssi`,
+  `get_service_messages`, `get_system_info`).
+
+### Fixed
+
+Roughly 100 verified defects across seven audit rounds — highlights beyond
+the behavior changes above:
+
+- Writing plain bool system variables was impossible (the CCU reports type
+  `LOGIC`; the code matched `BOOL`).
+- Privilege-denied calls leaked CCU sessions via doomed re-login+retry loops
+  (contributing to "too many sessions").
+- Idle-evicted HTTP clients could never reconnect without a server restart.
+- A TTL'd auth token caused a permanent 401 lockout once uptime passed the
+  TTL.
+- Multiple shutdown races (in-flight login resurrecting a session after
+  logout, rate-limited calls firing into a closing session, force-exit
+  preempting `Session.logout`).
+- Docker: the image now contains build info; HEALTHCHECK honors `MCP_PORT`
+  and native TLS; the README Docker flow works as written
+  (`docker build` step, `MCP_ALLOWED_HOSTS`).
+- HM-script JSON emitters escape control characters (a newline in a channel
+  name or string datapoint no longer breaks `get_values` /
+  `get_service_messages` for the whole result).
+- Device-type cache: TTL staleness honored (stale caches re-warm on
+  `use_ccu`), concurrent disk writes serialized, enum `valueList` tokenized
+  from the CCU's TCL list format.
+
+## v1.6.0 and earlier
+
+See the git tags and GitHub release notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,14 @@ instead of looping through re-login.
 - `set_system_variable` verifies bool/float/enum writes found their target
   (one extra read per write): the CCU's setters report success even for a
   variable deleted moments earlier.
+- `get_values` now returns datapoint values as native types (bool/number/
+  null/string) like the single `get_value` and `get_paramset` do — previously
+  the bulk read handed back the raw quoted strings the HM-script emits
+  (`"true"`, `"19.000000"`), so the same datapoint read two ways gave
+  different types.
+- The CCU-backed resources (`homematic://devices`, `rooms`, …) surface a
+  malformed/`null` CCU result as an error like the sibling `list_*` tools,
+  instead of serving a subscriber the literal text `"null"`.
 
 - Device-type cache format is v2 (enum `valueList` is now a proper label
   array); the old cache is discarded and re-warmed once after upgrade.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,8 @@ instead of looping through re-login.
   return 404 instead of answering the full protocol. Point clients at the
   bare server URL as documented.
 - A persisted CCU session is only restored when the configured credentials
-  still match (session.json carries a credential hash) — after a password
+  still match (session.json carries a salted scrypt credential verifier) —
+  after a password
   change the server does a fresh login instead of silently renewing the old
   session forever. Existing session files trigger one fresh login after
   upgrade.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,12 @@ COPY package*.json ./
 RUN npm ci
 COPY tsconfig.json ./
 COPY src/ ./src/
-RUN npx tsc
+COPY scripts/ ./scripts/
+# Full build (tsc + build-info stamp). No .git in the build context ⇒ the git
+# fields are null, but dist/build-info.json exists with builtAt, so
+# get_system_info's `build` block works in the image instead of silently
+# reporting nothing. Pass real values by building from a git checkout in CI.
+RUN npm run build
 
 FROM node:24-alpine
 WORKDIR /app
@@ -18,6 +23,8 @@ VOLUME /data
 ENV CACHE_DIR=/data
 USER app
 EXPOSE 3000
+# Honors MCP_PORT and native TLS (self-signed): try HTTP first, fall back to
+# HTTPS with certificate checking off (it's a loopback liveness probe).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD wget -qO- http://localhost:3000/health | grep -q '"status"' || exit 1
+  CMD sh -c 'wget -qO- "http://localhost:${MCP_PORT:-3000}/health" 2>/dev/null | grep -q "\"status\"" || wget -qO- --no-check-certificate "https://localhost:${MCP_PORT:-3000}/health" 2>/dev/null | grep -q "\"status\"" || exit 1'
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The MCP server handles device discovery, type resolution, session management, an
 
 - A running HomeMatic CCU (debmatic, CCU3, or OpenCCU — formerly RaspberryMatic) reachable on your network
 - The CCU's admin username and password (the same credentials you use to log into the WebUI)
-- Node.js 22+ (for running from source or stdio mode) or Docker
+- Node.js 24+ (for running from source or stdio mode) or Docker
 
 ## Quick start
 
@@ -84,14 +84,24 @@ Use this if you want the server running independently — for example on a home 
 **1. Start the container:**
 
 ```bash
+git clone https://github.com/claymore666/ccu-mcp.git && cd ccu-mcp
+docker build -t ccu-mcp .
 docker run -d \
   --name ccu-mcp \
   -e CCU_HOST=your-ccu-hostname-or-ip \
   -e CCU_PASSWORD=your-ccu-admin-password \
+  -e MCP_ALLOWED_HOSTS=your-server-ip:3000 \
   -v ccu-data:/data \
   -p 3000:3000 \
   ccu-mcp
 ```
+
+> **`MCP_ALLOWED_HOSTS` is required for remote clients.** The server's
+> DNS-rebinding protection rejects any request whose `Host` header isn't on
+> the allowlist — by default only `localhost`/`127.0.0.1`/`[::1]` on the MCP
+> port. Set it to every name/IP clients will use to reach the server
+> (comma-separated, `host:port`). Without it, the local health check works
+> but every remote MCP request gets **403 Invalid Host header**.
 
 **2. Get the auth token.** The server generates a random bearer token on first startup and saves it inside the container's data volume. You need this token to authenticate your MCP client. Grab it with:
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,12 @@ This has been tested against a production debmatic installation with:
 
 Other device types should work too — the server queries the CCU for parameter descriptions rather than maintaining a static device database.
 
+## Changelog
+
+Release notes — including **behavior changes to check before upgrading**
+(stricter config validation, `/health` response shape, per-session write
+confirmation, retry semantics) — live in [CHANGELOG.md](CHANGELOG.md).
+
 ## Related projects
 
 - [OpenCCU](https://github.com/OpenCCU/OpenCCU) — community-maintained, cloud-free CCU firmware for Raspberry Pi, x86/ARM, and CCU3/ELV-Charly hardware (formerly **RaspberryMatic**; built on the OCCU framework)

--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ curl http://localhost:3000/health
 
 By default the HTTP server sends **no** CORS headers, so a random web page can't drive a local instance. To let browser-based MCP clients like [MCP Inspector](https://github.com/modelcontextprotocol/inspector) connect directly, set `MCP_ALLOWED_ORIGINS` to a comma-separated allowlist of trusted origins (e.g. `https://app.example,http://localhost:6274`). A request whose `Origin` is on the list gets that **exact** origin reflected in `Access-Control-Allow-Origin` — never the wildcard `*`, which would let any site drive a local instance that controls real CCU hardware. A request from any other origin gets no CORS headers (the browser blocks it) and is rejected server-side by DNS-rebinding protection. Authentication is always enforced regardless: every MCP request needs the bearer token.
 
-The HTTP transport also has **DNS-rebinding protection** on by default: it rejects requests whose `Host` header isn't `localhost`/`127.0.0.1` on the configured port. If you reach the server under another hostname (reverse proxy, container DNS name), list those hosts in `MCP_ALLOWED_HOSTS` or legitimate requests get a `403`.
+The HTTP transport also has **DNS-rebinding protection** on by default: it rejects requests whose `Host` header isn't `localhost`/`127.0.0.1`/`[::1]` on the configured port. If you reach the server under another hostname or IP (reverse proxy, container DNS name, the server's LAN address), list those hosts in `MCP_ALLOWED_HOSTS` or legitimate requests get a `403`.
 
 **TLS.** The bearer token travels in the request, so anything beyond loopback should be encrypted. You have two options: terminate TLS at a reverse proxy (Caddy/nginx) in front and bind the server to loopback (`MCP_HOST=127.0.0.1`), or let the server serve HTTPS itself by setting `MCP_TLS_CERT` and `MCP_TLS_KEY` to a PEM cert/key pair. Plain HTTP is still fully supported — it stays the zero-config default — but the server logs a warning at startup when it's serving the token over unencrypted HTTP on a non-loopback bind; set `MCP_ALLOW_PLAINTEXT=true` to acknowledge that and silence it.
 
 **Token rotation & expiry.** By default the bearer token lives forever. Two optional, composable controls let you rotate it without dropping clients:
 
-- *Auto-generated token* — set `MCP_AUTH_TOKEN_TTL_DAYS` (fractional days allowed) to give the generated token a lifetime. Once it lapses, the server mints a fresh one **on the next startup** and prints it on stderr, while the just-replaced token keeps validating for `MCP_AUTH_TOKEN_GRACE_HOURS` (default 24) so in-flight clients survive the swap. Expiry is also enforced live: a lapsed token is rejected mid-run with a `401` + `WWW-Authenticate: Bearer … error="invalid_token"`. To force a rotation sooner, delete `$CACHE_DIR/.env` (or just its `MCP_AUTH_TOKEN` line) and restart.
+- *Auto-generated token* — set `MCP_AUTH_TOKEN_TTL_DAYS` (fractional days allowed) to give the generated token a lifetime. The server rotates it **automatically at runtime** shortly before it lapses (no restart needed; also on startup if it expired while the server was down), prints the new token on stderr, and keeps the just-replaced token validating for `MCP_AUTH_TOKEN_GRACE_HOURS` (default 24) so in-flight clients survive the swap. To force a rotation sooner, delete `$CACHE_DIR/.env` (or just its `MCP_AUTH_TOKEN` line) and restart.
 - *Explicit token* — when you set `MCP_AUTH_TOKEN` yourself, you own its lifetime (TTL doesn't apply). To rotate, put the new token in `MCP_AUTH_TOKEN`, move the old one to `MCP_AUTH_TOKEN_PREVIOUS`, and restart; both are accepted during the overlap. Drop `MCP_AUTH_TOKEN_PREVIOUS` and restart once every client is on the new token. Comparison stays timing-safe across every currently-valid token.
 
 **Brute-force protection (fail2ban).** The auto-generated token is 256 bits of randomness, so guessing it is infeasible. If you set `MCP_AUTH_TOKEN` yourself, **make it long and random** (e.g. `openssl rand -base64 32`) — a short or guessable token is the one case brute force matters. The server does **not** rate-limit or lock out failed logins in-process; that job belongs to a firewall-level tool like [fail2ban](https://www.fail2ban.org/), which bans the source IP before the request ever reaches the server. To make that easy, every rejected request logs a structured line to stderr:
@@ -207,10 +207,10 @@ All configuration is via environment variables:
 | `MCP_PORT` | `3000` | HTTP server port (HTTP mode only) |
 | `MCP_AUTH_TOKEN` | auto-generated | Bearer token for HTTP mode; generated and saved to `$CACHE_DIR/.env` on first start |
 | `MCP_AUTH_TOKEN_PREVIOUS` | unset | Previous bearer token, accepted alongside `MCP_AUTH_TOKEN` during a rotation overlap; remove it (and restart) to end the overlap. Explicit-token path only |
-| `MCP_AUTH_TOKEN_TTL_DAYS` | unset (never expires) | Lifetime of the **auto-generated** token, in days (fractional allowed). Past expiry it auto-rotates on next startup; ignored when `MCP_AUTH_TOKEN` is set |
+| `MCP_AUTH_TOKEN_TTL_DAYS` | unset (never expires) | Lifetime of the **auto-generated** token, in days (fractional allowed). The server auto-rotates it at runtime shortly before expiry (new token announced on stderr); ignored when `MCP_AUTH_TOKEN` is set |
 | `MCP_AUTH_TOKEN_GRACE_HOURS` | `24` | Overlap (hours) after an auto-rotation during which the just-replaced token is still accepted |
 | `MCP_ALLOWED_ORIGINS` | unset | Comma-separated allowlist of browser origins. Unset = no cross-origin browser access (default-deny). An allowlisted origin is reflected exactly in `Access-Control-Allow-Origin` (never `*`); the list also drives DNS-rebinding origin checks |
-| `MCP_ALLOWED_HOSTS` | `localhost`/`127.0.0.1` | Extra `Host` values accepted by DNS-rebinding protection (comma-separated `host:port`); add your hostname when behind a proxy or container DNS name |
+| `MCP_ALLOWED_HOSTS` | `localhost`/`127.0.0.1`/`[::1]` on the MCP port | Extra `Host` values accepted by DNS-rebinding protection (comma-separated `host:port`); add every name/IP clients use to reach the server (proxy, container DNS name, plain server IP) |
 | `MCP_HOST` | unset (all interfaces) | Bind address for the HTTP listener; set `127.0.0.1` to restrict to loopback (e.g. behind a TLS-terminating proxy), which also silences the plaintext warning |
 | `MCP_TLS_CERT` / `MCP_TLS_KEY` | unset | PEM cert/key paths. Set **both** to serve MCP over HTTPS natively; leave unset for plain HTTP. Setting only one is a configuration error |
 | `MCP_ALLOW_PLAINTEXT` | `false` | Set `true` to acknowledge serving the bearer token over plain HTTP and silence the non-loopback plaintext warning |
@@ -309,7 +309,7 @@ Besides tools, the server exposes MCP **resources** — browsable JSON snapshots
 
 `homematic://devices`, `homematic://rooms`, `homematic://functions`, `homematic://programs`, `homematic://sysvars`, `homematic://interfaces`, `homematic://device-types`, `homematic://system`
 
-The server polls the CCU in the background (every `RESOURCE_POLL_INTERVAL` seconds) and notifies connected clients when the device list changes.
+The server polls the CCU in the background (every `RESOURCE_POLL_INTERVAL` seconds) and sends `notifications/resources/updated` for resources whose content changed — to clients that subscribed to them via `resources/subscribe`.
 
 It also ships MCP **prompts** — ready-made workflows you can invoke from clients that support them (e.g. as slash commands in Claude Code):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.6.0",
+  "version": "1.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -262,12 +262,15 @@ export async function resolveAuthTokens(
       state.issued = now;
       changed = true;
     } else if (now + lookaheadMs - state.issued >= ttlMs) {
-      // Expired → rotate. Keep the old token valid for the grace overlap.
+      // Expired → rotate. Keep the old token valid for the grace overlap —
+      // and never SHORTER than its promised hard expiry: a lookahead-triggered
+      // early rotation with a grace smaller than the tick interval must not
+      // cut the token off before issued+ttl.
       state = {
         token: randomBytes(32).toString("base64url"),
         issued: now,
         previous: state.token,
-        previousExpires: now + graceMs,
+        previousExpires: Math.max(now + graceMs, state.issued + ttlMs),
       };
       changed = true;
       minted = true;

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -73,6 +73,12 @@ export interface ResolveAuthTokensOptions {
   ttlMs?: number;
   /** Overlap after an auto-rotation during which the just-replaced token still validates. */
   graceMs: number;
+  /**
+   * Announce a freshly-minted token even when persisting it FAILED. True for
+   * startup (an in-memory token beats none); rotation ticks pass false so a
+   * broken data dir doesn't announce a new never-persisted token every tick.
+   */
+  announceUnpersisted?: boolean;
 }
 
 /** Persisted shape of the auto-generated token file. */
@@ -235,8 +241,9 @@ export async function resolveAuthTokens(
     changed = true;
   }
 
+  let saved = true;
   if (changed) {
-    const saved = await persist(dataDir, state, logger);
+    saved = await persist(dataDir, state, logger);
     if (!saved && rotated) {
       // A rotation that can't be persisted must not take effect: the next
       // check would re-read the unchanged file and rotate AGAIN, minting and
@@ -251,7 +258,9 @@ export async function resolveAuthTokens(
       rotated = false;
     }
   }
-  if (minted) announce(state.token!, dataDir, rotated);
+  if (minted && (saved || opts.announceUnpersisted !== false)) {
+    announce(state.token!, dataDir, rotated);
+  }
 
   const entries: TokenEntry[] = [
     {
@@ -289,22 +298,31 @@ export function startAutoRotation(
   logger: Logger,
   intervalMs: number = ROTATION_CHECK_INTERVAL_MS,
 ): () => void {
+  const hasPersistedToken = async (): Promise<boolean> => {
+    try {
+      return Boolean(parsePersisted(await readFile(join(opts.dataDir, ENV_FILENAME), "utf-8")).token);
+    } catch {
+      return false;
+    }
+  };
   const tick = (): void => {
     void (async () => {
-      // Only rotate what is actually PERSISTED. If the startup generation
-      // could not be saved (unwritable data dir), a tick would re-read the
-      // empty state and generate + announce a brand-new token, invalidating
-      // the startup-announced one — every interval. Skipping keeps the
-      // in-memory token stable; auth_token_save_failed already flagged the
-      // root cause.
-      try {
-        const persisted = parsePersisted(await readFile(join(opts.dataDir, ENV_FILENAME), "utf-8"));
-        if (!persisted.token) return;
-      } catch {
-        return; // nothing persisted → nothing to rotate
+      // Only ADOPT what ends up persisted. If the startup save failed
+      // (unwritable data dir), blindly adopting each tick's resolve would
+      // mint + announce a brand-new token every interval, 401ing the
+      // previous one. Announce is suppressed for unpersisted mints, and the
+      // in-memory startup token stays valid until the data dir is fixed —
+      // at which point the resolve below persists a fresh token, announces
+      // it, and rotation resumes without a restart.
+      const hadPersisted = await hasPersistedToken();
+      const fresh = await resolveAuthTokens(
+        { ...opts, announceUnpersisted: false },
+        logger,
+        Date.now() + intervalMs,
+      );
+      if (hadPersisted || (await hasPersistedToken())) {
+        tokens.replaceWith(fresh);
       }
-      const fresh = await resolveAuthTokens(opts, logger, Date.now() + intervalMs);
-      tokens.replaceWith(fresh);
     })().catch((err: unknown) => {
       logger.error("auth_token_rotation_failed", { error: (err as Error).message });
     });

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -37,6 +37,22 @@ export class AuthTokens {
   }
 
   /**
+   * Adopt a freshly-resolved set while keeping the CURRENT tokens valid for a
+   * grace window. Used when persistence recovers after a broken data dir: the
+   * in-memory startup token clients were given must not 401 instantly — it
+   * gets the same overlap a normal rotation grants the outgoing token.
+   */
+  adoptWithGrace(other: AuthTokens, graceMs: number, now: number = Date.now()): void {
+    const cutoff = now + graceMs;
+    const graced = this.entries.map((e) => ({
+      ...e,
+      expiresAt: e.expiresAt === null ? cutoff : Math.min(e.expiresAt, cutoff),
+      label: `${e.label}-graced`,
+    }));
+    this.entries = [...other.entries, ...graced];
+  }
+
+  /**
    * Timing-safe check of a presented token against every entry. Compares against
    * ALL entries (no early return) so neither a match nor expiry leaks via timing,
    * preserving the original single-token guarantee across the rotation set.
@@ -320,8 +336,13 @@ export function startAutoRotation(
         logger,
         Date.now() + intervalMs,
       );
-      if (hadPersisted || (await hasPersistedToken())) {
+      if (hadPersisted) {
         tokens.replaceWith(fresh);
+      } else if (await hasPersistedToken()) {
+        // Persistence just recovered: the newly persisted token replaces the
+        // unpersisted in-memory one, but clients holding the old one get the
+        // usual grace overlap instead of an instant 401.
+        tokens.adoptWithGrace(fresh, opts.graceMs);
       }
     })().catch((err: unknown) => {
       logger.error("auth_token_rotation_failed", { error: (err as Error).message });

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -182,12 +182,18 @@ async function persist(dataDir: string, state: PersistedToken, logger: Logger): 
   }
 }
 
-function announce(token: string, dataDir: string, rotated: boolean): void {
+function announce(token: string, dataDir: string, rotated: boolean, saved: boolean): void {
   const envPath = join(dataDir, ENV_FILENAME);
   const what = rotated ? "Rotated auth token" : "Generated auth token";
   // stderr so the operator can copy it; never goes through the structured logger.
   process.stderr.write(`\n[ccu-mcp] ${what}: ${token}\n`);
-  process.stderr.write(`[ccu-mcp] Token saved to ${envPath}\n`);
+  if (saved) {
+    process.stderr.write(`[ccu-mcp] Token saved to ${envPath}\n`);
+  } else {
+    process.stderr.write(
+      `[ccu-mcp] WARNING: the token could NOT be saved to ${envPath} — it is valid for this run only. Fix the data dir permissions.\n`,
+    );
+  }
   process.stderr.write(`[ccu-mcp] Use this token in your MCP client configuration.\n\n`);
 }
 
@@ -200,15 +206,22 @@ function announce(token: string, dataDir: string, rotated: boolean): void {
  *     rotation overlap; the operator ends the overlap by dropping it + restart.
  *     TTL does not apply to operator-supplied tokens — the operator owns them.
  *  2. The auto-generated token persisted under `dataDir/.env`. With `ttlMs` set
- *     it carries an issued-at; once it lapses we rotate on startup: a fresh
- *     token is generated and the just-replaced one stays valid for `graceMs`
- *     so in-flight clients aren't cut off mid-migration.
+ *     it carries an issued-at; once it lapses we rotate (at startup and via
+ *     the runtime rotation ticks): a fresh token is generated and the
+ *     just-replaced one stays valid for `graceMs` so in-flight clients aren't
+ *     cut off mid-migration.
  *  3. If neither exists, generate and persist a new token.
+ *
+ * `lookaheadMs` advances ONLY the TTL-expiry decision (rotate slightly early
+ * so there is no 401 window between hard expiry and the next tick). Pruning
+ * and timestamp stamping always use the REAL clock — a skewed prune clock
+ * could drop the outgoing token before its promised grace end.
  */
 export async function resolveAuthTokens(
   opts: ResolveAuthTokensOptions,
   logger: Logger,
   now: number = Date.now(),
+  lookaheadMs: number = 0,
 ): Promise<AuthTokens> {
   // 1. Explicit env token(s) — operator-managed, no TTL, file untouched.
   if (opts.envToken) {
@@ -248,7 +261,7 @@ export async function resolveAuthTokens(
       // expiring a token whose true age we can't know.
       state.issued = now;
       changed = true;
-    } else if (now - state.issued >= ttlMs) {
+    } else if (now + lookaheadMs - state.issued >= ttlMs) {
       // Expired → rotate. Keep the old token valid for the grace overlap.
       state = {
         token: randomBytes(32).toString("base64url"),
@@ -292,7 +305,7 @@ export async function resolveAuthTokens(
     }
   }
   if (minted && (saved || opts.announceUnpersisted !== false)) {
-    announce(state.token!, dataDir, rotated);
+    announce(state.token!, dataDir, rotated, saved);
   }
 
   const entries: TokenEntry[] = [
@@ -346,12 +359,15 @@ export function startAutoRotation(
       // previous one. Announce is suppressed for unpersisted mints, and the
       // in-memory startup token stays valid until the data dir is fixed —
       // at which point the resolve below persists a fresh token, announces
-      // it, and rotation resumes without a restart.
+      // it, and rotation resumes without a restart. The interval is passed
+      // as LOOKAHEAD (rotate-early decision only); pruning uses the real
+      // clock so a short grace window is never cut off by the skew.
       const hadPersisted = await hasPersistedToken();
       const fresh = await resolveAuthTokens(
         { ...opts, announceUnpersisted: false },
         logger,
-        Date.now() + intervalMs,
+        Date.now(),
+        intervalMs,
       );
       if (hadPersisted) {
         tokens.replaceWith(fresh);

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -242,7 +242,10 @@ export async function resolveAuthTokens(
       // check would re-read the unchanged file and rotate AGAIN, minting and
       // announcing a fresh token every interval (each invalidating the last).
       // Keep the pre-rotation state; auth_token_save_failed points the
-      // operator at the real problem (unwritable data dir).
+      // operator at the real problem (unwritable data dir). Deliberate
+      // trade-off: once the old token's hard expiry passes, verify() rejects
+      // everything until the data dir is fixed — a deterministic, logged
+      // lockout beats silently churning through announced tokens.
       state = preRotationState;
       minted = false;
       rotated = false;
@@ -287,11 +290,24 @@ export function startAutoRotation(
   intervalMs: number = ROTATION_CHECK_INTERVAL_MS,
 ): () => void {
   const tick = (): void => {
-    resolveAuthTokens(opts, logger, Date.now() + intervalMs)
-      .then((fresh) => tokens.replaceWith(fresh))
-      .catch((err: unknown) => {
-        logger.error("auth_token_rotation_failed", { error: (err as Error).message });
-      });
+    void (async () => {
+      // Only rotate what is actually PERSISTED. If the startup generation
+      // could not be saved (unwritable data dir), a tick would re-read the
+      // empty state and generate + announce a brand-new token, invalidating
+      // the startup-announced one — every interval. Skipping keeps the
+      // in-memory token stable; auth_token_save_failed already flagged the
+      // root cause.
+      try {
+        const persisted = parsePersisted(await readFile(join(opts.dataDir, ENV_FILENAME), "utf-8"));
+        if (!persisted.token) return;
+      } catch {
+        return; // nothing persisted → nothing to rotate
+      }
+      const fresh = await resolveAuthTokens(opts, logger, Date.now() + intervalMs);
+      tokens.replaceWith(fresh);
+    })().catch((err: unknown) => {
+      logger.error("auth_token_rotation_failed", { error: (err as Error).message });
+    });
   };
   // Run once immediately: a token expiring within the FIRST interval after
   // startup would otherwise 401 until the first timer tick (the startup

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -117,7 +117,7 @@ function serialize(state: PersistedToken): string {
 // belongs to the operator and must survive a rewrite.
 const MANAGED_KEY_RE = /^MCP_AUTH_TOKEN(_ISSUED|_PREVIOUS|_PREVIOUS_EXPIRES)?=/;
 
-async function persist(dataDir: string, state: PersistedToken, logger: Logger): Promise<void> {
+async function persist(dataDir: string, state: PersistedToken, logger: Logger): Promise<boolean> {
   const envPath = join(dataDir, ENV_FILENAME);
   try {
     await mkdir(dataDir, { recursive: true });
@@ -136,8 +136,10 @@ async function persist(dataDir: string, state: PersistedToken, logger: Logger): 
     // 0600: file contains the bearer token(s) for the HTTP transport
     await writeFile(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
     await rename(tmpPath, envPath);
+    return true;
   } catch (err) {
     logger.error("auth_token_save_failed", { error: (err as Error).message });
+    return false;
   }
 }
 
@@ -193,6 +195,7 @@ export async function resolveAuthTokens(
   let changed = false;
   let minted = false; // brand-new token this run (generate or rotate) → announce
   let rotated = false;
+  const preRotationState: PersistedToken = { ...state };
 
   if (!state.token) {
     // 3. No usable token — generate.
@@ -232,7 +235,19 @@ export async function resolveAuthTokens(
     changed = true;
   }
 
-  if (changed) await persist(dataDir, state, logger);
+  if (changed) {
+    const saved = await persist(dataDir, state, logger);
+    if (!saved && rotated) {
+      // A rotation that can't be persisted must not take effect: the next
+      // check would re-read the unchanged file and rotate AGAIN, minting and
+      // announcing a fresh token every interval (each invalidating the last).
+      // Keep the pre-rotation state; auth_token_save_failed points the
+      // operator at the real problem (unwritable data dir).
+      state = preRotationState;
+      minted = false;
+      rotated = false;
+    }
+  }
   if (minted) announce(state.token!, dataDir, rotated);
 
   const entries: TokenEntry[] = [
@@ -271,13 +286,18 @@ export function startAutoRotation(
   logger: Logger,
   intervalMs: number = ROTATION_CHECK_INTERVAL_MS,
 ): () => void {
-  const timer = setInterval(() => {
+  const tick = (): void => {
     resolveAuthTokens(opts, logger, Date.now() + intervalMs)
       .then((fresh) => tokens.replaceWith(fresh))
       .catch((err: unknown) => {
         logger.error("auth_token_rotation_failed", { error: (err as Error).message });
       });
-  }, intervalMs);
+  };
+  // Run once immediately: a token expiring within the FIRST interval after
+  // startup would otherwise 401 until the first timer tick (the startup
+  // resolve has no lookahead).
+  tick();
+  const timer = setInterval(tick, intervalMs);
   timer.unref();
   return () => clearInterval(timer);
 }

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -31,9 +31,21 @@ export class AuthTokens {
    * Swap in the entries of a freshly-resolved set. Used by runtime rotation:
    * requests hold a reference to ONE AuthTokens instance, so rotation must
    * mutate it in place rather than build a new object nobody consults.
+   *
+   * In-memory graced entries (from adoptWithGrace) survive the swap until
+   * their own expiry — they exist ONLY in memory, so rebuilding from the
+   * persisted file alone would cut the promised grace short at the very next
+   * rotation tick.
    */
-  replaceWith(other: AuthTokens): void {
-    this.entries = other.entries;
+  replaceWith(other: AuthTokens, now: number = Date.now()): void {
+    const keptGraced = this.entries.filter(
+      (e) =>
+        e.label.endsWith("-graced") &&
+        e.expiresAt !== null &&
+        now <= e.expiresAt &&
+        !other.entries.some((o) => o.hash.equals(e.hash)),
+    );
+    this.entries = [...other.entries, ...keptGraced];
   }
 
   /**
@@ -41,14 +53,19 @@ export class AuthTokens {
    * grace window. Used when persistence recovers after a broken data dir: the
    * in-memory startup token clients were given must not 401 instantly — it
    * gets the same overlap a normal rotation grants the outgoing token.
+   * Expired entries are pruned and duplicates skipped, so repeated recoveries
+   * can't grow the set (and per-request verify cost) without bound.
    */
   adoptWithGrace(other: AuthTokens, graceMs: number, now: number = Date.now()): void {
     const cutoff = now + graceMs;
-    const graced = this.entries.map((e) => ({
-      ...e,
-      expiresAt: e.expiresAt === null ? cutoff : Math.min(e.expiresAt, cutoff),
-      label: `${e.label}-graced`,
-    }));
+    const graced = this.entries
+      .filter((e) => e.expiresAt === null || now <= e.expiresAt)
+      .filter((e) => !other.entries.some((o) => o.hash.equals(e.hash)))
+      .map((e) => ({
+        ...e,
+        expiresAt: e.expiresAt === null ? cutoff : Math.min(e.expiresAt, cutoff),
+        label: e.label.endsWith("-graced") ? e.label : `${e.label}-graced`,
+      }));
     this.entries = [...other.entries, ...graced];
   }
 

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -25,7 +25,16 @@ interface TokenEntry {
  * lapses — no restart or background timer needed.
  */
 export class AuthTokens {
-  constructor(private readonly entries: TokenEntry[]) {}
+  constructor(private entries: TokenEntry[]) {}
+
+  /**
+   * Swap in the entries of a freshly-resolved set. Used by runtime rotation:
+   * requests hold a reference to ONE AuthTokens instance, so rotation must
+   * mutate it in place rather than build a new object nobody consults.
+   */
+  replaceWith(other: AuthTokens): void {
+    this.entries = other.entries;
+  }
 
   /**
    * Timing-safe check of a presented token against every entry. Compares against
@@ -104,13 +113,28 @@ function serialize(state: PersistedToken): string {
   return lines.join("\n") + "\n";
 }
 
+// The keys this module owns inside the .env file. Everything else in the file
+// belongs to the operator and must survive a rewrite.
+const MANAGED_KEY_RE = /^MCP_AUTH_TOKEN(_ISSUED|_PREVIOUS|_PREVIOUS_EXPIRES)?=/;
+
 async function persist(dataDir: string, state: PersistedToken, logger: Logger): Promise<void> {
   const envPath = join(dataDir, ENV_FILENAME);
   try {
     await mkdir(dataDir, { recursive: true });
+    // Preserve operator-added lines (it's a normal dotenv file and the announce
+    // message points operators at it) — only the managed token keys are replaced.
+    let foreign: string[] = [];
+    try {
+      foreign = (await readFile(envPath, "utf-8"))
+        .split(/\r?\n/)
+        .filter((line) => line.trim() !== "" && !MANAGED_KEY_RE.test(line));
+    } catch {
+      // No existing file — nothing to preserve.
+    }
+    const content = serialize(state) + (foreign.length > 0 ? foreign.join("\n") + "\n" : "");
     const tmpPath = envPath + ".tmp";
     // 0600: file contains the bearer token(s) for the HTTP transport
-    await writeFile(tmpPath, serialize(state), { encoding: "utf-8", mode: 0o600 });
+    await writeFile(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
     await rename(tmpPath, envPath);
   } catch (err) {
     logger.error("auth_token_save_failed", { error: (err as Error).message });
@@ -226,4 +250,34 @@ export async function resolveAuthTokens(
     });
   }
   return new AuthTokens(entries);
+}
+
+const ROTATION_CHECK_INTERVAL_MS = 5 * 60_000;
+
+/**
+ * Keep the auto-generated token rotating while the server RUNS. `verify()`
+ * enforces expiry live, but without this the replacement token would only be
+ * minted at the next restart — a server up past the TTL would 401 every client
+ * permanently. Re-resolves the persisted state periodically; the `now`
+ * lookahead of one interval rotates just BEFORE the hard expiry, so there is
+ * no 401 window (the outgoing token stays valid through the grace overlap).
+ *
+ * Only meaningful for the file-backed token path with a TTL; do not call for
+ * operator-managed env tokens. Returns a stop function for shutdown.
+ */
+export function startAutoRotation(
+  tokens: AuthTokens,
+  opts: ResolveAuthTokensOptions,
+  logger: Logger,
+  intervalMs: number = ROTATION_CHECK_INTERVAL_MS,
+): () => void {
+  const timer = setInterval(() => {
+    resolveAuthTokens(opts, logger, Date.now() + intervalMs)
+      .then((fresh) => tokens.replaceWith(fresh))
+      .catch((err: unknown) => {
+        logger.error("auth_token_rotation_failed", { error: (err as Error).message });
+      });
+  }, intervalMs);
+  timer.unref();
+  return () => clearInterval(timer);
 }

--- a/src/cache/device-type-cache.ts
+++ b/src/cache/device-type-cache.ts
@@ -5,6 +5,7 @@ import type { RateLimiter } from "../middleware/rate-limiter.js";
 import type { Logger } from "../logger.js";
 import type { CachedDeviceType, CachedParamDescription, DeviceTypeCacheFile } from "./types.js";
 import { CACHE_VERSION } from "./types.js";
+import { expectArray } from "../utils.js";
 
 const DEFAULT_CACHE_FILENAME = "device-type-cache.json";
 
@@ -179,7 +180,9 @@ export class DeviceTypeCache {
 
       // Get all interfaces
       await rateLimiter.acquire();
-      const interfaces = await session.call("Interface.listInterfaces") as Array<{ name: string }>;
+      const interfaces = expectArray<{ name: string }>(
+        await session.call("Interface.listInterfaces"), "Interface.listInterfaces",
+      );
 
       // Get all devices per interface
       const devicesByType = new Map<string, { interface: string; address: string; channels: string[] }>();
@@ -188,7 +191,9 @@ export class DeviceTypeCache {
         await rateLimiter.acquire();
         let devices: Array<{ type: string; address: string; children?: string[]; parent?: string }>;
         try {
-          devices = await session.call("Interface.listDevices", { interface: iface.name }) as typeof devices;
+          devices = expectArray(
+            await session.call("Interface.listDevices", { interface: iface.name }), "Interface.listDevices",
+          );
         } catch {
           this.logger.warn("cache_warm_interface_skip", { interface: iface.name });
           continue;

--- a/src/cache/device-type-cache.ts
+++ b/src/cache/device-type-cache.ts
@@ -13,8 +13,41 @@ const WARM_CONCURRENCY = 3;
 
 type RawParamDesc = {
   ID: string; TYPE: string; OPERATIONS: string;
-  MIN?: string; MAX?: string; DEFAULT?: string; UNIT?: string; VALUE_LIST?: string[];
+  MIN?: string; MAX?: string; DEFAULT?: string; UNIT?: string; VALUE_LIST?: string[] | string;
 };
+
+/**
+ * getparamsetdescription.tcl pushes VALUE_LIST through json_toString, which
+ * serializes the TCL list as ONE space-joined string, brace-wrapping entries
+ * that contain spaces ('{Party Mode} Off'). Tokenize it back into labels so
+ * enum indexes line up with the real value list.
+ */
+function parseTclList(input: string): string[] {
+  const items: string[] = [];
+  let i = 0;
+  while (i < input.length) {
+    while (input[i] === " ") i++;
+    if (i >= input.length) break;
+    if (input[i] === "{") {
+      let depth = 1;
+      let j = i + 1;
+      const start = j;
+      while (j < input.length && depth > 0) {
+        if (input[j] === "{") depth++;
+        else if (input[j] === "}") depth--;
+        j++;
+      }
+      items.push(input.slice(start, depth === 0 ? j - 1 : j));
+      i = j;
+    } else {
+      let j = i;
+      while (j < input.length && input[j] !== " ") j++;
+      items.push(input.slice(i, j));
+      i = j;
+    }
+  }
+  return items;
+}
 
 function parseParamDescriptions(descArray: RawParamDesc[]): Record<string, CachedParamDescription> {
   const params: Record<string, CachedParamDescription> = {};
@@ -26,7 +59,9 @@ function parseParamDescriptions(descArray: RawParamDesc[]): Record<string, Cache
       ...(p.MAX !== undefined && { max: Number(p.MAX) }),
       ...(p.DEFAULT !== undefined && { default: p.DEFAULT }),
       ...(p.UNIT && { unit: p.UNIT }),
-      ...(p.VALUE_LIST && { valueList: p.VALUE_LIST }),
+      ...(p.VALUE_LIST && {
+        valueList: Array.isArray(p.VALUE_LIST) ? p.VALUE_LIST : parseTclList(p.VALUE_LIST),
+      }),
     };
   }
   return params;

--- a/src/cache/device-type-cache.ts
+++ b/src/cache/device-type-cache.ts
@@ -40,6 +40,12 @@ export class DeviceTypeCache {
   private readonly fileName: string;
   private warming = false;
   private inflightQueries = new Map<string, Promise<CachedDeviceType | undefined>>();
+  // True until a load proves fresh or a warm completes: expired-on-disk data is
+  // still loaded as a fallback, but callers can see it needs a refresh.
+  private stale = true;
+  // Serializes saveToDisk calls: concurrent saves share one fixed .tmp path, so
+  // interleaved write/rename pairs could drop a save or keep the older snapshot.
+  private savePromise: Promise<void> = Promise.resolve();
 
   constructor(cacheDir: string, ttl: number, logger: Logger, fileName?: string) {
     this.cacheDir = cacheDir;
@@ -82,6 +88,7 @@ export class DeviceTypeCache {
       const expired = age > this.ttl;
 
       this.cache = new Map(Object.entries(parsed.types));
+      this.stale = expired;
       this.logger.info("cache_loaded", { types: this.cache.size, age_seconds: Math.round(age), expired });
 
       return !expired;
@@ -91,8 +98,15 @@ export class DeviceTypeCache {
     }
   }
 
-  /** Atomic write: serialize → tmp file → rename */
-  async saveToDisk(): Promise<void> {
+  /** Atomic write: serialize → tmp file → rename. Calls are queued so two
+   *  concurrent saves (background warm + a live-query save) can't interleave
+   *  on the shared .tmp path. */
+  saveToDisk(): Promise<void> {
+    this.savePromise = this.savePromise.then(() => this.doSaveToDisk());
+    return this.savePromise;
+  }
+
+  private async doSaveToDisk(): Promise<void> {
     const filePath = join(this.cacheDir, this.fileName);
     const tmpPath = filePath + ".tmp";
 
@@ -223,6 +237,7 @@ export class DeviceTypeCache {
       await Promise.all(workers);
 
       await this.saveToDisk();
+      this.stale = false;
 
       const duration = Date.now() - start;
       this.logger.info("cache_warm_done", { types: this.cache.size, duration_ms: duration });
@@ -297,5 +312,10 @@ export class DeviceTypeCache {
 
   isWarming(): boolean {
     return this.warming;
+  }
+
+  /** True when the cached schemas are older than the TTL (or never loaded). */
+  isStale(): boolean {
+    return this.stale;
   }
 }

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -25,4 +25,7 @@ export interface CachedParamDescription {
   valueList?: string[];
 }
 
-export const CACHE_VERSION = 1;
+// v2: valueList changed shape — pre-v2 caches stored the raw TCL-list string
+// ("AUTO MANU {Party Mode}") instead of tokenized labels; the bump discards
+// them so stale enum shapes are never served from disk.
+export const CACHE_VERSION = 2;

--- a/src/ccu/client.ts
+++ b/src/ccu/client.ts
@@ -25,8 +25,11 @@ export class CcuClient {
     if (config.https) {
       this.dispatcher = new Agent({
         connect: this.buildConnect(config, logger),
+        // pipelining: 0 also disables HTTP keep-alive in undici — every
+        // request gets a fresh connection (and, with the pinning connector's
+        // maxCachedSessions: 0, a full TLS handshake). Deliberate: the cert
+        // must be present to pin on every connection.
         pipelining: 0,
-        keepAliveTimeout: 1000,
       });
     }
   }
@@ -138,8 +141,11 @@ export class CcuClient {
       if (err instanceof CcuError) throw err;
 
       const duration = Date.now() - start;
-      this.logger.error("ccu_request_failed", { method, duration_ms: duration, error: (err as Error).message });
-      throw new CcuError(mapNetworkError(err as Error, method));
+      // Log the MAPPED message: it unwraps undici's generic "fetch failed"
+      // wrapper to the real cause (TLS pin mismatch, ECONNREFUSED, ...).
+      const structured = mapNetworkError(err as Error, method);
+      this.logger.error("ccu_request_failed", { method, duration_ms: duration, error: structured.message });
+      throw new CcuError(structured);
     }
 
     const duration = Date.now() - start;

--- a/src/ccu/client.ts
+++ b/src/ccu/client.ts
@@ -99,13 +99,13 @@ export class CcuClient {
 
     const start = Date.now();
     let response: CcuRpcResponse;
+    let httpStatus = 0;
 
     try {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), effectiveTimeout);
 
       let text: string;
-      let httpStatus = 0;
       try {
         const httpResponse = await undiciFetch(this.baseUrl, {
           method: "POST",
@@ -147,6 +147,20 @@ export class CcuClient {
     if (response.error) {
       this.logger.debug("ccu_response_error", { method, duration_ms: duration, code: response.error.code });
       throw new CcuError(mapCcuError(response.error, method));
+    }
+
+    // A non-2xx status whose body parses as JSON but carries no CCU error object
+    // is NOT a CCU response (reverse proxy / gateway error page). Treating it as
+    // success would make write tools report success for a request that never
+    // reached the CCU.
+    if (httpStatus < 200 || httpStatus >= 300) {
+      throw new CcuError({
+        error: "CCU_ERROR",
+        code: 0,
+        message: `Unexpected HTTP ${httpStatus} from CCU endpoint (no JSON-RPC error in body)`,
+        hint: "The response did not come from the CCU JSON-RPC API — check proxies or the CCU's web server.",
+        ccuMethod: method,
+      });
     }
 
     this.logger.debug("ccu_response_ok", { method, duration_ms: duration });

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -141,11 +141,15 @@ export class SessionManager {
         // The CCU answers 400 "access denied" both for an expired session and
         // for a valid session whose user lacks the method's privilege level.
         // Re-login distinguishes them: if it comes back with the SAME session
-        // id, the session was never invalid — the 400 was a permission denial
-        // and retrying would fail identically.
-        const staleSid = this.sessionId;
+        // id THE FAILED REQUEST USED, that session was never invalid — the 400
+        // was a permission denial and retrying would fail identically. Compare
+        // against the id the request carried (not this.sessionId at catch
+        // time): a concurrent re-login may already have swapped in a new id,
+        // and then the right move is to retry with it, not to report a
+        // privilege problem.
+        const usedSid = paramsWithSession._session_id_;
         await this.login();
-        if (this.sessionId !== null && this.sessionId === staleSid) {
+        if (this.sessionId !== null && this.sessionId === usedSid) {
           throw new CcuError({
             error: "AUTH",
             code: err.structured.code,

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -19,6 +19,11 @@ export class SessionManager {
   private sessionId: string | null = null;
   private renewTimer: ReturnType<typeof setInterval> | null = null;
   private loginPromise: Promise<void> | null = null;
+  // Set on logout/destroy: an in-flight call failing AUTH after logout must
+  // not lazily re-login — that would mint a CCU session nobody ever logs out,
+  // restart the renewal timer post-destroy, and re-persist a session file
+  // that logout just cleared.
+  private closed = false;
 
   constructor(config: CcuConfig, logger: Logger, cacheDir?: string, sessionFile?: string) {
     this.config = config;
@@ -44,6 +49,14 @@ export class SessionManager {
   }
 
   private async doLogin(): Promise<void> {
+    if (this.closed) {
+      throw new CcuError({
+        error: "AUTH",
+        code: 0,
+        message: "Session manager is closed (server shutting down)",
+        hint: "Retry after the server restarts.",
+      });
+    }
     // Reuse the in-memory session if the CCU still accepts it. This matters
     // when re-login was triggered by a 400 that was really a privilege denial
     // (the session is fine, the user just may not call that method): minting a
@@ -101,6 +114,7 @@ export class SessionManager {
   }
 
   async logout(): Promise<void> {
+    this.closed = true;
     this.stopRenewal();
     if (this.sessionId) {
       try {
@@ -258,6 +272,7 @@ export class SessionManager {
   }
 
   destroy(): void {
+    this.closed = true;
     this.stopRenewal();
   }
 }

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 import type { CcuConfig } from "./types.js";
 import { CcuClient } from "./client.js";
 import { CcuError } from "../middleware/error-mapper.js";
@@ -210,13 +211,28 @@ export class SessionManager {
     return this.sessionId !== null;
   }
 
+  /**
+   * Truncated hash of the credentials that minted the persisted session. A
+   * session must NOT be restored when the configured password changed:
+   * renewals would keep the old session alive indefinitely, so a rotated (or
+   * mistyped) password would never be exercised and rotation wouldn't cut off
+   * access. Truncated to 16 hex chars — the file already holds the session id
+   * (full CCU access) at mode 0600, so this adds no meaningful exposure.
+   */
+  private credHash(): string {
+    return createHash("sha256")
+      .update(`${this.config.user}:${this.config.password}`)
+      .digest("hex")
+      .slice(0, 16);
+  }
+
   private async tryRestoreSession(): Promise<boolean> {
     try {
       const filePath = join(this.cacheDir, this.sessionFile);
       const data = JSON.parse(await readFile(filePath, "utf-8"));
 
       if (data.sessionId && data.host === this.config.host && data.port === this.config.port
-          && data.user === this.config.user) {
+          && data.user === this.config.user && data.cred === this.credHash()) {
         // Test if session is still valid
         try {
           await this.client.call("Session.renew", { _session_id_: data.sessionId });
@@ -245,6 +261,7 @@ export class SessionManager {
         host: this.config.host,
         port: this.config.port,
         user: this.config.user,
+        cred: this.credHash(),
         timestamp: new Date().toISOString(),
       });
       // 0600: the session ID grants full admin access to the CCU

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -44,7 +44,21 @@ export class SessionManager {
   }
 
   private async doLogin(): Promise<void> {
-    // Try to reuse a persisted session first
+    // Reuse the in-memory session if the CCU still accepts it. This matters
+    // when re-login was triggered by a 400 that was really a privilege denial
+    // (the session is fine, the user just may not call that method): minting a
+    // fresh session would leak the old one and drive the CCU toward its
+    // session limit. A dead session is cleared so /health reflects reality.
+    if (this.sessionId) {
+      try {
+        await this.client.call("Session.renew", { _session_id_: this.sessionId });
+        return;
+      } catch {
+        this.sessionId = null;
+      }
+    }
+
+    // Try to reuse a persisted session next
     const restored = await this.tryRestoreSession();
     if (restored) return;
 
@@ -68,6 +82,18 @@ export class SessionManager {
             await new Promise((r) => setTimeout(r, LOGIN_RETRY_DELAY));
             continue;
           }
+          // Out of retries. The CCU returns this single 501 message for BOTH
+          // wrong credentials and session exhaustion (occu login.tcl), so
+          // surface it as an auth problem instead of "CCU internal error. Try
+          // again" — a mistyped password must not read as a transient fault.
+          throw new CcuError({
+            ...err.structured,
+            error: "AUTH",
+            hint:
+              "The CCU reports one error for both invalid credentials and too many sessions. " +
+              "Verify CCU_USER/CCU_PASSWORD first; if they are correct, wait a few minutes " +
+              "for stale CCU sessions to expire and try again.",
+          });
         }
         throw err;
       }
@@ -112,8 +138,26 @@ export class SessionManager {
       return await this.client.call(method, paramsWithSession, timeout);
     } catch (err) {
       if (err instanceof CcuError && err.structured.error === "AUTH") {
-        this.logger.warn("session_expired", { method });
+        // The CCU answers 400 "access denied" both for an expired session and
+        // for a valid session whose user lacks the method's privilege level.
+        // Re-login distinguishes them: if it comes back with the SAME session
+        // id, the session was never invalid — the 400 was a permission denial
+        // and retrying would fail identically.
+        const staleSid = this.sessionId;
         await this.login();
+        if (this.sessionId !== null && this.sessionId === staleSid) {
+          throw new CcuError({
+            error: "AUTH",
+            code: err.structured.code,
+            message: `Access denied for ${method}: the CCU user lacks the required privilege level`,
+            hint:
+              "The session is valid but the configured CCU user may not call this method " +
+              "(e.g. script execution needs an ADMIN-level user). Configure a user with " +
+              "sufficient rights or avoid this tool.",
+            ccuMethod: method,
+          });
+        }
+        this.logger.warn("session_expired", { method });
         const retryParams = { ...params, _session_id_: this.getSessionId() };
         return this.client.call(method, retryParams, timeout);
       }

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { createHash } from "node:crypto";
+import { scryptSync, randomBytes, timingSafeEqual } from "node:crypto";
 import type { CcuConfig } from "./types.js";
 import { CcuClient } from "./client.js";
 import { CcuError } from "../middleware/error-mapper.js";
@@ -212,23 +212,34 @@ export class SessionManager {
   }
 
   /**
-   * Truncated hash of the credentials that minted the persisted session. A
-   * session must NOT be restored when the configured password changed:
-   * renewals would keep the old session alive indefinitely, so a rotated (or
-   * mistyped) password would never be exercised and rotation wouldn't cut off
-   * access. Truncated to 16 hex chars — the file already holds the session id
-   * (full CCU access) at mode 0600, so this adds no meaningful exposure.
+   * A verifier for the credentials that minted the persisted session, so a
+   * restore is refused after the password changed (otherwise renewals keep
+   * the old session alive indefinitely and a rotated/mistyped password is
+   * never exercised).
+   *
+   * Uses scrypt (a slow, salted password KDF) — NOT a fast hash: the session
+   * file is mode 0600 but a leaked copy must not expose the CCU password to
+   * offline brute-force (the password may be reused elsewhere). The user is
+   * length-prefixed so distinct (user, password) pairs can't alias through
+   * the delimiter.
    */
-  private credHash(): string {
-    // Length-prefix the user so distinct (user, password) pairs can never
-    // alias through the delimiter (e.g. "a"/"b:c" vs "a:b"/"c"). Both are
-    // operator config, so this is belt-and-suspenders, not a security
-    // boundary — but an unambiguous credential hash is worth the one line.
+  private credVerifier(saltHex: string): string {
     const { user, password } = this.config;
-    return createHash("sha256")
-      .update(`${user.length}:${user}:${password}`)
-      .digest("hex")
-      .slice(0, 16);
+    const input = `${user.length}:${user}:${password}`;
+    return scryptSync(input, Buffer.from(saltHex, "hex"), 32).toString("hex");
+  }
+
+  /** Timing-safe check of a stored {credSalt, cred} against the current config. */
+  private credMatches(data: { cred?: unknown; credSalt?: unknown }): boolean {
+    if (typeof data.cred !== "string" || typeof data.credSalt !== "string") return false;
+    let expected: Buffer;
+    try {
+      expected = Buffer.from(this.credVerifier(data.credSalt), "hex");
+    } catch {
+      return false; // malformed salt
+    }
+    const stored = Buffer.from(data.cred, "hex");
+    return expected.length === stored.length && timingSafeEqual(expected, stored);
   }
 
   private async tryRestoreSession(): Promise<boolean> {
@@ -237,7 +248,7 @@ export class SessionManager {
       const data = JSON.parse(await readFile(filePath, "utf-8"));
 
       if (data.sessionId && data.host === this.config.host && data.port === this.config.port
-          && data.user === this.config.user && data.cred === this.credHash()) {
+          && data.user === this.config.user && this.credMatches(data)) {
         // Test if session is still valid
         try {
           await this.client.call("Session.renew", { _session_id_: data.sessionId });
@@ -261,12 +272,14 @@ export class SessionManager {
       await mkdir(this.cacheDir, { recursive: true });
       const filePath = join(this.cacheDir, this.sessionFile);
       const tmpPath = filePath + ".tmp";
+      const credSalt = randomBytes(16).toString("hex");
       const data = JSON.stringify({
         sessionId: this.sessionId,
         host: this.config.host,
         port: this.config.port,
         user: this.config.user,
-        cred: this.credHash(),
+        credSalt,
+        cred: this.credVerifier(credSalt),
         timestamp: new Date().toISOString(),
       });
       // 0600: the session ID grants full admin access to the CCU

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -116,6 +116,14 @@ export class SessionManager {
   async logout(): Promise<void> {
     this.closed = true;
     this.stopRenewal();
+    // Let an in-flight login settle: one already past the closed check may
+    // still assign sessionId and restart the renewal timer. Awaiting it here
+    // means the session it minted is logged out below instead of leaked
+    // (counting toward the CCU's "too many sessions").
+    if (this.loginPromise) {
+      await this.loginPromise.catch(() => {});
+      this.stopRenewal();
+    }
     if (this.sessionId) {
       try {
         await this.client.call("Session.logout", { _session_id_: this.sessionId });

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -77,6 +77,17 @@ export class SessionManager {
 
     // Fresh login with retry on "too many sessions"
     for (let attempt = 0; attempt <= LOGIN_MAX_RETRIES; attempt++) {
+      // Re-check between retries: logout() awaits this promise, and a full
+      // retry cycle (~9-12s) would push shutdown past the 10s force-exit,
+      // skipping Session.logout entirely.
+      if (this.closed) {
+        throw new CcuError({
+          error: "AUTH",
+          code: 0,
+          message: "Session manager is closed (server shutting down)",
+          hint: "Retry after the server restarts.",
+        });
+      }
       try {
         const result = await this.client.call("Session.login", {
           username: this.config.user,

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -220,8 +220,13 @@ export class SessionManager {
    * (full CCU access) at mode 0600, so this adds no meaningful exposure.
    */
   private credHash(): string {
+    // Length-prefix the user so distinct (user, password) pairs can never
+    // alias through the delimiter (e.g. "a"/"b:c" vs "a:b"/"c"). Both are
+    // operator config, so this is belt-and-suspenders, not a security
+    // boundary — but an unambiguous credential hash is worth the one line.
+    const { user, password } = this.config;
     return createHash("sha256")
-      .update(`${this.config.user}:${this.config.password}`)
+      .update(`${user.length}:${user}:${password}`)
       .digest("hex")
       .slice(0, 16);
   }

--- a/src/ccu/target-registry.ts
+++ b/src/ccu/target-registry.ts
@@ -8,9 +8,9 @@ import { Resolver } from "../middleware/resolver.js";
 import { DeviceTypeCache } from "../cache/device-type-cache.js";
 import { CcuError } from "../middleware/error-mapper.js";
 
-/** Short-lived sysvar name→type cache (issue #9), now scoped per target. */
+/** Short-lived sysvar name→type(+enum labels) cache (issue #9), scoped per target. */
 export interface SysVarTypeCacheHolder {
-  entry: { ts: number; types: Map<string, string> } | null;
+  entry: { ts: number; types: Map<string, { type: string; valueList?: string }> } | null;
 }
 
 /**
@@ -24,12 +24,6 @@ export interface Target {
   resolver: Resolver;
   deviceTypeCache: DeviceTypeCache;
   sysVarTypeCache: SysVarTypeCacheHolder;
-  /**
-   * Writes to a `protected` target are unlocked for the rest of the session
-   * once the caller confirms once (the "ask once per session" model). Always
-   * false → no effect for non-protected targets.
-   */
-  unlocked: boolean;
 }
 
 // Filesystem-safe, collision-free per-target suffix for cache/session filenames.
@@ -48,14 +42,16 @@ function fileSuffix(name: string): string {
 }
 
 /**
- * Holds every configured CCU target and which one is active. Tools reach the
- * active target via ServerDeps getters; an optional per-call `target` arg routes
- * a single call elsewhere via resolveTarget().
+ * Holds every configured CCU target (shared, process-wide). WHICH target is
+ * active — and which protected targets are unlocked — is per-MCP-session state
+ * and lives in TargetSelection, so in HTTP mode one client's use_ccu/confirm
+ * cannot retarget or de-gate another client's calls.
  */
 export class TargetRegistry {
   private readonly targets = new Map<string, Target>(); // keyed by lowercased name
   private readonly order: string[] = []; // actual names, config order
-  private activeKey: string;
+  /** Lowercased name of the startup-default target. */
+  readonly defaultKey: string;
 
   constructor(config: AppConfig, logger: Logger, cacheDir: string) {
     for (const profile of config.profiles) {
@@ -68,16 +64,16 @@ export class TargetRegistry {
         resolver: new Resolver(),
         deviceTypeCache: new DeviceTypeCache(cacheDir, config.cache.ttl, logger, `device-type-cache${suffix}.json`),
         sysVarTypeCache: { entry: null },
-        unlocked: false,
       };
       this.targets.set(profile.name.toLowerCase(), target);
       this.order.push(profile.name);
     }
-    this.activeKey = config.defaultProfile.toLowerCase();
+    this.defaultKey = config.defaultProfile.toLowerCase();
   }
 
-  get active(): Target {
-    return this.targets.get(this.activeKey)!;
+  /** The startup-default target (process-level consumers: health, poller). */
+  get default(): Target {
+    return this.targets.get(this.defaultKey)!;
   }
 
   getByName(name: string): Target | undefined {
@@ -93,24 +89,14 @@ export class TargetRegistry {
     return this.order.map((n) => this.targets.get(n.toLowerCase())!);
   }
 
-  /** Switch the active target; throws NOT_FOUND on an unknown name. */
-  use(name: string): Target {
-    const t = this.getByName(name);
-    if (!t) {
-      throw new CcuError({
-        error: "NOT_FOUND",
-        code: 0,
-        message: `Unknown CCU target: ${name}`,
-        hint: `Configured targets: ${this.order.join(", ")}. Call list_ccu_targets.`,
-      });
-    }
-    this.activeKey = t.profile.name.toLowerCase();
-    return t;
+  /** All configured target names, config order (for error hints). */
+  names(): string[] {
+    return [...this.order];
   }
 
-  /** Log in the active target (other targets log in lazily on first use). */
-  async loginActive(): Promise<void> {
-    await this.active.session.login();
+  /** Log in the default target (others log in lazily on first use). */
+  async loginDefault(): Promise<void> {
+    await this.default.session.login();
   }
 
   /** Load each target's device-type cache from disk. */
@@ -118,9 +104,9 @@ export class TargetRegistry {
     await Promise.all(this.list().map((t) => t.deviceTypeCache.loadFromDisk()));
   }
 
-  /** Warm only the active target's cache (others warm lazily on first query). */
-  warmActive(rateLimiter: RateLimiter): Promise<void> {
-    const t = this.active;
+  /** Warm only the default target's cache (others warm lazily on switch). */
+  warmDefault(rateLimiter: RateLimiter): Promise<void> {
+    const t = this.default;
     return t.deviceTypeCache.warm(t.session, rateLimiter);
   }
 
@@ -138,12 +124,59 @@ export class TargetRegistry {
 }
 
 /**
- * Resolve the target for a tool call: the optional per-call `target` name, or
- * the active target when omitted. Throws NOT_FOUND for an unknown name.
+ * Per-MCP-session view onto the registry: which target is active for THIS
+ * client, and which protected targets THIS client has unlocked. One instance
+ * per McpServer (stdio has exactly one; HTTP mode one per Mcp-Session-Id), so
+ * neither use_ccu switches nor confirm-unlocks leak across clients.
  */
-export function resolveTarget(targets: TargetRegistry, name?: string): Target {
-  if (!name) return targets.active;
-  const t = targets.getByName(name);
+export class TargetSelection {
+  private activeKey: string;
+  private readonly unlockedKeys = new Set<string>();
+
+  constructor(private readonly registry: TargetRegistry) {
+    this.activeKey = registry.defaultKey;
+  }
+
+  get active(): Target {
+    return this.registry.getByName(this.activeKey)!;
+  }
+
+  /** Switch this session's active target; throws NOT_FOUND on an unknown name. */
+  use(name: string): Target {
+    const t = this.registry.getByName(name);
+    if (!t) {
+      throw new CcuError({
+        error: "NOT_FOUND",
+        code: 0,
+        message: `Unknown CCU target: ${name}`,
+        hint: `Configured targets: ${this.registry.names().join(", ")}. Call list_ccu_targets.`,
+      });
+    }
+    this.activeKey = t.profile.name.toLowerCase();
+    return t;
+  }
+
+  isUnlocked(target: Target): boolean {
+    return this.unlockedKeys.has(target.profile.name.toLowerCase());
+  }
+
+  unlock(target: Target): void {
+    this.unlockedKeys.add(target.profile.name.toLowerCase());
+  }
+
+  /** Lookup a target by name in the shared registry (used by resolveTarget). */
+  registryLookup(name: string): Target | undefined {
+    return this.registry.getByName(name);
+  }
+}
+
+/**
+ * Resolve the target for a tool call: the optional per-call `target` name, or
+ * this session's active target when omitted. Throws NOT_FOUND for an unknown name.
+ */
+export function resolveTarget(selection: TargetSelection, name?: string): Target {
+  if (!name) return selection.active;
+  const t = selection.registryLookup(name);
   if (!t) {
     throw new CcuError({
       error: "NOT_FOUND",
@@ -168,6 +201,7 @@ export function resolveTarget(targets: TargetRegistry, name?: string): Target {
  * was given for a harmless set_value.
  */
 export function assertWritable(
+  selection: TargetSelection,
   target: Target,
   confirm: boolean | undefined,
   opts?: { alwaysConfirm?: boolean },
@@ -192,7 +226,7 @@ export function assertWritable(
     }
     return; // per-call authorization only — never unlocks the session
   }
-  if (!target.unlocked) {
+  if (!selection.isUnlocked(target)) {
     if (confirm !== true) {
       throw new CcuError({
         error: "INVALID_INPUT",
@@ -201,6 +235,6 @@ export function assertWritable(
         hint: "Safety gate on a production CCU. Pass confirm:true to proceed; later writes this session won't need it (except run_script and delete_system_variable, which confirm every call).",
       });
     }
-    target.unlocked = true;
+    selection.unlock(target);
   }
 }

--- a/src/ccu/target-registry.ts
+++ b/src/ccu/target-registry.ts
@@ -11,6 +11,12 @@ import { CcuError } from "../middleware/error-mapper.js";
 /** Short-lived sysvar name→type(+enum labels) cache (issue #9), scoped per target. */
 export interface SysVarTypeCacheHolder {
   entry: { ts: number; types: Map<string, { type: string; valueList?: string }> } | null;
+  /**
+   * Bumped on every invalidation (create/delete). A writer that fetched
+   * SysVar.getAll BEFORE an invalidation must not install its now-stale
+   * snapshot AFTER it — it compares this counter around the await.
+   */
+  gen: number;
 }
 
 /**
@@ -63,7 +69,7 @@ export class TargetRegistry {
         session: new SessionManager(profile.ccu, logger, cacheDir, `session${suffix}.json`),
         resolver: new Resolver(),
         deviceTypeCache: new DeviceTypeCache(cacheDir, config.cache.ttl, logger, `device-type-cache${suffix}.json`),
-        sysVarTypeCache: { entry: null },
+        sysVarTypeCache: { entry: null, gen: 0 },
       };
       this.targets.set(profile.name.toLowerCase(), target);
       this.order.push(profile.name);

--- a/src/ccu/types.ts
+++ b/src/ccu/types.ts
@@ -88,28 +88,34 @@ export interface CcuFunction {
   channelIds: string[];
 }
 
-// CCU program types
+// CCU program types (fields per occu program/getall.tcl — there is NO
+// description field in the response)
 export interface CcuProgram {
   id: string;
   name: string;
-  description: string;
   isActive: boolean;
   isInternal: boolean;
   lastExecuteTime: string;
 }
 
-// CCU system variable types
+// CCU system variable types (fields per occu sysvar/getall.tcl: no
+// description; valueList only for LIST, minValue/maxValue only for NUMBER,
+// valueName0/1 only for LOGIC/ALARM)
 export interface CcuSysVar {
   id: string;
   name: string;
-  description: string;
   type: string;
   value: string;
-  valueList: string;
-  minValue: string;
-  maxValue: string;
   unit: string;
+  channelId: string;
+  isVisible: boolean;
+  isInternal: boolean;
   isLogged: boolean;
+  valueList?: string;
+  minValue?: string;
+  maxValue?: string;
+  valueName0?: string;
+  valueName1?: string;
 }
 
 // CCU interface info

--- a/src/ccu/types.ts
+++ b/src/ccu/types.ts
@@ -27,6 +27,10 @@ export type ErrorCategory =
   | "CCU_ERROR"
   | "TIMEOUT"
   | "UNREACHABLE"
+  // Deterministic TLS verification failure (pin mismatch): deliberately NOT
+  // retriable — re-handshaking with a possibly-MITM'd peer only delays the
+  // security signal.
+  | "TLS_ERROR"
   | "RATE_LIMITED"
   | "INTERNAL";
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,8 @@ export interface AppConfig {
      * Lifetime of the AUTO-GENERATED bearer token in ms (`MCP_AUTH_TOKEN_TTL_DAYS`,
      * fractional days allowed). Unset ⇒ the generated token never expires (the
      * historical default). Does not apply to an explicit `MCP_AUTH_TOKEN`, which
-     * the operator owns. On startup past expiry the token auto-rotates.
+     * the operator owns. The token auto-rotates AT RUNTIME shortly before
+     * expiry (and on startup if it expired while the server was down).
      */
     authTokenTtlMs?: number;
     /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -203,6 +203,14 @@ export function loadConfig(): AppConfig {
   if (!profilesEnv) {
     // Back-compat: no CCU_PROFILES ⇒ one "default" profile from the flat
     // CCU_HOST/CCU_PASSWORD/... vars, with the exact validation as before.
+    // A leftover CCU_DEFAULT_PROFILE would be silently meaningless here — and
+    // writes would target the flat CCU_HOST box while the env file suggests a
+    // named profile — so fail loudly like every other config typo.
+    if (process.env.CCU_DEFAULT_PROFILE?.trim()) {
+      throw new Error(
+        "CCU_DEFAULT_PROFILE is set but CCU_PROFILES is not — either define CCU_PROFILES or remove CCU_DEFAULT_PROFILE",
+      );
+    }
     const host = process.env.CCU_HOST;
     if (!host) throw new Error("CCU_HOST environment variable is required");
     const password = process.env.CCU_PASSWORD;

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,9 +85,15 @@ export interface AppConfig {
 }
 
 export function loadConfig(): AppConfig {
-  // CLI flags override env vars for transport
+  // CLI flags override env vars for transport. Validate the env value: a typo
+  // ("STDIO", "Stdio") must fail loudly, not silently select HTTP and leave a
+  // stdio-spawning client hanging forever.
   const args = process.argv.slice(2);
-  let transport: "http" | "stdio" = (process.env.MCP_TRANSPORT as "http" | "stdio") || "http";
+  const transportEnv = process.env.MCP_TRANSPORT?.trim().toLowerCase();
+  if (transportEnv && transportEnv !== "http" && transportEnv !== "stdio") {
+    throw new Error(`MCP_TRANSPORT must be "http" or "stdio", got: "${process.env.MCP_TRANSPORT}"`);
+  }
+  let transport: "http" | "stdio" = (transportEnv as "http" | "stdio" | undefined) || "http";
   if (args.includes("--stdio")) transport = "stdio";
   if (args.includes("--http")) transport = "http";
 
@@ -120,6 +126,11 @@ export function loadConfig(): AppConfig {
   const allowedHosts = [
     `127.0.0.1:${mcpPort}`,
     `localhost:${mcpPort}`,
+    // IPv6 loopback: a client connecting to http://[::1]:port sends the
+    // bracketed literal in the Host header, and the SDK's check is an exact
+    // string match — without this entry the documented MCP_HOST=::1 setup
+    // would 403 every request.
+    `[::1]:${mcpPort}`,
     ...(process.env.MCP_ALLOWED_HOSTS || "")
       .split(",")
       .map((h) => h.trim())
@@ -218,10 +229,22 @@ export function loadConfig(): AppConfig {
     const names = profilesEnv.split(",").map((s) => s.trim()).filter(Boolean);
     if (names.length === 0) throw new Error("CCU_PROFILES is set but lists no profile names");
     const seen = new Set<string>();
+    // Distinct names can still collide on the sanitized env prefix
+    // ("prod-a" and "prod.a" both read CCU_PROD_A_*), which would silently
+    // configure two "different" targets from the same variables.
+    const seenPrefix = new Map<string, string>();
     for (const n of names) {
       const key = n.toLowerCase();
       if (seen.has(key)) throw new Error(`CCU_PROFILES lists "${n}" more than once`);
       seen.add(key);
+      const prefix = n.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+      const clash = seenPrefix.get(prefix);
+      if (clash) {
+        throw new Error(
+          `CCU_PROFILES names "${clash}" and "${n}" both map to the same env prefix CCU_${prefix}_* — rename one`,
+        );
+      }
+      seenPrefix.set(prefix, n);
     }
     profiles = names.map(buildProfile);
     const requested = process.env.CCU_DEFAULT_PROFILE?.trim();
@@ -234,6 +257,19 @@ export function loadConfig(): AppConfig {
     defaultProfile = match.name;
   }
 
+  // TLS settings on a plain-HTTP target are a contradiction: the pinning /
+  // verification code path is only built for HTTPS, so the operator would
+  // believe the connection is verified while credentials travel in cleartext.
+  // Fail fast instead of silently ignoring the settings.
+  for (const p of profiles) {
+    if (!p.ccu.https && (p.ccu.tlsFingerprint || p.ccu.caCert || p.ccu.tlsVerify)) {
+      throw new Error(
+        `CCU profile "${p.name}": TLS_FINGERPRINT/CA_CERT/TLS_VERIFY is set but HTTPS is disabled — ` +
+        `these settings only apply over HTTPS. Set ${p.name === "default" ? "CCU_HTTPS" : `CCU_${p.name.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_HTTPS`}=true or remove them.`,
+      );
+    }
+  }
+
   const defaultCcu = profiles.find((p) => p.name === defaultProfile)!.ccu;
 
   return {
@@ -243,7 +279,10 @@ export function loadConfig(): AppConfig {
     mcp: {
       transport,
       port: mcpPort,
-      authToken: process.env.MCP_AUTH_TOKEN,
+      // trim: a trailing space/CR (CRLF env file, quoted systemd Environment=)
+      // would otherwise be hashed into the expected token and 401 every client;
+      // MCP_AUTH_TOKEN_PREVIOUS and file-parsed tokens are already trimmed.
+      authToken: process.env.MCP_AUTH_TOKEN?.trim() || undefined,
       authTokenPrevious: process.env.MCP_AUTH_TOKEN_PREVIOUS?.trim() || undefined,
       authTokenTtlMs: parseDurationEnv("MCP_AUTH_TOKEN_TTL_DAYS", 86_400_000),
       authTokenGraceMs: parseDurationEnv("MCP_AUTH_TOKEN_GRACE_HOURS", 3_600_000) ?? 24 * 3_600_000,

--- a/src/health/handler.ts
+++ b/src/health/handler.ts
@@ -7,7 +7,16 @@ export interface HealthDeps {
   deviceTypeCache: DeviceTypeCache;
 }
 
-export function handleHealthRequest(req: IncomingMessage, res: ServerResponse, deps: HealthDeps): void {
+export function handleHealthRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: HealthDeps,
+  // Detailed checks only for authenticated callers: pre-auth, session_valid
+  // would tell an unauthenticated scanner whether the configured CCU admin
+  // credentials currently work (and fingerprint the service). Status alone
+  // is all an uptime monitor needs.
+  detailed: boolean = false,
+): void {
   const { session, deviceTypeCache } = deps;
 
   const checks = {
@@ -21,5 +30,5 @@ export function handleHealthRequest(req: IncomingMessage, res: ServerResponse, d
   const httpStatus = status === "healthy" ? 200 : 503;
 
   res.writeHead(httpStatus, { "Content-Type": "application/json" });
-  res.end(JSON.stringify({ status, checks }));
+  res.end(JSON.stringify(detailed ? { status, checks } : { status }));
 }

--- a/src/health/handler.ts
+++ b/src/health/handler.ts
@@ -19,6 +19,15 @@ export function handleHealthRequest(
 ): void {
   const { session, deviceTypeCache } = deps;
 
+  if (!detailed) {
+    // Liveness only. healthy/degraded (and 200/503) is a pure function of
+    // session_valid, so exposing it pre-auth would still tell any scanner
+    // whether the configured CCU admin credentials currently work.
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok" }));
+    return;
+  }
+
   const checks = {
     server: "up" as const,
     session_valid: session.isLoggedIn(),
@@ -30,5 +39,5 @@ export function handleHealthRequest(
   const httpStatus = status === "healthy" ? 200 : 503;
 
   res.writeHead(httpStatus, { "Content-Type": "application/json" });
-  res.end(JSON.stringify(detailed ? { status, checks } : { status }));
+  res.end(JSON.stringify({ status, checks }));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { TargetRegistry, TargetSelection } from "./ccu/target-registry.js";
 import { ResourcePoller } from "./resources/poller.js";
 import { resolveAuthTokens, startAutoRotation } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
-import { createMcpServer, type ServerDeps } from "./server.js";
+import { createMcpServer, serverSubscriptions, type ServerDeps } from "./server.js";
 import { extractBearerToken, normalizeClientIp } from "./utils.js";
 
 async function main(): Promise<void> {
@@ -92,7 +92,12 @@ async function main(): Promise<void> {
     const transport = new StdioServerTransport();
     await mcpServer.connect(transport);
     poller = new ResourcePoller(
-      () => mcpServer.server.sendResourceListChanged(),
+      async (changedUris) => {
+        const subs = serverSubscriptions.get(mcpServer);
+        for (const uri of changedUris) {
+          if (subs?.has(uri)) await mcpServer.server.sendResourceUpdated({ uri });
+        }
+      },
       () => stdioDeps.selection.active.session, rateLimiter, logger, config.resourcePollInterval,
     );
     poller.start();
@@ -369,9 +374,14 @@ async function main(): Promise<void> {
     }
 
     poller = new ResourcePoller(
-      async () => {
+      async (changedUris) => {
         await Promise.allSettled(
-          [...sessions.values()].map((s) => s.server.server.sendResourceListChanged()),
+          [...sessions.values()].flatMap((s) => {
+            const subs = serverSubscriptions.get(s.server);
+            return changedUris
+              .filter((uri) => subs?.has(uri))
+              .map((uri) => s.server.server.sendResourceUpdated({ uri }));
+          }),
         );
       },
       () => targets.default.session, rateLimiter, logger, config.resourcePollInterval,

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,7 @@ async function main(): Promise<void> {
     // authenticated client must still not grow this without bound.
     const MAX_SESSIONS = 256;
     const SESSION_IDLE_MS = 30 * 60_000; // 30 min without a request → reclaim
+    const MAX_BODY_BYTES = 4 * 1024 * 1024; // JSON-RPC messages are tiny; 4 MB is generous
     const sessions = new Map<
       string,
       { server: McpServer; transport: StreamableHTTPServerTransport; lastSeen: number; openStreams: number }
@@ -194,8 +195,9 @@ async function main(): Promise<void> {
           return;
         }
 
-        // Health check endpoint
-        if (req.url === "/health" && req.method === "GET") {
+        // Health check endpoint (tolerate cache-busting query strings that
+        // uptime monitors append — req.url includes the query part)
+        if ((req.url === "/health" || req.url?.startsWith("/health?")) && req.method === "GET") {
           handleHealthRequest(req, res, { session: targets.default.session, deviceTypeCache: targets.default.deviceTypeCache });
           return;
         }
@@ -232,6 +234,18 @@ async function main(): Promise<void> {
           return;
         }
 
+        // Body size cap: the SDK transport buffers the whole JSON body with no
+        // limit of its own, so an authenticated client could otherwise balloon
+        // the heap with one multi-GB POST. Content-Length covers every normal
+        // client; a chunked-encoding bypass requires a hostile valid-token
+        // holder, which is outside the threat model.
+        const contentLength = Number(req.headers["content-length"]);
+        if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+          res.writeHead(413, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Request body too large" }));
+          return;
+        }
+
         // Existing session: route to its transport (POST, GET/SSE, DELETE) and
         // mark it active so the idle sweep doesn't reclaim a session in use.
         const sessionId = req.headers["mcp-session-id"];
@@ -253,6 +267,22 @@ async function main(): Promise<void> {
             });
           }
           await existing.transport.handleRequest(req, res);
+          return;
+        }
+
+        // A request that CARRIES a session id we don't know (idle-evicted or
+        // pre-restart) must get 404 "Session not found" — the MCP spec's cue
+        // for the client to re-initialize. Routing it into a fresh transport
+        // would answer 400 "Server not initialized", which clients treat as a
+        // hard error and never recover from (and would waste a McpServer
+        // construction per request).
+        if (typeof sessionId === "string") {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32001, message: "Session not found" },
+            id: null,
+          }));
           return;
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,12 +85,15 @@ async function main(): Promise<void> {
   let httpServer: HttpServer | HttpsServer | null = null;
 
   if (config.mcp.transport === "stdio") {
-    const mcpServer = createMcpServer(makeDeps());
+    // stdio has exactly one MCP session; the poller follows ITS selection so a
+    // use_ccu switch moves change-detection along with the resource reads.
+    const stdioDeps = makeDeps();
+    const mcpServer = createMcpServer(stdioDeps);
     const transport = new StdioServerTransport();
     await mcpServer.connect(transport);
     poller = new ResourcePoller(
       () => mcpServer.server.sendResourceListChanged(),
-      () => targets.default.session, rateLimiter, logger, config.resourcePollInterval,
+      () => stdioDeps.selection.active.session, rateLimiter, logger, config.resourcePollInterval,
     );
     poller.start();
     closeTransports = () => mcpServer.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,9 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { loadConfig } from "./config.js";
 import { createLogger } from "./logger.js";
 import { RateLimiter } from "./middleware/rate-limiter.js";
-import { TargetRegistry } from "./ccu/target-registry.js";
+import { TargetRegistry, TargetSelection } from "./ccu/target-registry.js";
 import { ResourcePoller } from "./resources/poller.js";
-import { resolveAuthTokens } from "./auth/token.js";
+import { resolveAuthTokens, startAutoRotation } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
 import { createMcpServer, type ServerDeps } from "./server.js";
 import { extractBearerToken, normalizeClientIp } from "./utils.js";
@@ -46,7 +46,7 @@ async function main(): Promise<void> {
   // it start before the CCU is reachable. Only the active target logs in eagerly;
   // others log in lazily on first use / switch.
   try {
-    await targets.loginActive();
+    await targets.loginDefault();
   } catch (err) {
     logger.warn("startup_degraded", {
       error: (err as Error).message,
@@ -54,23 +54,30 @@ async function main(): Promise<void> {
     });
   }
 
-  // Load each target's device-type cache; warm only the active one in background.
+  // Load each target's device-type cache; warm only the default one in background.
   await targets.loadCaches();
-  targets.warmActive(rateLimiter).catch((err) => {
+  targets.warmDefault(rateLimiter).catch((err) => {
     logger.error("cache_warm_background_error", { error: (err as Error).message });
   });
 
-  // Shared tool dependencies. session/resolver/deviceTypeCache are getters that
-  // resolve to the ACTIVE target each access, so a use_ccu() switch is picked up
-  // by the next tool call without touching tools that read deps.session etc.
-  const deps: ServerDeps = {
-    config,
-    targets,
-    get session() { return targets.active.session; },
-    get resolver() { return targets.active.resolver; },
-    get deviceTypeCache() { return targets.active.deviceTypeCache; },
-    rateLimiter,
-    logger,
+  // Per-MCP-session tool dependencies: each McpServer gets its OWN
+  // TargetSelection (active-target pointer + protected-target unlocks), so in
+  // HTTP mode one client's use_ccu/confirm can't affect another client.
+  // session/resolver/deviceTypeCache are getters that resolve to the
+  // selection's active target on each access, so a use_ccu() switch is picked
+  // up by the next tool call without touching tools that read deps.session etc.
+  const makeDeps = (): ServerDeps => {
+    const selection = new TargetSelection(targets);
+    return {
+      config,
+      targets,
+      selection,
+      get session() { return selection.active.session; },
+      get resolver() { return selection.active.resolver; },
+      get deviceTypeCache() { return selection.active.deviceTypeCache; },
+      rateLimiter,
+      logger,
+    };
   };
 
   let poller: ResourcePoller;
@@ -78,12 +85,12 @@ async function main(): Promise<void> {
   let httpServer: HttpServer | HttpsServer | null = null;
 
   if (config.mcp.transport === "stdio") {
-    const mcpServer = createMcpServer(deps);
+    const mcpServer = createMcpServer(makeDeps());
     const transport = new StdioServerTransport();
     await mcpServer.connect(transport);
     poller = new ResourcePoller(
       () => mcpServer.server.sendResourceListChanged(),
-      () => targets.active.session, rateLimiter, logger, config.resourcePollInterval,
+      () => targets.default.session, rateLimiter, logger, config.resourcePollInterval,
     );
     poller.start();
     closeTransports = () => mcpServer.close();
@@ -93,16 +100,21 @@ async function main(): Promise<void> {
     // A stateless StreamableHTTPServerTransport only survives a single request,
     // so each MCP session gets its own transport + server (deps are shared),
     // routed by the Mcp-Session-Id header per the SDK's session pattern.
-    const authTokens = await resolveAuthTokens(
-      {
-        envToken: config.mcp.authToken,
-        envPreviousToken: config.mcp.authTokenPrevious,
-        dataDir: config.cache.dir,
-        ttlMs: config.mcp.authTokenTtlMs,
-        graceMs: config.mcp.authTokenGraceMs,
-      },
-      logger,
-    );
+    const authTokenOpts = {
+      envToken: config.mcp.authToken,
+      envPreviousToken: config.mcp.authTokenPrevious,
+      dataDir: config.cache.dir,
+      ttlMs: config.mcp.authTokenTtlMs,
+      graceMs: config.mcp.authTokenGraceMs,
+    };
+    const authTokens = await resolveAuthTokens(authTokenOpts, logger);
+    // With a TTL on the auto-generated token, rotation must also happen while
+    // the server RUNS — verify() enforces expiry live, and a long-running
+    // process would otherwise lock every client out until a manual restart.
+    const stopTokenRotation =
+      !config.mcp.authToken && config.mcp.authTokenTtlMs !== undefined
+        ? startAutoRotation(authTokens, authTokenOpts, logger)
+        : null;
     // Bound the session map. Each MCP session pins a McpServer + transport that
     // is removed only on transport.onclose (explicit DELETE / clean teardown).
     // A client that initializes then drops its connection — or reconnects in a
@@ -114,15 +126,18 @@ async function main(): Promise<void> {
     const SESSION_IDLE_MS = 30 * 60_000; // 30 min without a request → reclaim
     const sessions = new Map<
       string,
-      { server: McpServer; transport: StreamableHTTPServerTransport; lastSeen: number }
+      { server: McpServer; transport: StreamableHTTPServerTransport; lastSeen: number; openStreams: number }
     >();
 
     // Reclaim sessions whose last request predates `cutoff`. Returns how many
     // were evicted. Shared by the periodic sweep and the at-capacity fast path.
+    // A session with an open SSE stream is NOT idle even without new POSTs —
+    // it is passively receiving notifications — so it is never reclaimed while
+    // the stream is up (openStreams drops to 0 when the connection closes).
     const evictIdleSessions = (cutoff: number): number => {
       let evicted = 0;
       for (const [sid, s] of sessions) {
-        if (s.lastSeen < cutoff) {
+        if (s.lastSeen < cutoff && s.openStreams === 0) {
           sessions.delete(sid);
           s.server.close().catch(() => {});
           evicted++;
@@ -178,7 +193,7 @@ async function main(): Promise<void> {
 
         // Health check endpoint
         if (req.url === "/health" && req.method === "GET") {
-          handleHealthRequest(req, res, { session: targets.active.session, deviceTypeCache: targets.active.deviceTypeCache });
+          handleHealthRequest(req, res, { session: targets.default.session, deviceTypeCache: targets.default.deviceTypeCache });
           return;
         }
 
@@ -220,6 +235,15 @@ async function main(): Promise<void> {
         const existing = typeof sessionId === "string" ? sessions.get(sessionId) : undefined;
         if (existing) {
           existing.lastSeen = Date.now();
+          if (req.method === "GET") {
+            // GET opens the long-lived SSE notification stream; hold the
+            // session out of idle eviction until the connection closes.
+            existing.openStreams++;
+            res.on("close", () => {
+              existing.openStreams--;
+              existing.lastSeen = Date.now();
+            });
+          }
           await existing.transport.handleRequest(req, res);
           return;
         }
@@ -254,7 +278,7 @@ async function main(): Promise<void> {
           allowedHosts: config.mcp.allowedHosts,
           allowedOrigins: config.mcp.allowedOrigins,
           onsessioninitialized: (sid) => {
-            sessions.set(sid, { server: sessionServer, transport, lastSeen: Date.now() });
+            sessions.set(sid, { server: sessionServer, transport, lastSeen: Date.now(), openStreams: 0 });
             logger.info("mcp_session_started", { sessions: sessions.size });
           },
         });
@@ -263,7 +287,7 @@ async function main(): Promise<void> {
             logger.info("mcp_session_closed", { sessions: sessions.size });
           }
         };
-        const sessionServer = createMcpServer(deps);
+        const sessionServer = createMcpServer(makeDeps());
         await sessionServer.connect(transport);
         await transport.handleRequest(req, res);
       } catch (err) {
@@ -312,11 +336,12 @@ async function main(): Promise<void> {
           [...sessions.values()].map((s) => s.server.server.sendResourceListChanged()),
         );
       },
-      () => targets.active.session, rateLimiter, logger, config.resourcePollInterval,
+      () => targets.default.session, rateLimiter, logger, config.resourcePollInterval,
     );
     poller.start();
     closeTransports = async () => {
       clearInterval(idleSweep);
+      stopTokenRotation?.();
       await Promise.allSettled([...sessions.values()].map((s) => s.server.close()));
       sessions.clear();
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,9 +202,16 @@ async function main(): Promise<void> {
           return;
         }
 
+        // Path routing: MCP is served on the root path only (README points
+        // clients at the bare URL; "/mcp" accepted as a common convention).
+        // Without this, the full protocol answered on ANY path, and a typo'd
+        // path surfaced as a misleading Accept/initialization error instead
+        // of 404.
+        const path = (req.url ?? "/").split("?")[0];
+
         // Health check endpoint (tolerate cache-busting query strings that
-        // uptime monitors append — req.url includes the query part)
-        if ((req.url === "/health" || req.url?.startsWith("/health?")) && req.method === "GET") {
+        // uptime monitors append)
+        if (path === "/health" && req.method === "GET") {
           const detailed = authTokens.verify(extractBearerToken(req.headers.authorization ?? ""));
           handleHealthRequest(req, res, { session: targets.default.session, deviceTypeCache: targets.default.deviceTypeCache }, detailed);
           return;
@@ -239,6 +246,13 @@ async function main(): Promise<void> {
             "WWW-Authenticate": challenge,
           });
           res.end(JSON.stringify({ error: "Unauthorized" }));
+          return;
+        }
+
+        // Unknown paths are 404 — not the MCP endpoint.
+        if (path !== "/" && path !== "/mcp") {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Not found" }));
           return;
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,14 +437,18 @@ async function main(): Promise<void> {
   process.on("SIGINT", () => shutdown("SIGINT"));
 
   // stdio: the client usually terminates by closing the pipe (stdin EOF),
-  // not by signaling. Without this, the process would exit via event-loop
-  // drain with no Session.logout (leaking a CCU session toward "too many
-  // sessions") and no cache save. shutdown() is re-entrancy-guarded, so the
-  // close event fired by our own closeTransports() is harmless.
+  // not by signaling. Hook stdin DIRECTLY — StdioServerTransport registers
+  // only 'data'/'error' listeners, so transport/server onclose never fires
+  // on EOF and the process would exit via event-loop drain with no
+  // Session.logout (leaking a CCU session toward "too many sessions") and
+  // no cache save. shutdown() is re-entrancy-guarded.
   if (stdioServer) {
-    stdioServer.server.onclose = () => {
-      void shutdown("stdio-closed");
-    };
+    process.stdin.on("end", () => {
+      void shutdown("stdin-eof");
+    });
+    process.stdin.on("close", () => {
+      void shutdown("stdin-closed");
+    });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,12 +83,14 @@ async function main(): Promise<void> {
   let poller: ResourcePoller;
   let closeTransports: () => Promise<void>;
   let httpServer: HttpServer | HttpsServer | null = null;
+  let stdioServer: McpServer | null = null;
 
   if (config.mcp.transport === "stdio") {
     // stdio has exactly one MCP session; the poller follows ITS selection so a
     // use_ccu switch moves change-detection along with the resource reads.
     const stdioDeps = makeDeps();
     const mcpServer = createMcpServer(stdioDeps);
+    stdioServer = mcpServer;
     const transport = new StdioServerTransport();
     await mcpServer.connect(transport);
     poller = new ResourcePoller(
@@ -203,7 +205,8 @@ async function main(): Promise<void> {
         // Health check endpoint (tolerate cache-busting query strings that
         // uptime monitors append — req.url includes the query part)
         if ((req.url === "/health" || req.url?.startsWith("/health?")) && req.method === "GET") {
-          handleHealthRequest(req, res, { session: targets.default.session, deviceTypeCache: targets.default.deviceTypeCache });
+          const detailed = authTokens.verify(extractBearerToken(req.headers.authorization ?? ""));
+          handleHealthRequest(req, res, { session: targets.default.session, deviceTypeCache: targets.default.deviceTypeCache }, detailed);
           return;
         }
 
@@ -432,6 +435,17 @@ async function main(): Promise<void> {
 
   process.on("SIGTERM", () => shutdown("SIGTERM"));
   process.on("SIGINT", () => shutdown("SIGINT"));
+
+  // stdio: the client usually terminates by closing the pipe (stdin EOF),
+  // not by signaling. Without this, the process would exit via event-loop
+  // drain with no Session.logout (leaking a CCU session toward "too many
+  // sessions") and no cache save. shutdown() is re-entrancy-guarded, so the
+  // close event fired by our own closeTransports() is harmless.
+  if (stdioServer) {
+    stdioServer.server.onclose = () => {
+      void shutdown("stdio-closed");
+    };
+  }
 }
 
 main().catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,6 +241,11 @@ async function main(): Promise<void> {
           if (req.method === "GET") {
             // GET opens the long-lived SSE notification stream; hold the
             // session out of idle eviction until the connection closes.
+            // TCP keep-alive makes the OS probe the peer so a half-open
+            // stream (client died without FIN/RST) still fires 'close' and
+            // releases the slot — otherwise a wedged stream would pin the
+            // session forever and eventually 503 the server at capacity.
+            req.socket.setKeepAlive(true, 60_000);
             existing.openStreams++;
             res.on("close", () => {
               existing.openStreams--;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -66,7 +66,9 @@ export class Logger {
 
 export function createLogger(): Logger {
   const level = (process.env.LOG_LEVEL || "info") as LogLevel;
-  if (!(level in LEVEL_PRIORITY)) {
+  // hasOwn, not `in`: `in` matches Object.prototype keys, so LOG_LEVEL values
+  // like "constructor" would pass validation and silently log at full verbosity.
+  if (!Object.hasOwn(LEVEL_PRIORITY, level)) {
     throw new Error(`Invalid LOG_LEVEL: ${level}. Must be one of: error, warn, info, debug`);
   }
   return new Logger(level);

--- a/src/middleware/error-mapper.ts
+++ b/src/middleware/error-mapper.ts
@@ -36,7 +36,7 @@ export function mapNetworkError(err: Error, ccuMethod: string): StructuredError 
 
   if (causeMsg.includes("fingerprint mismatch")) {
     return {
-      error: "UNREACHABLE",
+      error: "TLS_ERROR",
       code: 0,
       message: `CCU TLS certificate verification failed: ${causeMsg}`,
       hint:

--- a/src/middleware/error-mapper.ts
+++ b/src/middleware/error-mapper.ts
@@ -7,7 +7,7 @@ const CCU_ERROR_MAP: Record<number, { category: ErrorCategory; hint: string }> =
   402: { category: "INTERNAL", hint: "Missing required argument — this is a bug in ccu-mcp." },
   501: { category: "CCU_ERROR", hint: "CCU internal error. Try again or check CCU logs." },
   502: { category: "NOT_FOUND", hint: "Device or channel not found. Call list_devices to discover valid addresses." },
-  503: { category: "NOT_FOUND", hint: "Invalid paramset key. Valid keys are: VALUES, MASTER, LINK." },
+  503: { category: "NOT_FOUND", hint: "Invalid paramset key. Valid keys are VALUES, MASTER, or a link partner's channel address." },
   505: { category: "INVALID_INPUT", hint: "Invalid valueKey or value. Call describe_device_type to see valid parameters." },
   506: { category: "INVALID_INPUT", hint: "Operation not supported by this device/channel." },
   507: { category: "CCU_ERROR", hint: "Transmission pending in HmIP Legacy API. Try again shortly." },

--- a/src/middleware/error-mapper.ts
+++ b/src/middleware/error-mapper.ts
@@ -27,7 +27,27 @@ export function mapCcuError(ccuError: CcuRpcError, ccuMethod: string): Structure
 }
 
 export function mapNetworkError(err: Error, ccuMethod: string): StructuredError {
-  if (err.name === "AbortError" || err.message.includes("timeout")) {
+  // undici's fetch wraps every dispatch/connect failure in a generic
+  // TypeError("fetch failed") with the real error on `cause` — without
+  // unwrapping it, a TLS fingerprint mismatch (an active-MITM / cert-rotation
+  // signal!) is indistinguishable from an unplugged CCU.
+  const cause = (err as Error & { cause?: unknown }).cause;
+  const causeMsg = cause instanceof Error ? cause.message : "";
+
+  if (causeMsg.includes("fingerprint mismatch")) {
+    return {
+      error: "UNREACHABLE",
+      code: 0,
+      message: `CCU TLS certificate verification failed: ${causeMsg}`,
+      hint:
+        "The CCU presented a DIFFERENT certificate than the pinned one. If the CCU's " +
+        "certificate was legitimately renewed, refresh CCU_TLS_FINGERPRINT; otherwise " +
+        "treat this as a possible interception attempt.",
+      ccuMethod,
+    };
+  }
+
+  if (err.name === "AbortError" || /timeout/i.test(err.message) || /timeout/i.test(causeMsg)) {
     return {
       error: "TIMEOUT",
       code: 0,
@@ -40,7 +60,7 @@ export function mapNetworkError(err: Error, ccuMethod: string): StructuredError 
   return {
     error: "UNREACHABLE",
     code: 0,
-    message: `Cannot connect to CCU: ${err.message}`,
+    message: `Cannot connect to CCU: ${causeMsg ? `${err.message} (${causeMsg})` : err.message}`,
     hint: "Check that the CCU is running and reachable at the configured host/port.",
     ccuMethod,
   };

--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -8,6 +8,7 @@ export class RateLimiter {
   private lastRefill: number;
   private waitQueue: Array<{ resolve: () => void; reject: (err: Error) => void }> = [];
   private refillTimer: ReturnType<typeof setInterval> | null = null;
+  private destroyed = false;
 
   constructor(maxBurst: number = 20, refillRate: number = 10, maxQueue: number = 1000) {
     this.maxTokens = maxBurst;
@@ -53,6 +54,18 @@ export class RateLimiter {
   }
 
   async acquire(): Promise<void> {
+    // A post-destroy acquire (e.g. a tool's SECOND acquire racing shutdown)
+    // must fail like the queued waiters did — re-arming the refill timer and
+    // firing the call into a session being logged out would produce a
+    // confusing AUTH/UNREACHABLE error instead of this clean rejection.
+    if (this.destroyed) {
+      throw new CcuError({
+        error: "CCU_ERROR",
+        code: 0,
+        message: "Server is shutting down; the request was cancelled.",
+        hint: "Retry after the server restarts.",
+      });
+    }
     this.refill();
 
     if (this.tokens >= 1) {
@@ -80,6 +93,7 @@ export class RateLimiter {
   }
 
   destroy(): void {
+    this.destroyed = true;
     if (this.refillTimer) {
       clearInterval(this.refillTimer);
       this.refillTimer = null;

--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -6,7 +6,7 @@ export class RateLimiter {
   private readonly refillRate: number; // tokens per second
   private readonly maxQueue: number;
   private lastRefill: number;
-  private waitQueue: Array<() => void> = [];
+  private waitQueue: Array<{ resolve: () => void; reject: (err: Error) => void }> = [];
   private refillTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(maxBurst: number = 20, refillRate: number = 10, maxQueue: number = 1000) {
@@ -47,8 +47,8 @@ export class RateLimiter {
     // Wake up waiting requests
     while (this.waitQueue.length > 0 && this.tokens >= 1) {
       this.tokens -= 1;
-      const resolve = this.waitQueue.shift()!;
-      resolve();
+      const waiter = this.waitQueue.shift()!;
+      waiter.resolve();
     }
   }
 
@@ -73,8 +73,8 @@ export class RateLimiter {
     }
 
     // Wait for a token to become available
-    return new Promise<void>((resolve) => {
-      this.waitQueue.push(resolve);
+    return new Promise<void>((resolve, reject) => {
+      this.waitQueue.push({ resolve, reject });
       this.ensureRefillTimer();
     });
   }
@@ -84,9 +84,17 @@ export class RateLimiter {
       clearInterval(this.refillTimer);
       this.refillTimer = null;
     }
-    // Release any waiting requests
-    for (const resolve of this.waitQueue) {
-      resolve();
+    // REJECT waiting requests instead of releasing them: destroy() runs during
+    // shutdown, and an unthrottled release would fire the queued CCU calls
+    // into a session that is being logged out — confusing AUTH/UNREACHABLE
+    // errors instead of a clean "shutting down" failure.
+    for (const waiter of this.waitQueue) {
+      waiter.reject(new CcuError({
+        error: "CCU_ERROR",
+        code: 0,
+        message: "Server is shutting down; the queued request was cancelled.",
+        hint: "Retry after the server restarts.",
+      }));
     }
     this.waitQueue = [];
   }

--- a/src/middleware/resolver.ts
+++ b/src/middleware/resolver.ts
@@ -5,6 +5,7 @@ import type { Logger } from "../logger.js";
 import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "./error-mapper.js";
 import { withRetry } from "./retry.js";
+import { expectArray } from "../utils.js";
 
 export class Resolver {
   private interfaceMap: Map<string, string> | null = null;
@@ -132,7 +133,7 @@ export class Resolver {
       "Device.listAllDetail",
       logger,
       { rateLimiter },
-    ) as CcuDevice[];
+    ).then((r) => expectArray<CcuDevice>(r));
 
     this.updateDeviceList(devices);
   }

--- a/src/middleware/resolver.ts
+++ b/src/middleware/resolver.ts
@@ -39,7 +39,12 @@ export class Resolver {
     return iface;
   }
 
-  resolveType(
+  /**
+   * The parameter's RAW paramset TYPE (BOOL, ACTION, FLOAT, ...) from the
+   * device-type cache, or undefined when unknown. ACTION identifies one-shot
+   * trigger datapoints (button press, stop) that must never be auto-retried.
+   */
+  resolveRawParamType(
     address: string,
     valueKey: string,
     cache: DeviceTypeCache,
@@ -56,8 +61,16 @@ export class Resolver {
     const channel = cached.channels[channelIndex];
     if (!channel) return undefined;
 
-    const param = channel.paramsets["VALUES"]?.[valueKey];
-    if (!param) return undefined;
+    return channel.paramsets["VALUES"]?.[valueKey]?.type;
+  }
+
+  resolveType(
+    address: string,
+    valueKey: string,
+    cache: DeviceTypeCache,
+  ): string | undefined {
+    const rawType = this.resolveRawParamType(address, valueKey, cache);
+    if (!rawType) return undefined;
 
     const typeMap: Record<string, string> = {
       BOOL: "bool",
@@ -68,7 +81,7 @@ export class Resolver {
       STRING: "string",
     };
 
-    return typeMap[param.type] || "string";
+    return typeMap[rawType] || "string";
   }
 
   getDeviceType(address: string): string | undefined {

--- a/src/middleware/resolver.ts
+++ b/src/middleware/resolver.ts
@@ -43,11 +43,14 @@ export class Resolver {
    * The parameter's RAW paramset TYPE (BOOL, ACTION, FLOAT, ...) from the
    * device-type cache, or undefined when unknown. ACTION identifies one-shot
    * trigger datapoints (button press, stop) that must never be auto-retried.
+   * `paramsetKey` selects which paramset to consult — MASTER params live in
+   * their own schema, so a MASTER write must not be resolved against VALUES.
    */
   resolveRawParamType(
     address: string,
     valueKey: string,
     cache: DeviceTypeCache,
+    paramsetKey: string = "VALUES",
   ): string | undefined {
     const deviceAddress = address.includes(":") ? address.split(":")[0]! : address;
     const channelIndex = address.includes(":") ? address.split(":")[1]! : "0";
@@ -61,15 +64,16 @@ export class Resolver {
     const channel = cached.channels[channelIndex];
     if (!channel) return undefined;
 
-    return channel.paramsets["VALUES"]?.[valueKey]?.type;
+    return channel.paramsets[paramsetKey]?.[valueKey]?.type;
   }
 
   resolveType(
     address: string,
     valueKey: string,
     cache: DeviceTypeCache,
+    paramsetKey: string = "VALUES",
   ): string | undefined {
-    const rawType = this.resolveRawParamType(address, valueKey, cache);
+    const rawType = this.resolveRawParamType(address, valueKey, cache, paramsetKey);
     if (!rawType) return undefined;
 
     const typeMap: Record<string, string> = {
@@ -127,6 +131,7 @@ export class Resolver {
       () => session.call("Device.listAllDetail"),
       "Device.listAllDetail",
       logger,
+      { rateLimiter },
     ) as CcuDevice[];
 
     this.updateDeviceList(devices);

--- a/src/middleware/retry.ts
+++ b/src/middleware/retry.ts
@@ -12,6 +12,13 @@ const RETRIABLE_CATEGORIES = new Set(["TIMEOUT", "UNREACHABLE"]);
 export interface RetryOptions {
   maxRetries?: number;
   delayMs?: number;
+  /**
+   * When set, each RETRY attempt acquires a token first (the caller already
+   * paid for the first attempt). Without this, a timeout storm doubles the
+   * real request rate against an already-slow CCU — exactly when the limiter
+   * is supposed to shed load.
+   */
+  rateLimiter?: { acquire(): Promise<void> };
 }
 
 export async function withRetry<T>(
@@ -20,7 +27,7 @@ export async function withRetry<T>(
   logger: Logger,
   options: RetryOptions = {},
 ): Promise<T> {
-  const { maxRetries = 1, delayMs = 1000 } = options;
+  const { maxRetries = 1, delayMs = 1000, rateLimiter } = options;
 
   // Never retry non-idempotent methods
   if (NON_IDEMPOTENT_METHODS.has(method)) {
@@ -40,6 +47,7 @@ export async function withRetry<T>(
         if (attempt < maxRetries) {
           logger.warn("retry", { method, attempt: attempt + 1, maxRetries, delayMs });
           await new Promise((resolve) => setTimeout(resolve, delayMs));
+          if (rateLimiter) await rateLimiter.acquire();
           continue;
         }
       }

--- a/src/middleware/tool-handler.ts
+++ b/src/middleware/tool-handler.ts
@@ -31,8 +31,29 @@ export async function runTool<R>(
     logger.info("tool_call", { tool, duration_ms: Date.now() - start, status: "ok", ...extra });
     return result;
   } catch (err) {
-    logger.info("tool_call", { tool, duration_ms: Date.now() - start, status: "error" });
-    if (err instanceof CcuError) return err.toMcpError();
+    if (err instanceof CcuError) {
+      // Mapped CCU failure: expected operational error — keep it at info, but
+      // carry the category/message (and the body's extra fields) so a failing
+      // tool is diagnosable from the logs.
+      logger.info("tool_call", {
+        tool,
+        duration_ms: Date.now() - start,
+        status: "error",
+        error: err.structured.error,
+        message: err.structured.message,
+        ...extra,
+      });
+      return err.toMcpError();
+    }
+    // Unexpected crash (TypeError etc.): must stand out from routine CCU errors.
+    logger.error("tool_call", {
+      tool,
+      duration_ms: Date.now() - start,
+      status: "crash",
+      error: (err as Error).name,
+      message: (err as Error).message,
+      ...extra,
+    });
     throw err;
   }
 }

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -4,8 +4,9 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 export function registerPrompts(server: McpServer): void {
   server.registerPrompt("check-windows", { description: "Check all window/door sensors and report which are open" }, async () => ({
     messages: [{ role: "user" as const, content: { type: "text" as const, text:
-      "Check all window and door sensors using list_devices (filter by type containing 'SWDO' or 'SCI') " +
-      "and get_values. Report which are open and which are closed. Group by room if possible (use list_rooms)."
+      "Check all window and door sensors: call list_devices (no type filter — the type arg is EXACT-match), " +
+      "keep the devices whose type contains 'SWDO' or 'SCI' (e.g. HmIP-SWDO-I), then read them with get_values. " +
+      "Report which are open and which are closed. Group by room if possible (use list_rooms)."
     }}],
   }));
 

--- a/src/resources/poller.ts
+++ b/src/resources/poller.ts
@@ -18,6 +18,7 @@ const POLLABLE: PollableResource[] = [
   { uri: "homematic://functions", method: "Subsection.getAll" },
   { uri: "homematic://programs", method: "Program.getAll" },
   { uri: "homematic://sysvars", method: "SysVar.getAll" },
+  { uri: "homematic://interfaces", method: "Interface.listInterfaces" },
 ];
 
 // Backoff: 1×, 2×, 4×, 8×, capped at 10× the base interval

--- a/src/resources/poller.ts
+++ b/src/resources/poller.ts
@@ -31,9 +31,11 @@ export class ResourcePoller {
   private consecutiveFailures = 0;
 
   constructor(
-    // Called when a polled resource changed. In stdio mode this notifies the
-    // single server; in HTTP mode it fans out to all active MCP sessions.
-    private readonly notifyChanged: () => Promise<void>,
+    // Called with the URIs whose CONTENT changed. In stdio mode this notifies
+    // the single server; in HTTP mode it fans out to all active MCP sessions.
+    // Consumers send notifications/resources/updated per subscribed URI — the
+    // resource LIST is static, so list_changed would be the wrong signal.
+    private readonly notifyChanged: (changedUris: string[]) => Promise<void>,
     // Resolves the ACTIVE target's session on every cycle (not captured once),
     // so the poller follows a use_ccu() switch — matching how the resources
     // themselves read deps.session per-call. Capturing the startup session here
@@ -72,7 +74,7 @@ export class ResourcePoller {
   }
 
   private async poll(): Promise<void> {
-    let anyChanged = false;
+    const changedUris: string[] = [];
     let anyFailed = false;
 
     for (const resource of POLLABLE) {
@@ -82,6 +84,7 @@ export class ResourcePoller {
           () => this.getSession().call(resource.method),
           resource.method,
           this.logger,
+          { rateLimiter: this.rateLimiter },
         );
         const hash = createHash("sha256").update(JSON.stringify(data)).digest("hex");
 
@@ -90,7 +93,7 @@ export class ResourcePoller {
 
         if (prev && prev !== hash) {
           this.logger.info("resource_changed", { uri: resource.uri });
-          anyChanged = true;
+          changedUris.push(resource.uri);
         }
       } catch (err) {
         anyFailed = true;
@@ -107,9 +110,9 @@ export class ResourcePoller {
       this.consecutiveFailures = 0;
     }
 
-    if (anyChanged) {
+    if (changedUris.length > 0) {
       try {
-        await this.notifyChanged();
+        await this.notifyChanged(changedUris);
       } catch (err) {
         this.logger.warn("resource_notify_failed", { error: (err as Error).message });
       }

--- a/src/resources/poller.ts
+++ b/src/resources/poller.ts
@@ -27,6 +27,10 @@ const MAX_BACKOFF_MULTIPLIER = 10;
 export class ResourcePoller {
   private hashes = new Map<string, string>();
   private timer: ReturnType<typeof setTimeout> | null = null;
+  // Tracks which session the hashes belong to: after a use_ccu switch the new
+  // target's data must become the fresh baseline, not be diffed against the
+  // OLD target's hashes (which would fire one spurious update per resource).
+  private hashedSession: SessionManager | null = null;
   // Counts consecutive poll cycles where at least one resource failed.
   // Used to apply exponential backoff on the next schedule.
   private consecutiveFailures = 0;
@@ -37,10 +41,10 @@ export class ResourcePoller {
     // Consumers send notifications/resources/updated per subscribed URI — the
     // resource LIST is static, so list_changed would be the wrong signal.
     private readonly notifyChanged: (changedUris: string[]) => Promise<void>,
-    // Resolves the ACTIVE target's session on every cycle (not captured once),
-    // so the poller follows a use_ccu() switch — matching how the resources
-    // themselves read deps.session per-call. Capturing the startup session here
-    // would leave the poller watching the startup CCU after a switch.
+    // Resolved on every cycle (not captured once). In stdio mode this follows
+    // the single session's use_ccu() switch; in HTTP mode it deliberately pins
+    // the DEFAULT target — many MCP sessions share one poller, so there is no
+    // single "active" target to follow there.
     private readonly getSession: () => SessionManager,
     private readonly rateLimiter: RateLimiter,
     private readonly logger: Logger,
@@ -78,11 +82,17 @@ export class ResourcePoller {
     const changedUris: string[] = [];
     let anyFailed = false;
 
+    const session = this.getSession();
+    if (this.hashedSession !== session) {
+      this.hashes.clear();
+      this.hashedSession = session;
+    }
+
     for (const resource of POLLABLE) {
       try {
         await this.rateLimiter.acquire();
         const data = await withRetry(
-          () => this.getSession().call(resource.method),
+          () => session.call(resource.method),
           resource.method,
           this.logger,
           { rateLimiter: this.rateLimiter },

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -3,6 +3,18 @@ import type { ServerDeps } from "../server.js";
 import { withRetry } from "../middleware/retry.js";
 import { VERSION } from "../utils.js";
 
+/** Every registered resource URI — the source of truth for subscribe validation. */
+export const RESOURCE_URIS: readonly string[] = [
+  "homematic://devices",
+  "homematic://rooms",
+  "homematic://functions",
+  "homematic://programs",
+  "homematic://sysvars",
+  "homematic://interfaces",
+  "homematic://device-types",
+  "homematic://system",
+];
+
 export function registerResources(server: McpServer, deps: ServerDeps): void {
   const { rateLimiter, logger } = deps;
 

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import { withRetry } from "../middleware/retry.js";
-import { VERSION } from "../utils.js";
+import { VERSION, expectArray } from "../utils.js";
 
 // CCU-backed list resources: one JSON-RPC method each; polled for change
 // notifications (see poller.ts POLLABLE).
@@ -39,9 +39,13 @@ export function registerResources(server: McpServer, deps: ServerDeps): void {
   };
 
   for (const r of CCU_LIST_RESOURCES) {
-    server.registerResource(r.name, r.uri, { description: r.description }, async () => ({
-      contents: [{ uri: r.uri, text: JSON.stringify(await ccuRead(r.method), null, 2), mimeType: "application/json" }],
-    }));
+    server.registerResource(r.name, r.uri, { description: r.description }, async () => {
+      // Guard like the sibling list_* tools: a malformed CCU/proxy result
+      // (result:null) must surface as an error, not be handed to a subscriber
+      // as the literal text "null" indistinguishable from an empty payload.
+      const list = expectArray(await ccuRead(r.method), r.method);
+      return { contents: [{ uri: r.uri, text: JSON.stringify(list, null, 2), mimeType: "application/json" }] };
+    });
   }
 
   // The two non-polled resources: subscriptions are accepted but change

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -35,7 +35,7 @@ export function registerResources(server: McpServer, deps: ServerDeps): void {
   // the startup target at registration time.
   const ccuRead = async (method: string) => {
     await rateLimiter.acquire();
-    return withRetry(() => deps.session.call(method), method, logger);
+    return withRetry(() => deps.session.call(method), method, logger, { rateLimiter });
   };
 
   for (const r of CCU_LIST_RESOURCES) {

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -3,16 +3,28 @@ import type { ServerDeps } from "../server.js";
 import { withRetry } from "../middleware/retry.js";
 import { VERSION } from "../utils.js";
 
-/** Every registered resource URI — the source of truth for subscribe validation. */
+// CCU-backed list resources: one JSON-RPC method each; polled for change
+// notifications (see poller.ts POLLABLE).
+const CCU_LIST_RESOURCES = [
+  { name: "devices", uri: "homematic://devices", description: "All devices with channels", method: "Device.listAllDetail" },
+  { name: "rooms", uri: "homematic://rooms", description: "All rooms with channel assignments", method: "Room.getAll" },
+  { name: "functions", uri: "homematic://functions", description: "All function groups", method: "Subsection.getAll" },
+  { name: "programs", uri: "homematic://programs", description: "All automation programs", method: "Program.getAll" },
+  { name: "sysvars", uri: "homematic://sysvars", description: "All system variables with values", method: "SysVar.getAll" },
+  { name: "interfaces", uri: "homematic://interfaces", description: "Available communication interfaces", method: "Interface.listInterfaces" },
+] as const;
+
+const DEVICE_TYPES_URI = "homematic://device-types";
+const SYSTEM_URI = "homematic://system";
+
+/**
+ * Every registered resource URI, DERIVED from the registrations below so the
+ * subscribe validation in server.ts can't drift from what is actually served.
+ */
 export const RESOURCE_URIS: readonly string[] = [
-  "homematic://devices",
-  "homematic://rooms",
-  "homematic://functions",
-  "homematic://programs",
-  "homematic://sysvars",
-  "homematic://interfaces",
-  "homematic://device-types",
-  "homematic://system",
+  ...CCU_LIST_RESOURCES.map((r) => r.uri),
+  DEVICE_TYPES_URI,
+  SYSTEM_URI,
 ];
 
 export function registerResources(server: McpServer, deps: ServerDeps): void {
@@ -26,39 +38,23 @@ export function registerResources(server: McpServer, deps: ServerDeps): void {
     return withRetry(() => deps.session.call(method), method, logger);
   };
 
-  server.registerResource("devices", "homematic://devices", { description: "All devices with channels" }, async () => ({
-    contents: [{ uri: "homematic://devices", text: JSON.stringify(await ccuRead("Device.listAllDetail"), null, 2), mimeType: "application/json" }],
+  for (const r of CCU_LIST_RESOURCES) {
+    server.registerResource(r.name, r.uri, { description: r.description }, async () => ({
+      contents: [{ uri: r.uri, text: JSON.stringify(await ccuRead(r.method), null, 2), mimeType: "application/json" }],
+    }));
+  }
+
+  // The two non-polled resources: subscriptions are accepted but change
+  // notifications are not emitted for them (locally-derived / near-static).
+  server.registerResource("device-types", DEVICE_TYPES_URI, { description: "Cached device type schemas (not change-notified)" }, async () => ({
+    contents: [{ uri: DEVICE_TYPES_URI, text: JSON.stringify(deps.deviceTypeCache.getAll(), null, 2), mimeType: "application/json" }],
   }));
 
-  server.registerResource("rooms", "homematic://rooms", { description: "All rooms with channel assignments" }, async () => ({
-    contents: [{ uri: "homematic://rooms", text: JSON.stringify(await ccuRead("Room.getAll"), null, 2), mimeType: "application/json" }],
-  }));
-
-  server.registerResource("functions", "homematic://functions", { description: "All function groups" }, async () => ({
-    contents: [{ uri: "homematic://functions", text: JSON.stringify(await ccuRead("Subsection.getAll"), null, 2), mimeType: "application/json" }],
-  }));
-
-  server.registerResource("programs", "homematic://programs", { description: "All automation programs" }, async () => ({
-    contents: [{ uri: "homematic://programs", text: JSON.stringify(await ccuRead("Program.getAll"), null, 2), mimeType: "application/json" }],
-  }));
-
-  server.registerResource("sysvars", "homematic://sysvars", { description: "All system variables with values" }, async () => ({
-    contents: [{ uri: "homematic://sysvars", text: JSON.stringify(await ccuRead("SysVar.getAll"), null, 2), mimeType: "application/json" }],
-  }));
-
-  server.registerResource("interfaces", "homematic://interfaces", { description: "Available communication interfaces" }, async () => ({
-    contents: [{ uri: "homematic://interfaces", text: JSON.stringify(await ccuRead("Interface.listInterfaces"), null, 2), mimeType: "application/json" }],
-  }));
-
-  server.registerResource("device-types", "homematic://device-types", { description: "Cached device type schemas" }, async () => ({
-    contents: [{ uri: "homematic://device-types", text: JSON.stringify(deps.deviceTypeCache.getAll(), null, 2), mimeType: "application/json" }],
-  }));
-
-  server.registerResource("system", "homematic://system", { description: "CCU system info" }, async () => {
+  server.registerResource("system", SYSTEM_URI, { description: "CCU system info (not change-notified)" }, async () => {
     const info: Record<string, unknown> = { serverVersion: VERSION };
     for (const [key, method] of [["version", "CCU.getVersion"], ["serial", "CCU.getSerial"]] as const) {
       try { info[key] = await ccuRead(method); } catch { info[key] = null; }
     }
-    return { contents: [{ uri: "homematic://system", text: JSON.stringify(info, null, 2), mimeType: "application/json" }] };
+    return { contents: [{ uri: SYSTEM_URI, text: JSON.stringify(info, null, 2), mimeType: "application/json" }] };
   });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import type { RateLimiter } from "./middleware/rate-limiter.js";
 import type { Logger } from "./logger.js";
 import type { DeviceTypeCache } from "./cache/device-type-cache.js";
 import type { Resolver } from "./middleware/resolver.js";
-import type { TargetRegistry } from "./ccu/target-registry.js";
+import type { TargetRegistry, TargetSelection } from "./ccu/target-registry.js";
 import { registerDiscoveryTools } from "./tools/discovery.js";
 import { registerReadTools } from "./tools/read.js";
 import { registerControlTools } from "./tools/control.js";
@@ -18,13 +18,19 @@ import { VERSION } from "./utils.js";
 
 export interface ServerDeps {
   config: AppConfig;
-  /** All configured CCU targets and the active pointer. */
+  /** All configured CCU targets (shared across MCP sessions). */
   targets: TargetRegistry;
   /**
-   * The ACTIVE target's session/resolver/device-type cache. These are getters
-   * (see index.ts / _helpers.ts) that resolve to `targets.active.*` on each
-   * access, so a use_ccu() switch is picked up by the next tool call without
-   * touching any tool that reads `deps.session` etc.
+   * THIS MCP session's active-target pointer + protected-target unlocks.
+   * One per McpServer instance so concurrent HTTP clients can't retarget or
+   * de-gate each other.
+   */
+  selection: TargetSelection;
+  /**
+   * The session-active target's session/resolver/device-type cache. These are
+   * getters (see index.ts / _helpers.ts) that resolve to `selection.active.*`
+   * on each access, so a use_ccu() switch is picked up by the next tool call
+   * without touching any tool that reads `deps.session` etc.
    */
   readonly session: SessionManager;
   readonly resolver: Resolver;
@@ -42,7 +48,10 @@ export function createMcpServer(deps: ServerDeps): McpServer {
     {
       capabilities: {
         tools: {},
-        resources: { subscribe: true },
+        // listChanged is what the poller actually emits. Do NOT advertise
+        // `subscribe`: the SDK McpServer registers no resources/subscribe
+        // handler, so a client trusting that capability gets "Method not found".
+        resources: { listChanged: true },
         prompts: {},
         logging: {},
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { SubscribeRequestSchema, UnsubscribeRequestSchema, McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import type { AppConfig } from "./config.js";
 import type { SessionManager } from "./ccu/session.js";
 import type { RateLimiter } from "./middleware/rate-limiter.js";
@@ -13,7 +13,7 @@ import { registerControlTools } from "./tools/control.js";
 import { registerDiagnosticsTools } from "./tools/diagnostics.js";
 import { registerMetaTools } from "./tools/meta.js";
 import { registerTargetTools } from "./tools/targets.js";
-import { registerResources } from "./resources/registry.js";
+import { registerResources, RESOURCE_URIS } from "./resources/registry.js";
 import { registerPrompts } from "./prompts/registry.js";
 import { VERSION } from "./utils.js";
 
@@ -81,6 +81,14 @@ export function createMcpServer(deps: ServerDeps): McpServer {
   const subscriptions = new Set<string>();
   serverSubscriptions.set(server, subscriptions);
   server.server.setRequestHandler(SubscribeRequestSchema, async (req) => {
+    // Reject unknown URIs: silently accepting a typo would leave the client
+    // waiting forever for notifications that can never come.
+    if (!RESOURCE_URIS.includes(req.params.uri)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Unknown resource: ${req.params.uri}. Valid URIs: ${RESOURCE_URIS.join(", ")}`,
+      );
+    }
     subscriptions.add(req.params.uri);
     return {};
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { AppConfig } from "./config.js";
 import type { SessionManager } from "./ccu/session.js";
 import type { RateLimiter } from "./middleware/rate-limiter.js";
@@ -39,6 +40,14 @@ export interface ServerDeps {
   logger: Logger;
 }
 
+/**
+ * Per-server resource subscriptions (URIs a client subscribed to via
+ * resources/subscribe). The poller consults this to send
+ * notifications/resources/updated only where they were asked for. WeakMap so
+ * an evicted/closed server's entry is collectable with the server itself.
+ */
+export const serverSubscriptions = new WeakMap<McpServer, Set<string>>();
+
 export function createMcpServer(deps: ServerDeps): McpServer {
   const server = new McpServer(
     {
@@ -48,10 +57,10 @@ export function createMcpServer(deps: ServerDeps): McpServer {
     {
       capabilities: {
         tools: {},
-        // listChanged is what the poller actually emits. Do NOT advertise
-        // `subscribe`: the SDK McpServer registers no resources/subscribe
-        // handler, so a client trusting that capability gets "Method not found".
-        resources: { listChanged: true },
+        // subscribe is backed by the handlers registered below; the poller
+        // sends notifications/resources/updated for changed URIs to
+        // subscribers (list_changed would be wrong — the list is static).
+        resources: { listChanged: true, subscribe: true },
         prompts: {},
         logging: {},
       },
@@ -66,6 +75,19 @@ export function createMcpServer(deps: ServerDeps): McpServer {
   registerTargetTools(server, deps);
   registerResources(server, deps);
   registerPrompts(server);
+
+  // resources/subscribe support: the SDK's McpServer registers no handler for
+  // it, so back the advertised capability ourselves.
+  const subscriptions = new Set<string>();
+  serverSubscriptions.set(server, subscriptions);
+  server.server.setRequestHandler(SubscribeRequestSchema, async (req) => {
+    subscriptions.add(req.params.uri);
+    return {};
+  });
+  server.server.setRequestHandler(UnsubscribeRequestSchema, async (req) => {
+    subscriptions.delete(req.params.uri);
+    return {};
+  });
 
   return server;
 }

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -48,10 +48,15 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
       },
     },
     async (args) => runTool("set_value", deps.logger, async (log) => {
-      const { session, rateLimiter, logger, deviceTypeCache } = deps;
-      assertWritable(deps.selection, deps.selection.active, args.confirm);
-      const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
-      const valueType = args.type ?? deps.resolver.resolveType(args.address, args.valueKey, deviceTypeCache) ?? inferType(args.value);
+      const { rateLimiter, logger } = deps;
+      // Pin the target ONCE: deps.session/resolver are live getters, so a
+      // concurrent use_ccu in this MCP session mid-handler would otherwise
+      // resolve interface/type against a different target than the write.
+      const active = deps.selection.active;
+      const { session, resolver, deviceTypeCache } = active;
+      assertWritable(deps.selection, active, args.confirm);
+      const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
+      const valueType = args.type ?? resolver.resolveType(args.address, args.valueKey, deviceTypeCache) ?? inferType(args.value);
 
       // Read previous value (best-effort)
       let previousValue: unknown = null;
@@ -69,7 +74,7 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
       // Write new value. An ACTION datapoint (PRESS_SHORT, STOP, ...) is a
       // one-shot trigger: a timed-out request may still have been delivered,
       // so auto-retry could fire it twice — send those exactly once.
-      const rawParamType = deps.resolver.resolveRawParamType(args.address, args.valueKey, deviceTypeCache);
+      const rawParamType = resolver.resolveRawParamType(args.address, args.valueKey, deviceTypeCache);
       const doSetValue = () => session.call("Interface.setValue", {
         interface: iface,
         address: args.address,
@@ -81,7 +86,7 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
       if (rawParamType === "ACTION") {
         await doSetValue();
       } else {
-        await withRetry(doSetValue, "Interface.setValue", logger);
+        await withRetry(doSetValue, "Interface.setValue", logger, { rateLimiter });
       }
 
       log({ address: args.address });
@@ -120,14 +125,19 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
       },
     },
     async (args) => runTool("put_paramset", deps.logger, async () => {
-      const { session, rateLimiter, logger, deviceTypeCache } = deps;
-      assertWritable(deps.selection, deps.selection.active, args.confirm);
-      const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
+      const { rateLimiter, logger } = deps;
+      // Pin the target once (see set_value).
+      const active = deps.selection.active;
+      const { session, resolver, deviceTypeCache } = active;
+      assertWritable(deps.selection, active, args.confirm);
+      const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
-      // CCU expects set as array of {name, type, value} objects
+      // CCU expects set as array of {name, type, value} objects. Types must be
+      // resolved against the paramset actually being written — MASTER params
+      // have their own schema; resolving them against VALUES finds nothing and
+      // inferType would e.g. send "int" for a FLOAT param given 5.0.
       const paramArray = Object.entries(args.set).map(([name, value]) => {
-        // Try to resolve type from device type cache
-        let type = deps.resolver.resolveType(args.address, name, deviceTypeCache);
+        let type = resolver.resolveType(args.address, name, deviceTypeCache, args.paramsetKey);
         if (!type) type = inferType(value);
         return { name, type, value: String(value) };
       });
@@ -135,7 +145,7 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
       // If any written key is a one-shot ACTION trigger, the request must not
       // be auto-retried — a timeout after delivery would re-fire the trigger.
       const containsAction = Object.keys(args.set).some(
-        (name) => deps.resolver.resolveRawParamType(args.address, name, deviceTypeCache) === "ACTION",
+        (name) => resolver.resolveRawParamType(args.address, name, deviceTypeCache, args.paramsetKey) === "ACTION",
       );
       const doPutParamset = () => session.call("Interface.putParamset", {
         interface: iface,
@@ -147,7 +157,7 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
       if (containsAction) {
         await doPutParamset();
       } else {
-        await withRetry(doPutParamset, "Interface.putParamset", logger);
+        await withRetry(doPutParamset, "Interface.putParamset", logger, { rateLimiter });
       }
 
       return toolResult({ address: args.address, paramsetKey: args.paramsetKey, written: args.set });
@@ -180,9 +190,12 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
       },
     },
     async (args) => runTool("set_system_variable", deps.logger, async () => {
-      const { session, rateLimiter, logger } = deps;
-      const typeCacheHolder = deps.selection.active.sysVarTypeCache;
-      assertWritable(deps.selection, deps.selection.active, args.confirm);
+      const { rateLimiter, logger } = deps;
+      // Pin the target once (see set_value).
+      const active = deps.selection.active;
+      const { session } = active;
+      const typeCacheHolder = active.sysVarTypeCache;
+      assertWritable(deps.selection, active, args.confirm);
       // Look up variable type (cached) to choose correct setter
       let method: string;
       let sysVar: { type: string; valueList?: string } | undefined;
@@ -195,6 +208,7 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
           () => session.call("SysVar.getAll"),
           "SysVar.getAll",
           logger,
+          { rateLimiter },
         ) as Array<{ name: string; type: string; valueList?: string }>;
         typeCacheHolder.entry = {
           ts: Date.now(),
@@ -242,12 +256,20 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         method = "SysVar.setFloat"; // Enums use numeric index
         // Accept either a 0-based index or one of the enum's labels; anything
         // else would be forwarded unchecked to sv.State() and store garbage
-        // while the tool reports success.
+        // while the tool reports success. A NUMBER is always an index (the
+        // historical contract) — label matching applies to strings only, so
+        // an enum whose labels are numeric strings ("1;2;3") can't silently
+        // redefine what a numeric input means.
         const labels = (sysVar.valueList ?? "").split(";");
-        const asLabel = labels.indexOf(String(args.value));
-        const index = asLabel >= 0
-          ? asLabel
-          : (typeof args.value === "number" || /^\d+$/.test(String(args.value)) ? Number(args.value) : NaN);
+        let index: number;
+        if (typeof args.value === "number") {
+          index = args.value;
+        } else {
+          const asLabel = labels.indexOf(String(args.value));
+          index = asLabel >= 0
+            ? asLabel
+            : (/^\d+$/.test(String(args.value)) ? Number(args.value) : NaN);
+        }
         if (!Number.isInteger(index) || index < 0 || index >= labels.length) {
           throw new CcuError({
             error: "INVALID_INPUT",
@@ -270,9 +292,10 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
             script:
               `object sv = dom.GetObject(ID_SYSTEM_VARIABLES).Get("${escapedName}");\n` +
               `if (sv) { sv.State("${escapedValue}"); WriteLine("OK"); } else { WriteLine("NOT_FOUND"); }`,
-          }, deps.selection.active.profile.ccu.scriptTimeout),
+          }, active.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
+          { rateLimiter },
         );
         const outcome = typeof output === "string" ? output.trim() : "";
         if (outcome === "NOT_FOUND") {
@@ -307,6 +330,7 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         () => session.call(method, { name: args.name, value: rpcValue }),
         method,
         logger,
+        { rateLimiter },
       );
 
       return toolResult({ name: args.name, value: rpcValue, method });
@@ -339,9 +363,12 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
       },
     },
     async (args) => runTool("create_system_variable", deps.logger, async (log) => {
-      const { session, rateLimiter, logger } = deps;
-      const typeCacheHolder = deps.selection.active.sysVarTypeCache;
-      assertWritable(deps.selection, deps.selection.active, args.confirm);
+      const { rateLimiter, logger } = deps;
+      // Pin the target once (see set_value).
+      const active = deps.selection.active;
+      const { session } = active;
+      const typeCacheHolder = active.sysVarTypeCache;
+      assertWritable(deps.selection, active, args.confirm);
       if (args.type === "enum" && (!args.values || args.values.length === 0)) {
         throw new CcuError({
           error: "INVALID_INPUT",
@@ -370,6 +397,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
         () => session.call("SysVar.getAll"),
         "SysVar.getAll",
         logger,
+        { rateLimiter },
       ) as Array<{ name: string }>;
       if (existing.some((v) => v.name === args.name)) {
         throw new CcuError({
@@ -448,9 +476,10 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
 
       await rateLimiter.acquire();
       const createResult = await withRetry(
-        () => session.call("ReGa.runScript", { script }, deps.selection.active.profile.ccu.scriptTimeout),
+        () => session.call("ReGa.runScript", { script }, active.profile.ccu.scriptTimeout),
         "ReGa.runScript",
         logger,
+        { rateLimiter },
       );
 
       // The script echoes the ACTUAL stored name. Empty output means the ReGa
@@ -509,10 +538,13 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
       },
     },
     async (args) => runTool("delete_system_variable", deps.logger, async () => {
-      const { session, rateLimiter, logger } = deps;
-      const typeCacheHolder = deps.selection.active.sysVarTypeCache;
+      const { rateLimiter, logger } = deps;
+      // Pin the target once (see set_value).
+      const active = deps.selection.active;
+      const { session } = active;
+      const typeCacheHolder = active.sysVarTypeCache;
       // Destructive and unrecoverable — per-call confirm (#72)
-      assertWritable(deps.selection, deps.selection.active, args.confirm, { alwaysConfirm: true });
+      assertWritable(deps.selection, active, args.confirm, { alwaysConfirm: true });
       // Validate existence so an unknown name is a clean NOT_FOUND rather than
       // a silent no-op (deleteSysVarByName doesn't report a missing name).
       await rateLimiter.acquire();
@@ -520,6 +552,7 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
         () => session.call("SysVar.getAll"),
         "SysVar.getAll",
         logger,
+        { rateLimiter },
       ) as Array<{ name: string }>;
       if (!existing.some((v) => v.name === args.name)) {
         throw new CcuError({
@@ -535,6 +568,7 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
         () => session.call("SysVar.deleteSysVarByName", { name: args.name }),
         "SysVar.deleteSysVarByName",
         logger,
+        { rateLimiter },
       );
 
       typeCacheHolder.entry = null; // removed variable must not linger in the cache
@@ -569,8 +603,11 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
       },
     },
     async (args) => runTool(toolName, deps.logger, async () => {
-      const { session, rateLimiter, logger } = deps;
-      assertWritable(deps.selection, deps.selection.active, args.confirm);
+      const { rateLimiter, logger } = deps;
+      // Pin the target once (see set_value).
+      const active = deps.selection.active;
+      const { session } = active;
+      assertWritable(deps.selection, active, args.confirm);
       if (!args.room && !args.function) {
         throw new CcuError({
           error: "INVALID_INPUT",
@@ -586,8 +623,9 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
         () => session.call("Device.listAllDetail"),
         "Device.listAllDetail",
         logger,
+        { rateLimiter },
       ) as CcuDevice[];
-      deps.resolver.updateDeviceList(devices);
+      active.resolver.updateDeviceList(devices);
       let channelId: string | undefined;
       for (const d of devices) {
         const ch = d.channels.find((c) => c.address === args.channel);
@@ -610,6 +648,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
           () => session.call("Room.getAll"),
           "Room.getAll",
           logger,
+          { rateLimiter },
         ) as Array<{ id: string; name: string }>;
         const room = rooms.find((r) => r.name === args.room);
         if (!room) {
@@ -625,6 +664,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
           () => session.call(mode === "add" ? "Room.addChannel" : "Room.removeChannel", { id: room.id, channelId }),
           "Room.modifyChannel",
           logger,
+          { rateLimiter },
         );
         applied.push({ kind: "room", name: room.name });
       }
@@ -635,6 +675,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
           () => session.call("Subsection.getAll"),
           "Subsection.getAll",
           logger,
+          { rateLimiter },
         ) as Array<{ id: string; name: string }>;
         const fn = functions.find((f) => f.name === args.function);
         if (!fn) {
@@ -650,6 +691,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
           () => session.call(mode === "add" ? "Subsection.addChannel" : "Subsection.removeChannel", { id: fn.id, channelId }),
           "Subsection.modifyChannel",
           logger,
+          { rateLimiter },
         );
         applied.push({ kind: "function", name: fn.name });
       }
@@ -680,8 +722,11 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
       },
     },
     async (args) => runTool("execute_program", deps.logger, async () => {
-      const { session, rateLimiter, logger } = deps;
-      assertWritable(deps.selection, deps.selection.active, args.confirm);
+      const { rateLimiter, logger } = deps;
+      // Pin the target once (see set_value).
+      const active = deps.selection.active;
+      const { session } = active;
+      assertWritable(deps.selection, active, args.confirm);
       // The CCU's Program.execute reports success even for nonexistent IDs
       // (issue #18) — validate against the program list first.
       await rateLimiter.acquire();
@@ -689,6 +734,7 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
         () => session.call("Program.getAll"),
         "Program.getAll",
         logger,
+        { rateLimiter },
       ) as Array<{ id: string; name: string }>;
 
       const program = programs.find((p) => String(p.id) === args.id);
@@ -702,8 +748,18 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
       }
 
       await rateLimiter.acquire();
-      // No retry — Program.execute is not idempotent
-      await session.call("Program.execute", { id: args.id });
+      // No retry — Program.execute is not idempotent.
+      // execute.tcl answers `false` (not an error) when the ReGa script fails
+      // or ProgramExecute() didn't run — that must not read as success.
+      const executed = await session.call("Program.execute", { id: args.id });
+      if (executed !== true && executed !== "true") {
+        throw new CcuError({
+          error: "CCU_ERROR",
+          code: 0,
+          message: `Program.execute reported failure for program ${args.id} ("${program.name}")`,
+          hint: "The CCU's script engine failed or the program vanished. Check list_programs and the CCU logs, then retry.",
+        });
+      }
 
       return toolResult({ id: args.id, name: program.name, executed: true });
     }),

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -527,6 +527,12 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
           await rateLimiter.acquire();
           await session.call("SysVar.deleteSysVarByName", { name: actualName });
         } catch { /* best-effort cleanup of the unintended object */ }
+        // The create+delete pair mutated the sysvar list: invalidate the type
+        // cache here too, or a concurrent set's getAll snapshot taken between
+        // create and cleanup would pass the gen check and cache the phantom
+        // variable for the TTL.
+        typeCacheHolder.entry = null;
+        typeCacheHolder.gen++;
         throw new CcuError({
           error: "INVALID_INPUT",
           code: 0,

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -361,6 +361,11 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
       // variable makes getValueByName's script write nothing (""). A TRANSPORT
       // failure of this extra read must not turn the already-landed write into
       // a reported error — the result then says the write is unverified.
+      // Trade-off: getValueByName's lookup is global (same as the setters'),
+      // not scoped to ID_SYSTEM_VARIABLES — a scoped check would need
+      // ReGa.runScript, which is ADMIN-only and would break USER-level
+      // logins. Worst case is a false NOT_FOUND on a name collision with an
+      // empty-valued channel/program, never a false success.
       let verifyResult: unknown;
       let verified = true;
       try {

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -73,7 +73,10 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
 
       // Write new value. An ACTION datapoint (PRESS_SHORT, STOP, ...) is a
       // one-shot trigger: a timed-out request may still have been delivered,
-      // so auto-retry could fire it twice — send those exactly once.
+      // so auto-retry could fire it twice — send those exactly once. Retry
+      // only when the cache POSITIVELY says the param is not ACTION: on a
+      // cache miss (cold cache, unwarmed target) the param might be a trigger,
+      // and losing one retry is cheaper than double-firing a button press.
       const rawParamType = resolver.resolveRawParamType(args.address, args.valueKey, deviceTypeCache);
       const doSetValue = () => session.call("Interface.setValue", {
         interface: iface,
@@ -83,10 +86,10 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
         value: args.value,
       });
       await rateLimiter.acquire();
-      if (rawParamType === "ACTION") {
-        await doSetValue();
-      } else {
+      if (rawParamType !== undefined && rawParamType !== "ACTION") {
         await withRetry(doSetValue, "Interface.setValue", logger, { rateLimiter });
+      } else {
+        await doSetValue();
       }
 
       log({ address: args.address });
@@ -142,11 +145,14 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
         return { name, type, value: String(value) };
       });
 
-      // If any written key is a one-shot ACTION trigger, the request must not
-      // be auto-retried — a timeout after delivery would re-fire the trigger.
-      const containsAction = Object.keys(args.set).some(
-        (name) => resolver.resolveRawParamType(args.address, name, deviceTypeCache, args.paramsetKey) === "ACTION",
-      );
+      // If any written key is (or COULD be, on a cache miss) a one-shot ACTION
+      // trigger, the request must not be auto-retried — a timeout after
+      // delivery would re-fire the trigger. ACTION params only exist in
+      // VALUES; MASTER writes are config and always safe to retry.
+      const safeToRetry = args.paramsetKey === "MASTER" || Object.keys(args.set).every((name) => {
+        const raw = resolver.resolveRawParamType(args.address, name, deviceTypeCache, args.paramsetKey);
+        return raw !== undefined && raw !== "ACTION";
+      });
       const doPutParamset = () => session.call("Interface.putParamset", {
         interface: iface,
         address: args.address,
@@ -154,10 +160,10 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
         set: paramArray,
       });
       await rateLimiter.acquire();
-      if (containsAction) {
-        await doPutParamset();
-      } else {
+      if (safeToRetry) {
         await withRetry(doPutParamset, "Interface.putParamset", logger, { rateLimiter });
+      } else {
+        await doPutParamset();
       }
 
       return toolResult({ address: args.address, paramsetKey: args.paramsetKey, written: args.set });
@@ -252,6 +258,18 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         }
       } else if (varType.includes("FLOAT") || varType.includes("NUMBER") || varType.includes("INTEGER")) {
         method = "SysVar.setFloat";
+        // setfloat.tcl passes the value straight into sv.State() and always
+        // answers success — a non-numeric value would silently store 0.
+        const num = typeof args.value === "number" ? args.value : Number(String(args.value));
+        if (typeof args.value === "boolean" || String(args.value).trim() === "" || !Number.isFinite(num)) {
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: `System variable "${args.name}" is numeric; got: ${JSON.stringify(args.value)}`,
+            hint: "Pass a finite number.",
+          });
+        }
+        rpcValue = num;
       } else if (varType.includes("ENUM") || varType.includes("LIST")) {
         method = "SysVar.setFloat"; // Enums use numeric index
         // Accept either a 0-based index or one of the enum's labels; anything
@@ -670,30 +688,44 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
       }
 
       if (args.function) {
-        await rateLimiter.acquire();
-        const functions = await withRetry(
-          () => session.call("Subsection.getAll"),
-          "Subsection.getAll",
-          logger,
-          { rateLimiter },
-        ) as Array<{ id: string; name: string }>;
-        const fn = functions.find((f) => f.name === args.function);
-        if (!fn) {
-          throw new CcuError({
-            error: "NOT_FOUND",
-            code: 0,
-            message: `Function not found: ${args.function}`,
-            hint: `Valid functions: ${functions.map((f) => f.name).join(", ")}`,
-          });
+        try {
+          await rateLimiter.acquire();
+          const functions = await withRetry(
+            () => session.call("Subsection.getAll"),
+            "Subsection.getAll",
+            logger,
+            { rateLimiter },
+          ) as Array<{ id: string; name: string }>;
+          const fn = functions.find((f) => f.name === args.function);
+          if (!fn) {
+            throw new CcuError({
+              error: "NOT_FOUND",
+              code: 0,
+              message: `Function not found: ${args.function}`,
+              hint: `Valid functions: ${functions.map((f) => f.name).join(", ")}`,
+            });
+          }
+          await rateLimiter.acquire();
+          await withRetry(
+            () => session.call(mode === "add" ? "Subsection.addChannel" : "Subsection.removeChannel", { id: fn.id, channelId }),
+            "Subsection.modifyChannel",
+            logger,
+            { rateLimiter },
+          );
+          applied.push({ kind: "function", name: fn.name });
+        } catch (err) {
+          // The room step may already have been applied — a bare error would
+          // hide that partial state and invite a double-applying retry.
+          if (applied.length > 0 && err instanceof CcuError) {
+            throw new CcuError({
+              ...err.structured,
+              message:
+                `${err.structured.message} — NOTE: the room ` +
+                `${mode === "add" ? "assignment" : "removal"} ("${applied[0]!.name}") was already applied`,
+            });
+          }
+          throw err;
         }
-        await rateLimiter.acquire();
-        await withRetry(
-          () => session.call(mode === "add" ? "Subsection.addChannel" : "Subsection.removeChannel", { id: fn.id, channelId }),
-          "Subsection.modifyChannel",
-          logger,
-          { rateLimiter },
-        );
-        applied.push({ kind: "function", name: fn.name });
       }
 
       return toolResult({

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -49,7 +49,7 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => runTool("set_value", deps.logger, async (log) => {
       const { session, rateLimiter, logger, deviceTypeCache } = deps;
-      assertWritable(deps.targets.active, args.confirm);
+      assertWritable(deps.selection, deps.selection.active, args.confirm);
       const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
       const valueType = args.type ?? deps.resolver.resolveType(args.address, args.valueKey, deviceTypeCache) ?? inferType(args.value);
 
@@ -66,19 +66,23 @@ function registerSetValue(server: McpServer, deps: ServerDeps): void {
         // Pre-read failed — continue with write
       }
 
-      // Write new value
+      // Write new value. An ACTION datapoint (PRESS_SHORT, STOP, ...) is a
+      // one-shot trigger: a timed-out request may still have been delivered,
+      // so auto-retry could fire it twice — send those exactly once.
+      const rawParamType = deps.resolver.resolveRawParamType(args.address, args.valueKey, deviceTypeCache);
+      const doSetValue = () => session.call("Interface.setValue", {
+        interface: iface,
+        address: args.address,
+        valueKey: args.valueKey,
+        type: valueType,
+        value: args.value,
+      });
       await rateLimiter.acquire();
-      await withRetry(
-        () => session.call("Interface.setValue", {
-          interface: iface,
-          address: args.address,
-          valueKey: args.valueKey,
-          type: valueType,
-          value: args.value,
-        }),
-        "Interface.setValue",
-        logger,
-      );
+      if (rawParamType === "ACTION") {
+        await doSetValue();
+      } else {
+        await withRetry(doSetValue, "Interface.setValue", logger);
+      }
 
       log({ address: args.address });
       return toolResult({
@@ -117,7 +121,7 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => runTool("put_paramset", deps.logger, async () => {
       const { session, rateLimiter, logger, deviceTypeCache } = deps;
-      assertWritable(deps.targets.active, args.confirm);
+      assertWritable(deps.selection, deps.selection.active, args.confirm);
       const iface = args.interface ?? await deps.resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
       // CCU expects set as array of {name, type, value} objects
@@ -128,17 +132,23 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
         return { name, type, value: String(value) };
       });
 
-      await rateLimiter.acquire();
-      await withRetry(
-        () => session.call("Interface.putParamset", {
-          interface: iface,
-          address: args.address,
-          paramsetKey: args.paramsetKey,
-          set: paramArray,
-        }),
-        "Interface.putParamset",
-        logger,
+      // If any written key is a one-shot ACTION trigger, the request must not
+      // be auto-retried — a timeout after delivery would re-fire the trigger.
+      const containsAction = Object.keys(args.set).some(
+        (name) => deps.resolver.resolveRawParamType(args.address, name, deviceTypeCache) === "ACTION",
       );
+      const doPutParamset = () => session.call("Interface.putParamset", {
+        interface: iface,
+        address: args.address,
+        paramsetKey: args.paramsetKey,
+        set: paramArray,
+      });
+      await rateLimiter.acquire();
+      if (containsAction) {
+        await doPutParamset();
+      } else {
+        await withRetry(doPutParamset, "Interface.putParamset", logger);
+      }
 
       return toolResult({ address: args.address, paramsetKey: args.paramsetKey, written: args.set });
     }),
@@ -171,56 +181,29 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => runTool("set_system_variable", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const typeCacheHolder = deps.targets.active.sysVarTypeCache;
-      assertWritable(deps.targets.active, args.confirm);
+      const typeCacheHolder = deps.selection.active.sysVarTypeCache;
+      assertWritable(deps.selection, deps.selection.active, args.confirm);
       // Look up variable type (cached) to choose correct setter
       let method: string;
-      let sysVarType: string | undefined;
+      let sysVar: { type: string; valueList?: string } | undefined;
       if (typeCacheHolder.entry && Date.now() - typeCacheHolder.entry.ts < SYSVAR_TYPE_TTL_MS) {
-        sysVarType = typeCacheHolder.entry.types.get(args.name);
+        sysVar = typeCacheHolder.entry.types.get(args.name);
       }
-      if (sysVarType === undefined) {
+      if (sysVar === undefined) {
         await rateLimiter.acquire();
         const allVars = await withRetry(
           () => session.call("SysVar.getAll"),
           "SysVar.getAll",
           logger,
-        ) as Array<{ name: string; type: string }>;
-        typeCacheHolder.entry = { ts: Date.now(), types: new Map(allVars.map((v) => [v.name, v.type])) };
-        sysVarType = typeCacheHolder.entry.types.get(args.name);
+        ) as Array<{ name: string; type: string; valueList?: string }>;
+        typeCacheHolder.entry = {
+          ts: Date.now(),
+          types: new Map(allVars.map((v) => [v.name, { type: v.type, valueList: v.valueList }])),
+        };
+        sysVar = typeCacheHolder.entry.types.get(args.name);
       }
 
-      if (sysVarType !== undefined) {
-        const varType = sysVarType.toUpperCase();
-        if (varType.includes("BOOL") || varType.includes("ALARM")) {
-          method = "SysVar.setBool";
-        } else if (varType.includes("FLOAT") || varType.includes("NUMBER") || varType.includes("INTEGER")) {
-          method = "SysVar.setFloat";
-        } else if (varType.includes("ENUM") || varType.includes("LIST")) {
-          method = "SysVar.setFloat"; // Enums use numeric index
-        } else if (varType.includes("STRING")) {
-          // String variables: use ReGa.runScript as there's no SysVar.setString API
-          await rateLimiter.acquire();
-          const escapedName = escapeHmScript(String(args.name));
-          const escapedValue = escapeHmScript(String(args.value));
-          await withRetry(
-            () => session.call("ReGa.runScript", {
-              script: `var sv = dom.GetObject("${escapedName}"); if (sv) { sv.State("${escapedValue}"); }`,
-            }, deps.targets.active.profile.ccu.scriptTimeout),
-            "ReGa.runScript",
-            logger,
-          );
-          return toolResult({ name: args.name, value: args.value, method: "ReGa.runScript (string)" });
-        } else {
-          logger.warn("sysvar_unknown_type", { name: args.name, type: sysVarType });
-          throw new CcuError({
-            error: "INVALID_INPUT",
-            code: 0,
-            message: `System variable "${args.name}" has unsupported type: ${sysVarType}`,
-            hint: "Supported types are bool/alarm, float/integer, enum/list, and string.",
-          });
-        }
-      } else {
+      if (sysVar === undefined) {
         logger.warn("sysvar_not_found", { name: args.name });
         throw new CcuError({
           error: "NOT_FOUND",
@@ -230,14 +213,103 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         });
       }
 
+      // SysVar.getAll reports exactly LOGIC / ALARM / LIST / NUMBER / STRING
+      // (occu getall.tcl); the extra aliases keep any older/other firmware
+      // spellings working.
+      const varType = sysVar.type.toUpperCase();
+      let rpcValue: string | number | boolean = args.value;
+      if (varType.includes("LOGIC") || varType.includes("BOOL") || varType.includes("ALARM")) {
+        method = "SysVar.setBool";
+        // setbool.tcl compares non-0/1 values as STRINGS ("false" >= 1 is a
+        // lexicographic compare that yields true), so a JSON boolean false
+        // would be stored as 1. Normalize to numeric 0/1 and reject anything
+        // that isn't clearly a boolean.
+        if (args.value === true || args.value === "true" || args.value === 1 || args.value === "1") {
+          rpcValue = 1;
+        } else if (args.value === false || args.value === "false" || args.value === 0 || args.value === "0") {
+          rpcValue = 0;
+        } else {
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: `System variable "${args.name}" is boolean; got: ${JSON.stringify(args.value)}`,
+            hint: "Pass true/false (or 0/1).",
+          });
+        }
+      } else if (varType.includes("FLOAT") || varType.includes("NUMBER") || varType.includes("INTEGER")) {
+        method = "SysVar.setFloat";
+      } else if (varType.includes("ENUM") || varType.includes("LIST")) {
+        method = "SysVar.setFloat"; // Enums use numeric index
+        // Accept either a 0-based index or one of the enum's labels; anything
+        // else would be forwarded unchecked to sv.State() and store garbage
+        // while the tool reports success.
+        const labels = (sysVar.valueList ?? "").split(";");
+        const asLabel = labels.indexOf(String(args.value));
+        const index = asLabel >= 0
+          ? asLabel
+          : (typeof args.value === "number" || /^\d+$/.test(String(args.value)) ? Number(args.value) : NaN);
+        if (!Number.isInteger(index) || index < 0 || index >= labels.length) {
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: `Invalid value for enum variable "${args.name}": ${JSON.stringify(args.value)}`,
+            hint: `Pass an index 0-${labels.length - 1} or one of: ${labels.join(", ")}`,
+          });
+        }
+        rpcValue = index;
+      } else if (varType.includes("STRING")) {
+        // String variables: use ReGa.runScript as there's no SysVar.setString API.
+        // Scope the lookup to the sysvar list (a global dom.GetObject name match
+        // could hit a channel/program of the same name) and verify the script
+        // actually ran — empty output means ReGa failed, not success.
+        await rateLimiter.acquire();
+        const escapedName = escapeHmScript(String(args.name));
+        const escapedValue = escapeHmScript(String(args.value));
+        const output = await withRetry(
+          () => session.call("ReGa.runScript", {
+            script:
+              `object sv = dom.GetObject(ID_SYSTEM_VARIABLES).Get("${escapedName}");\n` +
+              `if (sv) { sv.State("${escapedValue}"); WriteLine("OK"); } else { WriteLine("NOT_FOUND"); }`,
+          }, deps.selection.active.profile.ccu.scriptTimeout),
+          "ReGa.runScript",
+          logger,
+        );
+        const outcome = typeof output === "string" ? output.trim() : "";
+        if (outcome === "NOT_FOUND") {
+          throw new CcuError({
+            error: "NOT_FOUND",
+            code: 0,
+            message: `System variable not found: ${args.name}`,
+            hint: "The variable disappeared between lookup and write. Call list_system_variables.",
+          });
+        }
+        if (outcome !== "OK") {
+          throw new CcuError({
+            error: "CCU_ERROR",
+            code: 0,
+            message: `ReGa script produced no confirmation while setting "${args.name}" — the write may not have happened`,
+            hint: "The CCU's script engine likely failed (busy or errored). Verify with get_value / list_system_variables and retry.",
+          });
+        }
+        return toolResult({ name: args.name, value: args.value, method: "ReGa.runScript (string)" });
+      } else {
+        logger.warn("sysvar_unknown_type", { name: args.name, type: sysVar.type });
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: `System variable "${args.name}" has unsupported type: ${sysVar.type}`,
+          hint: "Supported types are logic/alarm, number, list, and string.",
+        });
+      }
+
       await rateLimiter.acquire();
       await withRetry(
-        () => session.call(method, { name: args.name, value: args.value }),
+        () => session.call(method, { name: args.name, value: rpcValue }),
         method,
         logger,
       );
 
-      return toolResult({ name: args.name, value: args.value, method });
+      return toolResult({ name: args.name, value: rpcValue, method });
     }),
   );
 }
@@ -268,8 +340,8 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
     },
     async (args) => runTool("create_system_variable", deps.logger, async (log) => {
       const { session, rateLimiter, logger } = deps;
-      const typeCacheHolder = deps.targets.active.sysVarTypeCache;
-      assertWritable(deps.targets.active, args.confirm);
+      const typeCacheHolder = deps.selection.active.sysVarTypeCache;
+      assertWritable(deps.selection, deps.selection.active, args.confirm);
       if (args.type === "enum" && (!args.values || args.values.length === 0)) {
         throw new CcuError({
           error: "INVALID_INPUT",
@@ -277,6 +349,19 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
           message: "An enum system variable requires a non-empty 'values' list.",
           hint: "Pass values, e.g. [\"off\", \"low\", \"high\"].",
         });
+      }
+      // ";" is the CCU's in-band ValueList separator: a label containing it
+      // would silently split into extra enum states and shift every index
+      // after it. escapeHmScript can't help — the separator is data, not syntax.
+      for (const label of args.values ?? []) {
+        if (label.includes(";")) {
+          throw new CcuError({
+            error: "INVALID_INPUT",
+            code: 0,
+            message: `Enum label ${JSON.stringify(label)} contains ";", the CCU's value-list separator.`,
+            hint: "Rename the label without a semicolon — the CCU cannot represent one inside an enum state name.",
+          });
+        }
       }
 
       // Reject duplicates up front (creating over an existing name corrupts it).
@@ -316,8 +401,8 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
             'sv.State(false);';
           break;
         case "float": {
-          const min = Number.isFinite(args.min) ? args.min : 0;
-          const max = Number.isFinite(args.max) ? args.max : 100;
+          const min = hmNumberLiteral(Number.isFinite(args.min) ? args.min! : 0, "min");
+          const max = hmNumberLiteral(Number.isFinite(args.max) ? args.max! : 100, "max");
           typeSetup =
             'sv.ValueType(ivtFloat);\n' +
             `sv.Name("${name}");\n` +
@@ -363,19 +448,29 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
 
       await rateLimiter.acquire();
       const createResult = await withRetry(
-        () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
+        () => session.call("ReGa.runScript", { script }, deps.selection.active.profile.ccu.scriptTimeout),
         "ReGa.runScript",
         logger,
       );
 
-      // The script echoes the ACTUAL stored name. The CCU silently dedups a
-      // requested name against existing similar names (e.g. "X" becomes "X 1"
-      // when an "X 2" already exists), which the exact-match pre-check above
-      // can't see. If we didn't get the name we asked for, undo it and report
-      // the collision rather than leaving a surprise variable behind.
-      const actualName = typeof createResult === "string" && createResult.trim()
-        ? createResult.trim()
-        : args.name;
+      // The script echoes the ACTUAL stored name. Empty output means the ReGa
+      // script itself failed (hmscript.tcl returns "" on any script error) —
+      // treating that as "created" would report success for a create that
+      // never happened.
+      const actualName = typeof createResult === "string" ? createResult.trim() : "";
+      if (!actualName) {
+        throw new CcuError({
+          error: "CCU_ERROR",
+          code: 0,
+          message: `Create script for "${args.name}" produced no output — the variable was most likely NOT created`,
+          hint: "The CCU's script engine failed (busy or script error). Check with list_system_variables and retry.",
+        });
+      }
+      // The CCU silently dedups a requested name against existing similar names
+      // (e.g. "X" becomes "X 1" when an "X 2" already exists), which the
+      // exact-match pre-check above can't see. If we didn't get the name we
+      // asked for, undo it and report the collision rather than leaving a
+      // surprise variable behind.
       if (actualName !== args.name) {
         try {
           await rateLimiter.acquire();
@@ -415,9 +510,9 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
     },
     async (args) => runTool("delete_system_variable", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      const typeCacheHolder = deps.targets.active.sysVarTypeCache;
+      const typeCacheHolder = deps.selection.active.sysVarTypeCache;
       // Destructive and unrecoverable — per-call confirm (#72)
-      assertWritable(deps.targets.active, args.confirm, { alwaysConfirm: true });
+      assertWritable(deps.selection, deps.selection.active, args.confirm, { alwaysConfirm: true });
       // Validate existence so an unknown name is a clean NOT_FOUND rather than
       // a silent no-op (deleteSysVarByName doesn't report a missing name).
       await rateLimiter.acquire();
@@ -475,7 +570,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
     },
     async (args) => runTool(toolName, deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      assertWritable(deps.targets.active, args.confirm);
+      assertWritable(deps.selection, deps.selection.active, args.confirm);
       if (!args.room && !args.function) {
         throw new CcuError({
           error: "INVALID_INPUT",
@@ -586,7 +681,7 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => runTool("execute_program", deps.logger, async () => {
       const { session, rateLimiter, logger } = deps;
-      assertWritable(deps.targets.active, args.confirm);
+      assertWritable(deps.selection, deps.selection.active, args.confirm);
       // The CCU's Program.execute reports success even for nonexistent IDs
       // (issue #18) — validate against the program list first.
       await rateLimiter.acquire();
@@ -613,6 +708,25 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
       return toolResult({ id: args.id, name: program.name, executed: true });
     }),
   );
+}
+
+/**
+ * Render a number as a HomeMatic Script numeric literal. JS stringification
+ * uses exponent notation for extreme magnitudes ("1e-7", "1e+21"), which ReGa
+ * cannot parse — the whole script would fail. Reject those instead of emitting
+ * a broken script.
+ */
+function hmNumberLiteral(n: number, field: string): string {
+  const s = String(n);
+  if (!/^-?\d+(\.\d+)?$/.test(s)) {
+    throw new CcuError({
+      error: "INVALID_INPUT",
+      code: 0,
+      message: `Value for "${field}" (${s}) cannot be written as a HomeMatic Script number literal`,
+      hint: "Use a plain decimal magnitude (no exponent notation).",
+    });
+  }
+  return s;
 }
 
 export function inferType(value: unknown): string {

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -209,6 +209,7 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         sysVar = typeCacheHolder.entry.types.get(args.name);
       }
       if (sysVar === undefined) {
+        const genBefore = typeCacheHolder.gen;
         await rateLimiter.acquire();
         const allVars = await withRetry(
           () => session.call("SysVar.getAll"),
@@ -216,11 +217,14 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
           logger,
           { rateLimiter },
         ).then((r) => expectArray<{ name: string; type: string; valueList?: string }>(r));
-        typeCacheHolder.entry = {
-          ts: Date.now(),
-          types: new Map(allVars.map((v) => [v.name, { type: v.type, valueList: v.valueList }])),
-        };
-        sysVar = typeCacheHolder.entry.types.get(args.name);
+        const types = new Map(allVars.map((v) => [v.name, { type: v.type, valueList: v.valueList }]));
+        // Only cache the snapshot if no create/delete invalidated the holder
+        // while we were fetching — installing it would resurrect a pre-delete
+        // view for the next 30s. The snapshot still serves THIS call.
+        if (typeCacheHolder.gen === genBefore) {
+          typeCacheHolder.entry = { ts: Date.now(), types };
+        }
+        sysVar = types.get(args.name);
       }
 
       if (sysVar === undefined) {
@@ -531,7 +535,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
         });
       }
 
-      typeCacheHolder.entry = null; // new variable must be visible to the next set
+      typeCacheHolder.entry = null; typeCacheHolder.gen++; // new variable must be visible to the next set
       log({ type: args.type });
       return toolResult({ name: actualName, type: args.type, created: true });
     }),
@@ -589,7 +593,7 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
         { rateLimiter },
       );
 
-      typeCacheHolder.entry = null; // removed variable must not linger in the cache
+      typeCacheHolder.entry = null; typeCacheHolder.gen++; // removed variable must not linger in the cache
       return toolResult({ name: args.name, deleted: true });
     }),
   );

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -6,7 +6,7 @@ import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable } from "../ccu/target-registry.js";
-import { toolResult, parseValue, escapeHmScript } from "../utils.js";
+import { toolResult, parseValue, escapeHmScript, expectArray } from "../utils.js";
 
 // Optional `confirm` field for write tools: required (true) to authorize a write
 // against a `protected` CCU target (e.g. prod). Harmless on unprotected targets.
@@ -215,7 +215,7 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
           "SysVar.getAll",
           logger,
           { rateLimiter },
-        ) as Array<{ name: string; type: string; valueList?: string }>;
+        ).then((r) => expectArray<{ name: string; type: string; valueList?: string }>(r));
         typeCacheHolder.entry = {
           ts: Date.now(),
           types: new Map(allVars.map((v) => [v.name, { type: v.type, valueList: v.valueList }])),
@@ -416,7 +416,7 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
         "SysVar.getAll",
         logger,
         { rateLimiter },
-      ) as Array<{ name: string }>;
+      ).then((r) => expectArray<{ name: string }>(r));
       if (existing.some((v) => v.name === args.name)) {
         throw new CcuError({
           error: "INVALID_INPUT",
@@ -571,7 +571,7 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
         "SysVar.getAll",
         logger,
         { rateLimiter },
-      ) as Array<{ name: string }>;
+      ).then((r) => expectArray<{ name: string }>(r));
       if (!existing.some((v) => v.name === args.name)) {
         throw new CcuError({
           error: "NOT_FOUND",
@@ -642,7 +642,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
         "Device.listAllDetail",
         logger,
         { rateLimiter },
-      ) as CcuDevice[];
+      ).then((r) => expectArray<CcuDevice>(r));
       active.resolver.updateDeviceList(devices);
       let channelId: string | undefined;
       for (const d of devices) {
@@ -667,7 +667,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
           "Room.getAll",
           logger,
           { rateLimiter },
-        ) as Array<{ id: string; name: string }>;
+        ).then((r) => expectArray<{ id: string; name: string }>(r));
         const room = rooms.find((r) => r.name === args.room);
         if (!room) {
           throw new CcuError({
@@ -695,7 +695,7 @@ function registerAssignChannel(server: McpServer, deps: ServerDeps, mode: "add" 
             "Subsection.getAll",
             logger,
             { rateLimiter },
-          ) as Array<{ id: string; name: string }>;
+          ).then((r) => expectArray<{ id: string; name: string }>(r));
           const fn = functions.find((f) => f.name === args.function);
           if (!fn) {
             throw new CcuError({
@@ -767,7 +767,7 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
         "Program.getAll",
         logger,
         { rateLimiter },
-      ) as Array<{ id: string; name: string }>;
+      ).then((r) => expectArray<{ id: string; name: string }>(r));
 
       const program = programs.find((p) => String(p.id) === args.id);
       if (!program) {

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -355,6 +355,26 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         { rateLimiter },
       );
 
+      // setbool.tcl/setfloat.tcl answer success even when dom.GetObject finds
+      // no variable (verified in the OCCU TCL) — a delete racing the 30s type
+      // cache would silently no-op. Verify the write had a target: a missing
+      // variable makes getValueByName's script write nothing ("").
+      await rateLimiter.acquire();
+      const verify = await withRetry(
+        () => session.call("SysVar.getValueByName", { name: args.name }),
+        "SysVar.getValueByName",
+        logger,
+        { rateLimiter },
+      );
+      if (typeof verify !== "string" || verify === "") {
+        throw new CcuError({
+          error: "NOT_FOUND",
+          code: 0,
+          message: `System variable disappeared before the write could land: ${args.name}`,
+          hint: "It was likely deleted concurrently (the CCU's setBool/setFloat report success even without a target). Call list_system_variables to confirm.",
+        });
+      }
+
       return toolResult({ name: args.name, value: rpcValue, method });
     }),
   );

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -358,15 +358,24 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
       // setbool.tcl/setfloat.tcl answer success even when dom.GetObject finds
       // no variable (verified in the OCCU TCL) — a delete racing the 30s type
       // cache would silently no-op. Verify the write had a target: a missing
-      // variable makes getValueByName's script write nothing ("").
-      await rateLimiter.acquire();
-      const verify = await withRetry(
-        () => session.call("SysVar.getValueByName", { name: args.name }),
-        "SysVar.getValueByName",
-        logger,
-        { rateLimiter },
-      );
-      if (typeof verify !== "string" || verify === "") {
+      // variable makes getValueByName's script write nothing (""). A TRANSPORT
+      // failure of this extra read must not turn the already-landed write into
+      // a reported error — the result then says the write is unverified.
+      let verifyResult: unknown;
+      let verified = true;
+      try {
+        await rateLimiter.acquire();
+        verifyResult = await withRetry(
+          () => session.call("SysVar.getValueByName", { name: args.name }),
+          "SysVar.getValueByName",
+          logger,
+          { rateLimiter },
+        );
+      } catch (err) {
+        logger.warn("sysvar_write_unverified", { name: args.name, error: (err as Error).message });
+        verified = false;
+      }
+      if (verified && (typeof verifyResult !== "string" || verifyResult === "")) {
         throw new CcuError({
           error: "NOT_FOUND",
           code: 0,
@@ -375,7 +384,12 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         });
       }
 
-      return toolResult({ name: args.name, value: rpcValue, method });
+      return toolResult({
+        name: args.name,
+        value: rpcValue,
+        method,
+        ...(verified ? {} : { verified: false, note: "The write succeeded but could not be verified (CCU unreachable during verification)." }),
+      });
     }),
   );
 }

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -5,7 +5,7 @@ import type { CcuDevice } from "../ccu/types.js";
 import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
-import { assertWritable } from "../ccu/target-registry.js";
+import { assertWritable, resolveTarget } from "../ccu/target-registry.js";
 import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION, loadBuildInfo } from "../utils.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
@@ -28,11 +28,16 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
       title: "Get Service Messages",
       description:
         "Get all active service messages (low battery, unreachable, etc.) with device details and timestamps.",
+      inputSchema: {
+        target: z.string().optional().describe("CCU target to read from (default: active). See list_ccu_targets."),
+      },
       outputSchema: { messages: z.array(z.unknown()).describe("Active alarms: {id, type, address, channelName, timestamp}") },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => runTool("get_service_messages", deps.logger, async () => {
-      const { session, rateLimiter, logger } = deps;
+    async (args) => runTool("get_service_messages", deps.logger, async () => {
+      const { rateLimiter, logger } = deps;
+      const t = resolveTarget(deps.selection, args.target);
+      const { session } = t;
         // Two single passes instead of a nested per-alarm channel scan: emit the
         // alarms first while collecting their addresses, then resolve channel
         // names in ONE sweep over all channels (sentinel-comma Find, as in
@@ -65,9 +70,13 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
                   }
                 }
                 if (chAddr != "") { addrList = addrList # chAddr # ","; }
-                ! JSON-escape user-controlled names (backslash first, then quote)
+                ! JSON-escape user-controlled names (backslash first, then quote,
+                ! then raw control chars JSON forbids)
                 dpName = dpName.Replace("\\\\", "\\\\\\\\");
                 dpName = dpName.Replace("\\"", "\\\\\\"");
+                dpName = dpName.Replace("\\t", "\\\\t");
+                dpName = dpName.Replace("\\r", "\\\\r");
+                dpName = dpName.Replace("\\n", "\\\\n");
                 Write('{"id":"' # sId # '"');
                 Write(',"type":"' # dpName # '"');
                 Write(',"address":"' # chAddr # '"');
@@ -89,6 +98,9 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
                 string cName = c.Name();
                 cName = cName.Replace("\\\\", "\\\\\\\\");
                 cName = cName.Replace("\\"", "\\\\\\"");
+                cName = cName.Replace("\\t", "\\\\t");
+                cName = cName.Replace("\\r", "\\\\r");
+                cName = cName.Replace("\\n", "\\\\n");
                 Write('"' # c.Address() # '":"' # cName # '"');
               }
             }
@@ -98,15 +110,16 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
 
         await rateLimiter.acquire();
         const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, t.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
 
         const parsed = typeof result === "string" ? tryParseJson(result) : result;
 
-        // Merge channel names into the alarms (same output shape as before)
-        let messages: unknown = parsed;
+        // Merge channel names into the alarms (same output shape as before).
+        // A bare array (the pre-#8 script format) is accepted as-is.
+        let messages: unknown = Array.isArray(parsed) ? parsed : null;
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)
             && Array.isArray((parsed as Record<string, unknown>).alarms)) {
           const names = ((parsed as Record<string, unknown>).channelNames ?? {}) as Record<string, string>;
@@ -116,7 +129,19 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
           }));
         }
 
-        return structuredResult({ messages: Array.isArray(messages) ? messages : [] }, messages);
+        // Unparseable/empty script output must NOT read as "zero alarms" —
+        // that is a monitoring-grade false negative while LOWBAT/UNREACH may
+        // be active. runscript returns "" whenever the ReGa script fails.
+        if (!Array.isArray(messages)) {
+          throw new CcuError({
+            error: "CCU_ERROR",
+            code: 0,
+            message: "The CCU script for get_service_messages returned no parseable output",
+            hint: "The CCU's script engine failed (busy or errored). Try again — do not treat this as 'no service messages'.",
+          });
+        }
+
+        return structuredResult({ messages }, messages);
     }),
   );
 }
@@ -143,7 +168,7 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
     },
     async (args) => runTool("acknowledge_service_messages", deps.logger, async (log) => {
       const { session, rateLimiter, logger } = deps;
-        assertWritable(deps.targets.active, args.confirm);
+        assertWritable(deps.selection, deps.selection.active, args.confirm);
         if (!args.id && !args.address) {
           throw new CcuError({
             error: "INVALID_INPUT",
@@ -209,16 +234,26 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
 
         await rateLimiter.acquire();
         const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.targets.active.profile.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, deps.selection.active.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
         );
 
         const parsed = typeof result === "string" ? tryParseJson(result) : result;
-        const confirmed = (parsed && typeof parsed === "object" && !Array.isArray(parsed)
-          && Array.isArray((parsed as Record<string, unknown>).confirmed))
-          ? (parsed as Record<string, unknown>).confirmed as Array<Record<string, unknown>>
-          : [];
+        const isShapeOk = Boolean(parsed && typeof parsed === "object" && !Array.isArray(parsed)
+          && Array.isArray((parsed as Record<string, unknown>).confirmed));
+        // Distinguish "script ran, nothing matched" (NOT_FOUND below) from
+        // "script failed / output corrupted" — in the latter case AlReceipt may
+        // or may not have run, so claiming NOT_FOUND would be a lie either way.
+        if (!isShapeOk) {
+          throw new CcuError({
+            error: "CCU_ERROR",
+            code: 0,
+            message: "The CCU script for acknowledge_service_messages returned no parseable output",
+            hint: "The ReGa engine failed or its output was corrupted; the acknowledgement may or may not have happened. Call get_service_messages to check the current state.",
+          });
+        }
+        const confirmed = (parsed as Record<string, unknown>).confirmed as Array<Record<string, unknown>>;
 
         if (confirmed.length === 0) {
           throw new CcuError({
@@ -247,6 +282,9 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
         "login user and inferred role (ADMIN/USER) — note that version/serial/address are ADMIN-only " +
         "on the CCU, so they show \"N/A\" for a non-admin (USER) login. Also reports the running " +
         "server's build identification (git branch/commit/tag and build time) under `build`.",
+      inputSchema: {
+        target: z.string().optional().describe("CCU target to read from (default: active). See list_ccu_targets."),
+      },
       outputSchema: {
         serverVersion: z.string().optional(),
         target: z.string().optional().describe("Active CCU target name"),
@@ -271,9 +309,10 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => runTool("get_system_info", deps.logger, async () => {
-      const { session, rateLimiter, deviceTypeCache } = deps;
-      const active = deps.targets.active;
+    async (args) => runTool("get_system_info", deps.logger, async () => {
+      const { rateLimiter } = deps;
+      const active = resolveTarget(deps.selection, args.target);
+      const { session, deviceTypeCache } = active;
       const results: Record<string, unknown> = {
         serverVersion: VERSION,
         target: active.profile.name,
@@ -338,6 +377,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
         "Use to answer 'why is this sensor flaky?'. Higher (closer to 0) dBm is better; null = no measurement.",
       inputSchema: {
         name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
+        target: z.string().optional().describe("CCU target to read from (default: active). See list_ccu_targets."),
       },
       outputSchema: {
         devices: z.array(z.unknown()).describe("Per device: {address, name, interface, links:[{peer, rssiDevice, rssiPeer}]}"),
@@ -346,7 +386,8 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => runTool("get_rssi", deps.logger, async (log) => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
+      const { session, resolver } = resolveTarget(deps.selection, args.target);
         // Device list → address→{name,interface}. Same call list_devices uses;
         // also refresh the resolver so later interface lookups are warm.
         await rateLimiter.acquire();
@@ -355,7 +396,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
           "Device.listAllDetail",
           logger,
         ) as CcuDevice[];
-        deps.resolver.updateDeviceList(devices);
+        resolver.updateDeviceList(devices);
         const nameByAddress = new Map<string, string>();
         const ifaceByAddress = new Map<string, string>();
         for (const d of devices) {

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -6,7 +6,7 @@ import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable, resolveTarget } from "../ccu/target-registry.js";
-import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION, loadBuildInfo } from "../utils.js";
+import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION, loadBuildInfo, expectArray } from "../utils.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
   registerGetServiceMessages(server, deps);
@@ -401,7 +401,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
           "Device.listAllDetail",
           logger,
           { rateLimiter },
-        ) as CcuDevice[];
+        ).then((r) => expectArray<CcuDevice>(r));
         resolver.updateDeviceList(devices);
         const nameByAddress = new Map<string, string>();
         const ifaceByAddress = new Map<string, string>();
@@ -422,7 +422,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
           "Interface.listInterfaces",
           logger,
           { rateLimiter },
-        ) as Array<{ name: string }>;
+        ).then((r) => expectArray<{ name: string }>(r));
 
         const needle = args.name?.toLowerCase();
         const deviceEntries: Array<Record<string, unknown>> = [];

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -113,6 +113,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
           () => session.call("ReGa.runScript", { script }, t.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
+          { rateLimiter },
         );
 
         const parsed = typeof result === "string" ? tryParseJson(result) : result;
@@ -167,8 +168,11 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
       },
     },
     async (args) => runTool("acknowledge_service_messages", deps.logger, async (log) => {
-      const { session, rateLimiter, logger } = deps;
-        assertWritable(deps.selection, deps.selection.active, args.confirm);
+      const { rateLimiter, logger } = deps;
+      // Pin the target once (see control.ts set_value).
+      const active = deps.selection.active;
+      const { session } = active;
+        assertWritable(deps.selection, active, args.confirm);
         if (!args.id && !args.address) {
           throw new CcuError({
             error: "INVALID_INPUT",
@@ -234,9 +238,10 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
 
         await rateLimiter.acquire();
         const result = await withRetry(
-          () => session.call("ReGa.runScript", { script }, deps.selection.active.profile.ccu.scriptTimeout),
+          () => session.call("ReGa.runScript", { script }, active.profile.ccu.scriptTimeout),
           "ReGa.runScript",
           logger,
+          { rateLimiter },
         );
 
         const parsed = typeof result === "string" ? tryParseJson(result) : result;
@@ -395,6 +400,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
           () => session.call("Device.listAllDetail"),
           "Device.listAllDetail",
           logger,
+          { rateLimiter },
         ) as CcuDevice[];
         resolver.updateDeviceList(devices);
         const nameByAddress = new Map<string, string>();
@@ -415,6 +421,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
           () => session.call("Interface.listInterfaces"),
           "Interface.listInterfaces",
           logger,
+          { rateLimiter },
         ) as Array<{ name: string }>;
 
         const needle = args.name?.toLowerCase();
@@ -429,6 +436,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
               () => session.call("Interface.rssiInfo", { interface: iface.name }),
               "Interface.rssiInfo",
               logger,
+              { rateLimiter },
             ) as RssiEntry[];
           } catch {
             // Interfaces without RF (e.g. VirtualDevices) don't support rssiInfo.
@@ -482,6 +490,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
               () => session.call("Interface.getParamset", { interface: d.interface, address: maint.address, paramsetKey: "VALUES" }),
               "Interface.getParamset",
               logger,
+              { rateLimiter },
             ) as Record<string, unknown>;
             const rssiDevice = dbm(vals?.RSSI_DEVICE);
             const rssiPeer = dbm(vals?.RSSI_PEER);
@@ -507,6 +516,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
             () => session.call("Interface.listBidcosInterfaces"),
             "Interface.listBidcosInterfaces",
             logger,
+            { rateLimiter },
           );
         } catch {
           bidcosInterfaces = [];

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -224,9 +224,13 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
                 if (match) {
                   svc.AlReceipt();
                   if (!first) { Write(","); } first = false;
-                  ! JSON-escape user-controlled names (backslash first, then quote)
+                  ! JSON-escape user-controlled names (backslash first, then quote,
+                  ! then raw control chars — consistent with the other emitters)
                   dpName = dpName.Replace("\\\\", "\\\\\\\\");
                   dpName = dpName.Replace("\\"", "\\\\\\"");
+                  dpName = dpName.Replace("\\t", "\\\\t");
+                  dpName = dpName.Replace("\\r", "\\\\r");
+                  dpName = dpName.Replace("\\n", "\\\\n");
                   Write('{"id":"' # sId # '","type":"' # dpName # '","address":"' # chAddr # '"}');
                 }
               }

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -147,8 +147,11 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
       const { rateLimiter, logger } = deps;
       const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
-      const result = await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger, { rateLimiter });
-      return structuredResult({ interfaces: Array.isArray(result) ? result : [] }, result);
+      const result = expectArray(
+        await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger, { rateLimiter }),
+        "Interface.listInterfaces",
+      );
+      return structuredResult({ interfaces: result }, result);
     }),
   );
 }
@@ -167,8 +170,11 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
       const { rateLimiter, logger } = deps;
       const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
-      const result = await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger, { rateLimiter });
-      return structuredResult({ rooms: Array.isArray(result) ? result : [] }, result);
+      const result = expectArray(
+        await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger, { rateLimiter }),
+        "Room.getAll",
+      );
+      return structuredResult({ rooms: result }, result);
     }),
   );
 }
@@ -187,8 +193,11 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
       const { rateLimiter, logger } = deps;
       const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
-      const result = await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger, { rateLimiter });
-      return structuredResult({ functions: Array.isArray(result) ? result : [] }, result);
+      const result = expectArray(
+        await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger, { rateLimiter }),
+        "Subsection.getAll",
+      );
+      return structuredResult({ functions: result }, result);
     }),
   );
 }

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -5,7 +5,7 @@ import type { CcuDevice } from "../ccu/types.js";
 import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { resolveTarget } from "../ccu/target-registry.js";
-import { structuredResult } from "../utils.js";
+import { structuredResult, expectArray } from "../utils.js";
 
 // Optional per-call target override (route one read to a named CCU).
 const targetField = z.string().optional()
@@ -52,7 +52,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
         { rateLimiter },
       );
 
-      let devices = result as CcuDevice[];
+      let devices = expectArray<CcuDevice>(result, "Device.listAllDetail");
 
       // Update resolver's device list
       resolver.updateDeviceList(devices);
@@ -70,7 +70,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             "Room.getAll",
             logger,
             { rateLimiter },
-          ) as Array<{ id: string; name: string; channelIds: string[] }>;
+          ).then((r) => expectArray<{ id: string; name: string; channelIds: string[] }>(r));
           const room = rooms.find((r) => r.name === args.room);
           filterSets.push(new Set(room?.channelIds ?? []));
         }
@@ -82,7 +82,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             "Subsection.getAll",
             logger,
             { rateLimiter },
-          ) as Array<{ id: string; name: string; channelIds: string[] }>;
+          ).then((r) => expectArray<{ id: string; name: string; channelIds: string[] }>(r));
           const func = functions.find((f) => f.name === args.function);
           filterSets.push(new Set(func?.channelIds ?? []));
         }
@@ -210,7 +210,7 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
       const { rateLimiter, logger } = deps;
       const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
-      let programs = await withRetry(() => session.call("Program.getAll"), "Program.getAll", logger, { rateLimiter }) as Array<{ name: string }>;
+      let programs = await withRetry(() => session.call("Program.getAll"), "Program.getAll", logger, { rateLimiter }).then((r) => expectArray<{ name: string }>(r));
 
       if (args.name) {
         const needle = args.name.toLowerCase();
@@ -239,7 +239,7 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
       const { rateLimiter, logger } = deps;
       const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
-      let sysvars = await withRetry(() => session.call("SysVar.getAll"), "SysVar.getAll", logger, { rateLimiter }) as Array<{ name: string }>;
+      let sysvars = await withRetry(() => session.call("SysVar.getAll"), "SysVar.getAll", logger, { rateLimiter }).then((r) => expectArray<{ name: string }>(r));
 
       if (args.name) {
         const needle = args.name.toLowerCase();
@@ -335,7 +335,7 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
         "Device.listAllDetail",
         logger,
         { rateLimiter },
-      ) as CcuDevice[];
+      ).then((r) => expectArray<CcuDevice>(r));
       resolver.updateDeviceList(devices);
       const channelName = new Map<string, string>();
       for (const d of devices) for (const ch of d.channels) channelName.set(ch.address, ch.name);
@@ -347,7 +347,7 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
         "Interface.listInterfaces",
         logger,
         { rateLimiter },
-      ) as Array<{ name: string }>;
+      ).then((r) => expectArray<{ name: string }>(r));
 
       // Match a channel address against the filter: exact channel, or any
       // channel of the given device address (so a device-level filter works).

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -49,6 +49,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
         () => session.call("Device.listAllDetail"),
         "Device.listAllDetail",
         logger,
+        { rateLimiter },
       );
 
       let devices = result as CcuDevice[];
@@ -68,6 +69,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             () => session.call("Room.getAll"),
             "Room.getAll",
             logger,
+            { rateLimiter },
           ) as Array<{ id: string; name: string; channelIds: string[] }>;
           const room = rooms.find((r) => r.name === args.room);
           filterSets.push(new Set(room?.channelIds ?? []));
@@ -79,6 +81,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             () => session.call("Subsection.getAll"),
             "Subsection.getAll",
             logger,
+            { rateLimiter },
           ) as Array<{ id: string; name: string; channelIds: string[] }>;
           const func = functions.find((f) => f.name === args.function);
           filterSets.push(new Set(func?.channelIds ?? []));
@@ -144,7 +147,7 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
       const { rateLimiter, logger } = deps;
       const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
-      const result = await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger);
+      const result = await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger, { rateLimiter });
       return structuredResult({ interfaces: Array.isArray(result) ? result : [] }, result);
     }),
   );
@@ -164,7 +167,7 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
       const { rateLimiter, logger } = deps;
       const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
-      const result = await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger);
+      const result = await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger, { rateLimiter });
       return structuredResult({ rooms: Array.isArray(result) ? result : [] }, result);
     }),
   );
@@ -184,7 +187,7 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
       const { rateLimiter, logger } = deps;
       const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
-      const result = await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger);
+      const result = await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger, { rateLimiter });
       return structuredResult({ functions: Array.isArray(result) ? result : [] }, result);
     }),
   );
@@ -207,7 +210,7 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
       const { rateLimiter, logger } = deps;
       const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
-      let programs = await withRetry(() => session.call("Program.getAll"), "Program.getAll", logger) as Array<{ name: string }>;
+      let programs = await withRetry(() => session.call("Program.getAll"), "Program.getAll", logger, { rateLimiter }) as Array<{ name: string }>;
 
       if (args.name) {
         const needle = args.name.toLowerCase();
@@ -236,7 +239,7 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
       const { rateLimiter, logger } = deps;
       const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
-      let sysvars = await withRetry(() => session.call("SysVar.getAll"), "SysVar.getAll", logger) as Array<{ name: string }>;
+      let sysvars = await withRetry(() => session.call("SysVar.getAll"), "SysVar.getAll", logger, { rateLimiter }) as Array<{ name: string }>;
 
       if (args.name) {
         const needle = args.name.toLowerCase();
@@ -331,6 +334,7 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
         () => session.call("Device.listAllDetail"),
         "Device.listAllDetail",
         logger,
+        { rateLimiter },
       ) as CcuDevice[];
       resolver.updateDeviceList(devices);
       const channelName = new Map<string, string>();
@@ -342,6 +346,7 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
         () => session.call("Interface.listInterfaces"),
         "Interface.listInterfaces",
         logger,
+        { rateLimiter },
       ) as Array<{ name: string }>;
 
       // Match a channel address against the filter: exact channel, or any
@@ -360,6 +365,7 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
             () => session.call("Interface.getLinks", { interface: iface.name, address: args.address ?? "", flags: 0 }),
             "Interface.getLinks",
             logger,
+            { rateLimiter },
           );
         } catch {
           continue; // interface doesn't expose getLinks

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -43,7 +43,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => runTool("list_devices", deps.logger, async (log) => {
       const { rateLimiter, logger } = deps;
-      const { session, resolver } = resolveTarget(deps.targets, args.target);
+      const { session, resolver } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
       const result = await withRetry(
         () => session.call("Device.listAllDetail"),
@@ -57,7 +57,10 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
       resolver.updateDeviceList(devices);
 
       if (args.room || args.function) {
-        const channelIds = new Set<string>();
+        // Each filter contributes its own channel-id set; when both are given
+        // they must compose as AND (a channel in that room AND that function),
+        // not as a union — "room + function" means the intersection.
+        const filterSets: Array<Set<string>> = [];
 
         if (args.room) {
           await rateLimiter.acquire();
@@ -67,7 +70,7 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             logger,
           ) as Array<{ id: string; name: string; channelIds: string[] }>;
           const room = rooms.find((r) => r.name === args.room);
-          if (room) for (const id of room.channelIds) channelIds.add(id);
+          filterSets.push(new Set(room?.channelIds ?? []));
         }
 
         if (args.function) {
@@ -78,12 +81,12 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             logger,
           ) as Array<{ id: string; name: string; channelIds: string[] }>;
           const func = functions.find((f) => f.name === args.function);
-          if (func) for (const id of func.channelIds) channelIds.add(id);
+          filterSets.push(new Set(func?.channelIds ?? []));
         }
 
-        devices = channelIds.size > 0
-          ? devices.filter((d) => d.channels.some((ch) => channelIds.has(ch.id)))
-          : [];
+        devices = devices.filter((d) =>
+          d.channels.some((ch) => filterSets.every((s) => s.has(ch.id))),
+        );
       }
 
       if (args.type) devices = devices.filter((d) => d.type === args.type);
@@ -133,11 +136,13 @@ function registerListInterfaces(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Interfaces",
       description: "List available communication interfaces (BidCos-RF, HmIP-RF, VirtualDevices, etc.).",
+      inputSchema: { target: targetField },
       outputSchema: { interfaces: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => runTool("list_interfaces", deps.logger, async () => {
-      const { session, rateLimiter, logger } = deps;
+    async (args) => runTool("list_interfaces", deps.logger, async () => {
+      const { rateLimiter, logger } = deps;
+      const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
       const result = await withRetry(() => session.call("Interface.listInterfaces"), "Interface.listInterfaces", logger);
       return structuredResult({ interfaces: Array.isArray(result) ? result : [] }, result);
@@ -151,11 +156,13 @@ function registerListRooms(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Rooms",
       description: "List all rooms with their assigned channel IDs. Use with list_devices to find devices by room.",
+      inputSchema: { target: targetField },
       outputSchema: { rooms: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => runTool("list_rooms", deps.logger, async () => {
-      const { session, rateLimiter, logger } = deps;
+    async (args) => runTool("list_rooms", deps.logger, async () => {
+      const { rateLimiter, logger } = deps;
+      const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
       const result = await withRetry(() => session.call("Room.getAll"), "Room.getAll", logger);
       return structuredResult({ rooms: Array.isArray(result) ? result : [] }, result);
@@ -169,11 +176,13 @@ function registerListFunctions(server: McpServer, deps: ServerDeps): void {
     {
       title: "List Functions",
       description: "List all function groups (Heating, Lighting, etc.) with their assigned channel IDs.",
+      inputSchema: { target: targetField },
       outputSchema: { functions: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
-    async () => runTool("list_functions", deps.logger, async () => {
-      const { session, rateLimiter, logger } = deps;
+    async (args) => runTool("list_functions", deps.logger, async () => {
+      const { rateLimiter, logger } = deps;
+      const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
       const result = await withRetry(() => session.call("Subsection.getAll"), "Subsection.getAll", logger);
       return structuredResult({ functions: Array.isArray(result) ? result : [] }, result);
@@ -189,12 +198,14 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
       description: "List all automation programs. Use execute_program to trigger them.",
       inputSchema: {
         name: z.string().optional().describe("Filter by program name (substring, case-insensitive)"),
+        target: targetField,
       },
       outputSchema: { programs: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => runTool("list_programs", deps.logger, async () => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
+      const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
       let programs = await withRetry(() => session.call("Program.getAll"), "Program.getAll", logger) as Array<{ name: string }>;
 
@@ -216,12 +227,14 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
       description: "List all system variables with current values and metadata. Use set_system_variable to modify them.",
       inputSchema: {
         name: z.string().optional().describe("Filter by variable name (substring, case-insensitive)"),
+        target: targetField,
       },
       outputSchema: { systemVariables: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => runTool("list_system_variables", deps.logger, async () => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
+      const { session } = resolveTarget(deps.selection, args.target);
       await rateLimiter.acquire();
       let sysvars = await withRetry(() => session.call("SysVar.getAll"), "SysVar.getAll", logger) as Array<{ name: string }>;
 
@@ -254,7 +267,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
     async (args) => runTool("describe_device_type", deps.logger, async (log) => {
       const { rateLimiter } = deps;
       // resolveTarget may throw NOT_FOUND for an unknown target — runTool maps it.
-      const { session, resolver, deviceTypeCache } = resolveTarget(deps.targets, args.target);
+      const { session, resolver, deviceTypeCache } = resolveTarget(deps.selection, args.target);
 
       let cached = deviceTypeCache.get(args.deviceType);
 
@@ -304,12 +317,14 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
         "FALMOT). Read-only. Optionally filter to links involving a specific device or channel address.",
       inputSchema: {
         address: z.string().optional().describe("Device or channel address to filter by (e.g. '000A1BE9A71F15' or '000A1BE9A71F15:1')"),
+        target: targetField,
       },
       outputSchema: { links: z.array(z.unknown()) },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => runTool("list_links", deps.logger, async (log) => {
-      const { session, rateLimiter, logger } = deps;
+      const { rateLimiter, logger } = deps;
+      const { session, resolver } = resolveTarget(deps.selection, args.target);
       // Channel address → name map; SENDER/RECEIVER from getLinks are channel addresses.
       await rateLimiter.acquire();
       const devices = await withRetry(
@@ -317,7 +332,7 @@ function registerListLinks(server: McpServer, deps: ServerDeps): void {
         "Device.listAllDetail",
         logger,
       ) as CcuDevice[];
-      deps.resolver.updateDeviceList(devices);
+      resolver.updateDeviceList(devices);
       const channelName = new Map<string, string>();
       for (const d of devices) for (const ch of d.channels) channelName.set(ch.address, ch.name);
 

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -29,7 +29,10 @@ CCU → Interfaces → Devices → Channels → Datapoints (paramsets)
 ## Paramsets
 - **VALUES** — Runtime state (temperature, switch state, valve position)
 - **MASTER** — Device configuration (reporting interval, display settings)
-- **LINK** — Direct peering configuration
+- **Link parameters** — Direct peering configuration. Read them with
+  \`get_paramset\` by passing the link PARTNER's channel address as
+  \`paramsetKey\` (find partners with \`list_links\`) — the literal key
+  "LINK" is not valid on the CCU.
 
 ## Typical Workflow
 1. \`list_devices\` → find device types and channel addresses

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -268,12 +268,16 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
       },
     },
     async (args) => runTool("run_script", deps.logger, async () => {
-      const { session, rateLimiter } = deps;
+      const { rateLimiter } = deps;
+      // Pin the target once so a concurrent use_ccu can't split the guard,
+      // session, and timeout across different targets mid-handler.
+      const active = deps.selection.active;
+      const { session } = active;
       // Scripts bypass every guard the typed tools enforce — per-call confirm (#72)
-      assertWritable(deps.selection, deps.selection.active, args.confirm, { alwaysConfirm: true });
+      assertWritable(deps.selection, active, args.confirm, { alwaysConfirm: true });
       await rateLimiter.acquire();
       // No retry — scripts are not idempotent
-      const result = await session.call("ReGa.runScript", { script: args.script }, deps.selection.active.profile.ccu.scriptTimeout);
+      const result = await session.call("ReGa.runScript", { script: args.script }, active.profile.ccu.scriptTimeout);
 
       return toolResult(result);
     }),

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -265,10 +265,10 @@ function registerRunScript(server: McpServer, deps: ServerDeps): void {
     async (args) => runTool("run_script", deps.logger, async () => {
       const { session, rateLimiter } = deps;
       // Scripts bypass every guard the typed tools enforce — per-call confirm (#72)
-      assertWritable(deps.targets.active, args.confirm, { alwaysConfirm: true });
+      assertWritable(deps.selection, deps.selection.active, args.confirm, { alwaysConfirm: true });
       await rateLimiter.acquire();
       // No retry — scripts are not idempotent
-      const result = await session.call("ReGa.runScript", { script: args.script }, deps.targets.active.profile.ccu.scriptTimeout);
+      const result = await session.call("ReGa.runScript", { script: args.script }, deps.selection.active.profile.ccu.scriptTimeout);
 
       return toolResult(result);
     }),

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -71,74 +71,77 @@ This server can be configured with several named CCU targets (profiles). One is
 
 const TOOL_HELP: Record<string, string> = {
   list_devices: `List all devices with channels, types, and addresses.
-Args: room? (string), function? (string), type? (string), name? (string)
+Args: room? (string), function? (string), type? (string, EXACT match), name? (string, substring), target? (CCU target name)
+Room + function together filter as AND (channels in that room AND that function).
 Returns compact summary when unfiltered (address, name, type, channel names only).
 Returns full details (all channel properties) when any filter is applied.
 Related: describe_device_type, get_value`,
 
   list_interfaces: `List available communication interfaces.
-Args: none
+Args: target? (CCU target name)
 Returns: Array of {name, port, info}`,
 
   list_rooms: `List all rooms with assigned channel IDs.
-Args: none
+Args: target? (CCU target name)
 Returns: Array of rooms`,
 
   list_functions: `List all function groups with assigned channel IDs.
-Args: none
+Args: target? (CCU target name)
 Returns: Array of function groups`,
 
   list_programs: `List automation programs.
-Args: name? (substring filter)
+Args: name? (substring filter), target? (CCU target name)
 Returns: Array of programs with id, name, active state`,
 
   list_system_variables: `List system variables with current values.
-Args: name? (substring filter)
+Args: name? (substring filter), target? (CCU target name)
 Returns: Array of variables with id, name, value, type, min, max`,
 
   describe_device_type: `Get channel/datapoint schema for a device type (from cache).
-Args: deviceType (string, e.g. "HmIP-eTRV-2")
+Args: deviceType (string, e.g. "HmIP-eTRV-2"), target? (CCU target name)
 Returns: Channels with paramsets, datapoint types, ranges, operations`,
 
   list_links: `List direct device links (Direktverknüpfungen) — sender→receiver channel pairings that work without the CCU.
-Args: address? (device or channel address filter, e.g. "000A1BE9A71F15" or "000A1BE9A71F15:1")
+Args: address? (device or channel address filter, e.g. "000A1BE9A71F15" or "000A1BE9A71F15:1"), target? (CCU target name)
 Returns: Array of {sender, senderName, receiver, receiverName, name, description, flags, interface}
 Read-only; answers "what directly controls this?". Link creation/removal is out of scope.`,
 
   get_value: `Read a single datapoint value.
-Args: address (string), valueKey (string), interface? (auto-resolved)
+Args: address (string), valueKey (string), interface? (auto-resolved), target? (CCU target name)
 Returns: {address, valueKey, value}
 Idempotent: yes`,
 
   get_values: `Bulk read datapoints for multiple channels.
-Args: channels? (string[]), room? (string), function? (string)
+Args: channels? (string[]), room? (string), function? (string), target? (CCU target name)
 Returns: Array of {address, name, datapoints}
 Idempotent: yes`,
 
   get_paramset: `Read all parameters for a channel.
-Args: address (string), paramsetKey ("VALUES"|"MASTER"|"LINK"), interface? (auto-resolved)
+Args: address (string), paramsetKey ("VALUES"|"MASTER"|"LINK"), interface? (auto-resolved), target? (CCU target name)
 Returns: {address, paramsetKey, params}
 Idempotent: yes`,
 
   set_value: `Set a single datapoint value. Returns previous value for undo.
-Args: address (string), valueKey (string), value (string|number|boolean), interface? (auto), type? (auto)
+Args: address (string), valueKey (string), value (string|number|boolean), interface? (auto), type? (auto), confirm? (true to authorize on a protected target)
 Returns: {previousValue, newValue, address, valueKey}
 Idempotent: yes`,
 
   put_paramset: `Write multiple parameters at once.
-Args: address (string), paramsetKey ("VALUES"|"MASTER"), set (object with key:value pairs, e.g. {"TEMPERATURE_WINDOW_OPEN": 5.0}), interface? (auto)
+Args: address (string), paramsetKey ("VALUES"|"MASTER"), set (object with key:value pairs, e.g. {"TEMPERATURE_WINDOW_OPEN": 5.0}), interface? (auto), confirm? (true to authorize on a protected target)
 The set object uses simple key:value format — types are auto-resolved from the device type cache. Values are converted to strings internally.
 Returns: {address, paramsetKey, written}
 Idempotent: yes`,
 
   set_system_variable: `Set a system variable (type auto-detected).
-Args: name (string), value (string|number|boolean)
+Args: name (string), value (string|number|boolean), confirm? (true to authorize on a protected target)
+Enum (LIST) variables accept a 0-based index or one of the enum's labels.
 Returns: {name, value, method}
 Idempotent: yes`,
 
   create_system_variable: `Create a new system variable.
 Args: name (string), type ("bool"|"float"|"enum"|"string"), description? (string),
-  unit?/min?/max? (float only), values? (string[], required for enum)
+  unit?/min?/max? (float only), values? (string[], required for enum; labels must not contain ";"),
+  confirm? (true to authorize on a protected target)
 Returns: {name, type, created: true}
 INVALID_INPUT if the name already exists (or enum without values). Use set_system_variable to write it.`,
 
@@ -148,34 +151,36 @@ Returns: {name, deleted: true}
 NOT_FOUND if the name doesn't exist.`,
 
   assign_channel: `Assign a channel to a room and/or function group.
-Args: channel (address), room? (name), function? (name) — at least one of room/function
+Args: channel (address), room? (name), function? (name) — at least one of room/function; confirm? (true to authorize on a protected target)
 Returns: {channel, assignedTo: [{kind, name}]}
 NOT_FOUND (with valid names) for unknown channel/room/function.`,
 
   unassign_channel: `Remove a channel from a room and/or function group.
-Args: channel (address), room? (name), function? (name) — at least one of room/function
+Args: channel (address), room? (name), function? (name) — at least one of room/function; confirm? (true to authorize on a protected target)
 Returns: {channel, removedFrom: [{kind, name}]}
 NOT_FOUND (with valid names) for unknown channel/room/function.`,
 
   execute_program: `Trigger an automation program. NOT idempotent — never auto-retried.
-Args: id (string)
+Args: id (string), confirm? (true to authorize on a protected target)
 Returns: {id, executed}`,
 
   get_service_messages: `Get active service messages (low battery, unreachable, etc.).
-Args: none
-Returns: Array of {id, name, address, channelName, timestamp}`,
+Args: target? (CCU target name)
+Returns: Array of {id, type, address, channelName, timestamp} — type is the alarm datapoint name (e.g. LOWBAT, UNREACH)`,
 
   acknowledge_service_messages: `Confirm/dismiss active service messages (e.g. clear a low-battery warning).
-Args: id (single alarm id from get_service_messages) OR address (all active messages on a channel) — at least one required
+Args: id (single alarm id from get_service_messages) OR address (all active messages on a channel) — at least one required; confirm? (true to authorize on a protected target)
 Returns: {confirmed: Array of {id, type, address}, count}
 NOT_FOUND if no active message matches; the warning reappears if its condition persists.`,
 
-  get_system_info: `Get CCU system info: firmware, serial, addresses, cache status.
-Args: none
-Returns: {version, serial, address, hmipAddress, cacheTypes, cacheWarming}`,
+  get_system_info: `Get CCU system info plus server identity: active target, login user, inferred role, build.
+Args: target? (CCU target name)
+Returns: {serverVersion, target, user, role (ADMIN|USER|UNKNOWN), version, serial, address, hmipAddress,
+  accessNote? (present when ADMIN-only fields are unavailable), cacheTypes, cacheWarming, build {branch, commit, tag, describe, dirty, builtAt}}
+version/serial/address/hmipAddress are ADMIN-only on the CCU and show "N/A" for a USER-level login.`,
 
   get_rssi: `Radio link quality (RSSI, dBm) per device, plus BidCos interface health.
-Args: name (optional substring filter on device name/address)
+Args: name? (substring filter on device name/address), target? (CCU target name)
 Returns: {devices: [{address, name, interface, links: [{peer, peerName, rssiDevice, rssiPeer}]}], interfaces}
 rssiDevice/rssiPeer are dBm (higher = better); null means no measurement. Use to diagnose flaky devices.`,
 

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -117,7 +117,7 @@ Returns: Array of {address, name, datapoints}
 Idempotent: yes`,
 
   get_paramset: `Read all parameters for a channel.
-Args: address (string), paramsetKey ("VALUES"|"MASTER"|"LINK"), interface? (auto-resolved), target? (CCU target name)
+Args: address (string), paramsetKey ("VALUES" | "MASTER" | a link partner's channel address for that link's parameters), interface? (auto-resolved), target? (CCU target name)
 Returns: {address, paramsetKey, params}
 Idempotent: yes`,
 

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -227,8 +227,9 @@ function registerHelp(server: McpServer, deps: ServerDeps): void {
         return toolResult(CONCEPTUAL_GUIDE);
       }
 
-      // Check if it's a tool name
-      if (args.topic in TOOL_HELP) {
+      // Check if it's a tool name (hasOwn: `in` would match Object.prototype
+      // keys, so help("constructor") would print native-code source)
+      if (Object.hasOwn(TOOL_HELP, args.topic)) {
         return toolResult(`# ${args.topic}\n\n${TOOL_HELP[args.topic]}`);
       }
 

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -42,7 +42,7 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => runTool("get_value", deps.logger, async (log) => {
       const { rateLimiter, logger } = deps;
-      const { session, resolver } = resolveTarget(deps.targets, args.target);
+      const { session, resolver } = resolveTarget(deps.selection, args.target);
       const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
       await rateLimiter.acquire();
@@ -83,7 +83,7 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => runTool("get_values", deps.logger, async () => {
       const { rateLimiter, logger } = deps;
-      const t = resolveTarget(deps.targets, args.target);
+      const t = resolveTarget(deps.selection, args.target);
       const { session } = t;
       // Build HM Script to collect values
       let script: string;
@@ -115,21 +115,37 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
       );
 
       const data = typeof result === "string" ? tryParseJson(result) : result;
+      // A non-array here means the ReGa script FAILED (runscript returns ""
+      // on any script error) or emitted broken JSON — answering with an empty
+      // success would be indistinguishable from "no matching channels".
+      if (!Array.isArray(data)) {
+        throw new CcuError({
+          error: "CCU_ERROR",
+          code: 0,
+          message: "The CCU script for get_values returned no parseable output",
+          hint: "The CCU's script engine failed (busy or errored). Try again; if it persists, check the CCU's ReGa state.",
+        });
+      }
       // Wrap the array for structuredContent; keep the bare array as the text block.
-      return structuredResult({ values: Array.isArray(data) ? data : [] }, data);
+      return structuredResult({ values: data }, data);
     }),
   );
 }
 
 // Helper HM Script fragment: write channel datapoints as JSON object
 // Quote all values as JSON strings for safety — empty values, special chars, enums all handled.
-// Names and values are JSON-escaped (backslash first, then quote) since channel names and
-// STRING datapoints are user-controlled; addresses and HssType are CCU identifiers and safe.
+// Names and values are JSON-escaped (backslash first, then quote, then the control
+// characters JSON forbids raw — tab/newline/CR reachable via user-renamed channels and
+// STRING datapoints) since both are user-controlled; addresses and HssType are CCU
+// identifiers and safe. The "\t"/"\n"/"\r" literals are real ReGa string escapes.
 const WRITE_CHANNEL_DPS = `
           if (!first) { Write(","); } first = false;
           string chNameEsc = ch.Name();
           chNameEsc = chNameEsc.Replace("\\\\", "\\\\\\\\");
           chNameEsc = chNameEsc.Replace("\\"", "\\\\\\"");
+          chNameEsc = chNameEsc.Replace("\\t", "\\\\t");
+          chNameEsc = chNameEsc.Replace("\\r", "\\\\r");
+          chNameEsc = chNameEsc.Replace("\\n", "\\\\n");
           Write('{"address":"' # ch.Address() # '","name":"' # chNameEsc # '","datapoints":{');
           boolean firstDp = true;
           string dpId;
@@ -140,6 +156,9 @@ const WRITE_CHANNEL_DPS = `
               string dpValEsc = "" # dp.Value();
               dpValEsc = dpValEsc.Replace("\\\\", "\\\\\\\\");
               dpValEsc = dpValEsc.Replace("\\"", "\\\\\\"");
+              dpValEsc = dpValEsc.Replace("\\t", "\\\\t");
+              dpValEsc = dpValEsc.Replace("\\r", "\\\\r");
+              dpValEsc = dpValEsc.Replace("\\n", "\\\\n");
               Write('"' # dp.HssType() # '":"' # dpValEsc # '"');
             }
           }
@@ -213,7 +232,7 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => runTool("get_paramset", deps.logger, async () => {
       const { rateLimiter, logger } = deps;
-      const { session, resolver } = resolveTarget(deps.targets, args.target);
+      const { session, resolver } = resolveTarget(deps.selection, args.target);
       const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
       await rateLimiter.acquire();

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -217,11 +217,12 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
     {
       title: "Get Paramset",
       description:
-        "Read all parameters for a channel (VALUES, MASTER, or LINK). " +
-        "Interface is auto-resolved from the address.",
+        "Read all parameters for a channel: VALUES (runtime state), MASTER (config), or a link " +
+        "paramset — for the latter pass the LINK PARTNER's channel address as paramsetKey " +
+        "(find partners with list_links). Interface is auto-resolved from the address.",
       inputSchema: {
         address: z.string().describe("Channel address (e.g. '000A1BE9A71F15:1')"),
-        paramsetKey: z.enum(["VALUES", "MASTER", "LINK"]).describe("Paramset to read"),
+        paramsetKey: z.string().describe("'VALUES', 'MASTER', or a link partner's channel address (reads that direct link's parameters)"),
         interface: z.string().optional().describe("Interface name override (auto-resolved if omitted)"),
         target: targetField,
       },
@@ -235,6 +236,18 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
     async (args) => runTool("get_paramset", deps.logger, async () => {
       const { rateLimiter, logger } = deps;
       const { session, resolver } = resolveTarget(deps.selection, args.target);
+      // The XML-RPC layer accepts MASTER, VALUES, or a link PARTNER's channel
+      // address as the paramset key — the literal "LINK" is not a valid key
+      // (verified live: it fails 502 "unknown device or channel", which would
+      // surface as a misleading NOT_FOUND for a channel that exists).
+      if (args.paramsetKey.toUpperCase() === "LINK") {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: 'The literal "LINK" is not a valid paramset key on the CCU.',
+          hint: "To read a direct link's parameters, pass the LINK PARTNER's channel address as paramsetKey (find partners with list_links).",
+        });
+      }
       const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
       await rateLimiter.acquire();

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -128,6 +128,18 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
           hint: "The CCU's script engine failed (busy or errored). Try again; if it persists, check the CCU's ReGa state.",
         });
       }
+      // Parse each datapoint value to a native type, so a value read via the
+      // bulk get_values matches what the single get_value / get_paramset
+      // return (the HM-script emits every value as a quoted string for safe
+      // JSON; without this, STATE would be "true" here but boolean true there).
+      for (const entry of data) {
+        if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+          const dps = (entry as Record<string, unknown>).datapoints;
+          if (dps && typeof dps === "object" && !Array.isArray(dps)) {
+            (entry as Record<string, unknown>).datapoints = parseValues(dps as Record<string, unknown>);
+          }
+        }
+      }
       // Wrap the array for structuredContent; keep the bare array as the text block.
       return structuredResult({ values: data }, data);
     }),

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -54,6 +54,7 @@ function registerGetValue(server: McpServer, deps: ServerDeps): void {
         }),
         "Interface.getValue",
         logger,
+        { rateLimiter },
       );
 
       log({ address: args.address });
@@ -112,6 +113,7 @@ function registerGetValues(server: McpServer, deps: ServerDeps): void {
         () => session.call("ReGa.runScript", { script }, t.profile.ccu.scriptTimeout),
         "ReGa.runScript",
         logger,
+        { rateLimiter },
       );
 
       const data = typeof result === "string" ? tryParseJson(result) : result;
@@ -244,6 +246,7 @@ function registerGetParamset(server: McpServer, deps: ServerDeps): void {
         }),
         "Interface.getParamset",
         logger,
+        { rateLimiter },
       );
 
       // Parse values to native types if result is a flat object

--- a/src/tools/targets.ts
+++ b/src/tools/targets.ts
@@ -12,7 +12,7 @@ export function registerTargetTools(server: McpServer, deps: ServerDeps): void {
 }
 
 // Identity view of a target — NEVER includes the password.
-function targetInfo(t: Target, activeName: string) {
+function targetInfo(t: Target, activeName: string, unlocked: boolean) {
   return {
     name: t.profile.name,
     host: t.profile.ccu.host,
@@ -23,7 +23,7 @@ function targetInfo(t: Target, activeName: string) {
     readonly: t.profile.readonly,
     active: t.profile.name === activeName,
     loggedIn: t.session.isLoggedIn(),
-    writesUnlocked: t.unlocked,
+    writesUnlocked: unlocked,
   };
 }
 
@@ -43,8 +43,8 @@ function registerListTargets(server: McpServer, deps: ServerDeps): void {
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async () => {
-      const activeName = deps.targets.active.profile.name;
-      const targets = deps.targets.list().map((t) => targetInfo(t, activeName));
+      const activeName = deps.selection.active.profile.name;
+      const targets = deps.targets.list().map((t) => targetInfo(t, activeName, deps.selection.isUnlocked(t)));
       return structuredResult({ targets, active: activeName }, { targets, active: activeName });
     },
   );
@@ -73,8 +73,8 @@ function registerGetConnectionInfo(server: McpServer, deps: ServerDeps): void {
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async () => {
-      const active = deps.targets.active;
-      return structuredResult(targetInfo(active, active.profile.name));
+      const active = deps.selection.active;
+      return structuredResult(targetInfo(active, active.profile.name, deps.selection.isUnlocked(active)));
     },
   );
 }
@@ -107,9 +107,17 @@ function registerUseCcu(server: McpServer, deps: ServerDeps): void {
     },
     async (args) => {
       try {
-        const t = deps.targets.use(args.profile);
+        const t = deps.selection.use(args.profile);
         deps.logger.info("ccu_target_switched", { target: t.profile.name });
-        return structuredResult(targetInfo(t, t.profile.name));
+        // The switched-to target may only have an expired on-disk schema cache
+        // (only the default target warms at startup) — refresh it in the
+        // background so type resolution doesn't serve stale schemas forever.
+        if (t.deviceTypeCache.isStale() && !t.deviceTypeCache.isWarming()) {
+          t.deviceTypeCache.warm(t.session, deps.rateLimiter).catch((err) => {
+            deps.logger.error("cache_warm_background_error", { error: (err as Error).message });
+          });
+        }
+        return structuredResult(targetInfo(t, t.profile.name, deps.selection.isUnlocked(t)));
       } catch (err) {
         if (err instanceof CcuError) return err.toMcpError();
         throw err;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { CcuError } from "./middleware/error-mapper.js";
 const _require = createRequire(import.meta.url);
 
 /** Server version — read from package.json at runtime, single source of truth. */
@@ -94,6 +95,25 @@ export function structuredResult(structured: Record<string, unknown>, text?: unk
     content: [{ type: "text" as const, text: typeof body === "string" ? body : JSON.stringify(body, null, 2) }],
     structuredContent: structured,
   };
+}
+
+/**
+ * Assert a CCU JSON-RPC result is an array before it is iterated. A CCU (or a
+ * proxy in front of it) answering a valid JSON-RPC envelope with `result:
+ * null` must surface as a structured CCU_ERROR, not as a TypeError crash
+ * ("null is not iterable") with no category or hint.
+ */
+export function expectArray<T>(result: unknown, ccuMethod?: string): T[] {
+  if (!Array.isArray(result)) {
+    throw new CcuError({
+      error: "CCU_ERROR",
+      code: 0,
+      message: `CCU returned an unexpected non-array result${ccuMethod ? ` for ${ccuMethod}` : ""}`,
+      hint: "The CCU (or a proxy in front of it) answered with a malformed result. Try again; if it persists, check the CCU's API service.",
+      ...(ccuMethod && { ccuMethod }),
+    });
+  }
+  return result as T[];
 }
 
 /** Try to parse JSON, return raw string on failure. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,7 +116,12 @@ export function parseValue(val: unknown): unknown {
   if (s === "") return null;
   if (s === "true") return true;
   if (s === "false") return false;
-  if (DECIMAL_RE.test(s)) return Number(s);
+  if (DECIMAL_RE.test(s)) {
+    // Precision guard: Number() silently rounds past ~15 significant digits,
+    // so a long numeric ID stored in a STRING datapoint would be corrupted.
+    const significant = s.replace(/[-.]/g, "").replace(/^0+/, "");
+    if (significant.length <= 15) return Number(s);
+  }
   return s;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,6 +121,16 @@ export function parseValue(val: unknown): unknown {
     // so a long numeric ID stored in a STRING datapoint would be corrupted.
     const significant = s.replace(/[-.]/g, "").replace(/^0+/, "");
     if (significant.length <= 15) return Number(s);
+    // Longer digit strings are still fine when the double round-trips exactly
+    // (e.g. "3600000000000000" — trailing zeros carry no precision).
+    if (!s.includes(".")) {
+      try {
+        const n = Number(s);
+        if (BigInt(s) === BigInt(n)) return n;
+      } catch {
+        // fall through to returning the string
+      }
+    }
   }
   return s;
 }

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -140,10 +140,16 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     const sid = await initialize(mcpPort);
     const res = await mcpPost(mcpPort, {
       jsonrpc: "2.0", id: 2, method: "tools/call",
-      params: { name: "get_system_info", arguments: {} },
+      params: { name: "list_devices", arguments: {} },
     }, sid);
     expect(res.status).toBe(200);
-    await res.text();
+    const msg = await parseSse(res);
+    // The failure must surface as a STRUCTURED tool error (isError + JSON
+    // body with category and hint), not a JSON-RPC crash or empty success.
+    expect(msg.result.isError).toBe(true);
+    const structured = JSON.parse(msg.result.content[0].text) as { error: string; hint: string };
+    expect(["UNREACHABLE", "TIMEOUT", "AUTH", "CCU_ERROR"]).toContain(structured.error);
+    expect(structured.hint).toBeTruthy();
     expect(child.exitCode).toBeNull(); // server survived the failed CCU call
   });
 });

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -14,6 +14,21 @@ import { AddressInfo } from "node:net";
 
 const DIST = join(__dirname, "../../dist/index.js");
 const AUTH_TOKEN = "e2e-test-token";
+
+/**
+ * process.env with every server config var scrubbed. The e2e children must be
+ * driven ONLY by the vars each test sets: an ambient CCU_PROFILES would make
+ * the child ignore the injected mock CCU_HOST (and hit a real CCU!), and
+ * ambient CCU_TLS_x / CCU_DEFAULT_PROFILE would trip config validation and
+ * kill the child with an opaque "server did not start" timeout.
+ */
+function cleanEnv(): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (/^(CCU_|MCP_|CACHE_|RESOURCE_POLL_INTERVAL$|LOG_LEVEL$)/.test(key)) delete env[key];
+  }
+  return env;
+}
 // Origin on the allowlist for the CORS-enabled describe block below.
 const ALLOWED_ORIGIN = "http://localhost:6274";
 
@@ -86,7 +101,7 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
 
     child = spawn("node", [DIST], {
       env: {
-        ...process.env,
+        ...cleanEnv(),
         CCU_HOST: "127.0.0.1",
         CCU_PORT: "9", // discard port — nothing listens, connection refused
         CCU_HTTPS: "false",
@@ -167,7 +182,7 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
 
     child = spawn("node", [DIST], {
       env: {
-        ...process.env,
+        ...cleanEnv(),
         CCU_HOST: "127.0.0.1",
         CCU_PORT: String(ccu.port),
         CCU_HTTPS: "false",
@@ -437,7 +452,7 @@ describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebin
 
     child = spawn("node", [DIST], {
       env: {
-        ...process.env,
+        ...cleanEnv(),
         CCU_HOST: "127.0.0.1",
         CCU_PORT: String(ccu.port),
         CCU_HTTPS: "false",
@@ -572,7 +587,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
 
     child = spawn("node", [DIST], {
       env: {
-        ...process.env,
+        ...cleanEnv(),
         CCU_HOST: "127.0.0.1",
         CCU_PORT: String(ccu.port),
         CCU_HTTPS: "false",

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -135,9 +135,16 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
     rmSync(cacheDir, { recursive: true, force: true });
   });
 
-  it("stays alive and reports degraded health", async () => {
+  it("stays alive and reports degraded health (detailed view needs auth)", async () => {
     expect(child.exitCode).toBeNull();
-    const res = await fetch(`http://127.0.0.1:${mcpPort}/health`);
+    // Unauthenticated: liveness only — session state must not leak pre-auth.
+    const anon = await fetch(`http://127.0.0.1:${mcpPort}/health`);
+    expect(anon.status).toBe(200);
+    expect(((await anon.json()) as { status: string }).status).toBe("ok");
+    // Authenticated: full degraded status.
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/health`, {
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    });
     expect(res.status).toBe(503);
     const body = await res.json() as { status: string };
     expect(body.status).toBe("degraded");
@@ -221,11 +228,16 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
     rmSync(cacheDir, { recursive: true, force: true });
   });
 
-  it("serves the health endpoint without auth", async () => {
+  it("serves the health endpoint without auth (liveness only)", async () => {
     const res = await fetch(`http://127.0.0.1:${mcpPort}/health`);
     expect(res.status).toBe(200);
     const body = await res.json() as { status: string };
-    expect(body.status).toBe("healthy");
+    expect(body.status).toBe("ok");
+    // Detailed status requires the bearer token.
+    const detailed = await fetch(`http://127.0.0.1:${mcpPort}/health`, {
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    });
+    expect((await detailed.json() as { status: string }).status).toBe("healthy");
   });
 
   it("rejects MCP requests without a token", async () => {
@@ -626,7 +638,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   it("serves the health endpoint over HTTPS", async () => {
     const res = await httpsJson(mcpPort, { path: "/health", ca: caCert });
     expect(res.status).toBe(200);
-    expect((JSON.parse(res.text) as { status: string }).status).toBe("healthy");
+    expect((JSON.parse(res.text) as { status: string }).status).toBe("ok");
   });
 
   it("rejects a plaintext HTTP request to the TLS port (TLS is actually on)", async () => {

--- a/test/integration/ccu-client.test.ts
+++ b/test/integration/ccu-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { SessionManager } from "../../src/ccu/session.js";
 import { DeviceTypeCache } from "../../src/cache/device-type-cache.js";
+import { CACHE_VERSION } from "../../src/cache/types.js";
 import { RateLimiter } from "../../src/middleware/rate-limiter.js";
 import { createLogger } from "../../src/logger.js";
 import { Resolver } from "../../src/middleware/resolver.js";
@@ -173,7 +174,7 @@ describeIf("CCU Integration (against debmatic)", () => {
     const { readFile } = await import("node:fs/promises");
     const fileContent = await readFile(join(tempDir, "device-type-cache.json"), "utf-8");
     const parsed = JSON.parse(fileContent);
-    expect(parsed.version).toBe(1);
+    expect(parsed.version).toBe(CACHE_VERSION);
     expect(Object.keys(parsed.types).length).toBeGreaterThan(0);
 
     // Spot check a known device type

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { RateLimiter } from "../../src/middleware/rate-limiter.js";
-import { TargetRegistry } from "../../src/ccu/target-registry.js";
+import { TargetRegistry, TargetSelection } from "../../src/ccu/target-registry.js";
 import { createLogger } from "../../src/logger.js";
 import { createMcpServer, type ServerDeps } from "../../src/server.js";
 import type { AppConfig } from "../../src/config.js";
@@ -48,13 +48,15 @@ describeIf("MCP tools against live CCU", () => {
       resourcePollInterval: 3600,
     };
     targets = new TargetRegistry(appConfig, logger, tempDir);
-    await targets.loginActive();
+    await targets.loginDefault();
+    const selection = new TargetSelection(targets);
     deps = {
       config: appConfig,
       targets,
-      get session() { return targets.active.session; },
-      get resolver() { return targets.active.resolver; },
-      get deviceTypeCache() { return targets.active.deviceTypeCache; },
+      selection,
+      get session() { return selection.active.session; },
+      get resolver() { return selection.active.resolver; },
+      get deviceTypeCache() { return selection.active.deviceTypeCache; },
       rateLimiter: new RateLimiter(20, 10),
       logger,
     };

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -70,7 +70,7 @@ describeIf("MCP tools against live CCU", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it("get_values by room returns parsed channel data (live ReGa script)", async () => {
+  it("get_values by room returns channel data with native-typed datapoints (live ReGa script)", async () => {
     const rooms = parseToolResult(await callTool(server, "list_rooms")) as Array<{ name: string }>;
     expect(rooms.length).toBeGreaterThan(0);
 

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -4,8 +4,7 @@ import { Logger } from "../../src/logger.js";
 import { RateLimiter } from "../../src/middleware/rate-limiter.js";
 import { DeviceTypeCache } from "../../src/cache/device-type-cache.js";
 import { Resolver } from "../../src/middleware/resolver.js";
-import type { Target, TargetRegistry } from "../../src/ccu/target-registry.js";
-import { CcuError } from "../../src/middleware/error-mapper.js";
+import { TargetSelection, type Target, type TargetRegistry } from "../../src/ccu/target-registry.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 type SessionCall = (method: string, params?: Record<string, unknown>, timeout?: number) => Promise<unknown>;
@@ -43,32 +42,27 @@ function makeTarget(spec: TargetSpec): Target {
     resolver: new Resolver(),
     deviceTypeCache: new DeviceTypeCache("/tmp/nonexistent-test", 86400, new Logger("error"), `device-type-cache.${name}.json`),
     sysVarTypeCache: { entry: null },
-    unlocked: false,
   };
 }
 
 // Minimal in-memory stand-in for TargetRegistry (real one builds live sessions).
+// Mirrors the registry surface TargetSelection and the tools rely on.
 class FakeRegistry {
   private readonly byName = new Map<string, Target>();
   private readonly order: string[] = [];
-  private activeKey: string;
+  readonly defaultKey: string;
   constructor(targets: Target[]) {
     for (const t of targets) {
       this.byName.set(t.profile.name.toLowerCase(), t);
       this.order.push(t.profile.name);
     }
-    this.activeKey = targets[0]!.profile.name.toLowerCase();
+    this.defaultKey = targets[0]!.profile.name.toLowerCase();
   }
-  get active(): Target { return this.byName.get(this.activeKey)!; }
+  get default(): Target { return this.byName.get(this.defaultKey)!; }
   getByName(name: string): Target | undefined { return this.byName.get(name.toLowerCase()); }
   has(name: string): boolean { return this.byName.has(name.toLowerCase()); }
   list(): Target[] { return this.order.map((n) => this.byName.get(n.toLowerCase())!); }
-  use(name: string): Target {
-    const t = this.getByName(name);
-    if (!t) throw new CcuError({ error: "NOT_FOUND", code: 0, message: `Unknown CCU target: ${name}`, hint: "Call list_ccu_targets." });
-    this.activeKey = t.profile.name.toLowerCase();
-    return t;
-  }
+  names(): string[] { return [...this.order]; }
 }
 
 export function createMockDeps(overrides?: {
@@ -88,21 +82,23 @@ export function createMockDeps(overrides?: {
     sessionCall: overrides?.sessionCall,
   }];
   const registry = new FakeRegistry(specs.map(makeTarget));
+  const selection = new TargetSelection(registry as unknown as TargetRegistry);
 
   return {
     config: {
-      ccu: registry.active.profile.ccu,
+      ccu: registry.default.profile.ccu,
       profiles: registry.list().map((t) => t.profile),
-      defaultProfile: registry.active.profile.name,
+      defaultProfile: registry.default.profile.name,
       mcp: { transport: "stdio" as const, port: 3000, allowedOrigins: [], allowedHosts: [], allowPlaintext: false, authTokenGraceMs: 86400000 },
       cache: { dir: "/tmp", ttl: 86400 },
       rateLimiter: { burst: 1000, rate: 1000 },
       resourcePollInterval: 60,
     },
     targets: registry as unknown as TargetRegistry,
-    get session() { return registry.active.session; },
-    get resolver() { return registry.active.resolver; },
-    get deviceTypeCache() { return registry.active.deviceTypeCache; },
+    selection,
+    get session() { return selection.active.session; },
+    get resolver() { return selection.active.resolver; },
+    get deviceTypeCache() { return selection.active.deviceTypeCache; },
     rateLimiter,
     logger: new Logger("error"),
   };

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -41,7 +41,7 @@ function makeTarget(spec: TargetSpec): Target {
     session: makeSession(spec.sessionCall),
     resolver: new Resolver(),
     deviceTypeCache: new DeviceTypeCache("/tmp/nonexistent-test", 86400, new Logger("error"), `device-type-cache.${name}.json`),
-    sysVarTypeCache: { entry: null },
+    sysVarTypeCache: { entry: null, gen: 0 },
   };
 }
 

--- a/test/unit/auth-token.test.ts
+++ b/test/unit/auth-token.test.ts
@@ -151,6 +151,31 @@ describe("resolveAuthTokens", () => {
       expect(tokens.verify(tokenB, tRotate + 24 * HOUR + 1)).toBe(true);
     });
 
+    it("early (lookahead) rotation keeps the old token valid through its promised hard expiry", async () => {
+      const t0 = 1_000_000_000_000;
+      const MIN = 60_000;
+      // Token A, TTL 30 days, tiny grace (3 min) — shorter than the 5-min tick.
+      await resolveAuthTokens({ dataDir: dir, ttlMs: 30 * DAY, graceMs: 3 * MIN }, logger, t0);
+      const tokenA = await fileToken(dir);
+
+      // A tick 4 minutes BEFORE hard expiry rotates early via lookahead.
+      const tTick = t0 + 30 * DAY - 4 * MIN;
+      const tokens = await resolveAuthTokens(
+        { dataDir: dir, ttlMs: 30 * DAY, graceMs: 3 * MIN },
+        logger,
+        tTick,
+        5 * MIN, // lookahead
+      );
+      const tokenB = await fileToken(dir);
+      expect(tokenB).not.toBe(tokenA);
+
+      // A must stay valid until its PROMISED hard expiry (t0 + 30d), even
+      // though tick+grace (3 min) would end 1 min earlier.
+      expect(tokens.verify(tokenA, t0 + 30 * DAY - 1)).toBe(true);
+      expect(tokens.verify(tokenA, t0 + 30 * DAY + 1)).toBe(false);
+      expect(tokens.verify(tokenB, t0 + 30 * DAY + 1)).toBe(true);
+    });
+
     it("drops a rotated-out token from the file once its grace fully elapses", async () => {
       const t0 = 1_000_000_000_000;
       await resolveAuthTokens({ dataDir: dir, ttlMs: 30 * DAY, graceMs: 24 * HOUR }, logger, t0);

--- a/test/unit/auth-token.test.ts
+++ b/test/unit/auth-token.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { resolveAuthTokens } from "../../src/auth/token.js";
+import { resolveAuthTokens, AuthTokens } from "../../src/auth/token.js";
+import { createHash } from "node:crypto";
 import { Logger } from "../../src/logger.js";
 import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -182,5 +183,40 @@ describe("resolveAuthTokens", () => {
     // gets it on stderr. We can't read it from a file, but a bogus token fails.
     expect(tokens.verify("definitely-not-it")).toBe(false);
     expect(tokens.liveCount()).toBe(1);
+  });
+});
+
+describe("AuthTokens grace-entry retention (recovery after broken data dir)", () => {
+  const h = (s: string) => createHash("sha256").update(s).digest();
+  const entry = (token: string, expiresAt: number | null, label = "generated") =>
+    ({ hash: h(token), expiresAt, label });
+
+  it("replaceWith keeps in-memory graced entries until their own expiry", () => {
+    const now = 1_000_000;
+    const tokens = new AuthTokens([entry("startup", null)]);
+    // Recovery adopts the newly persisted token with a grace overlap...
+    tokens.adoptWithGrace(new AuthTokens([entry("persisted", null)]), 60_000, now);
+    expect(tokens.verify("startup", now + 1)).toBe(true);
+    // ...and the NEXT rotation tick, rebuilt from the file alone, must not
+    // wipe that grace (the file knows nothing of the in-memory token).
+    tokens.replaceWith(new AuthTokens([entry("persisted", null)]), now + 2);
+    expect(tokens.verify("startup", now + 3)).toBe(true);
+    expect(tokens.verify("persisted", now + 3)).toBe(true);
+    // The grace still ends at its cutoff.
+    expect(tokens.verify("startup", now + 60_001)).toBe(false);
+    expect(tokens.verify("persisted", now + 60_001)).toBe(true);
+  });
+
+  it("adoptWithGrace prunes expired entries and dedupes, bounding growth", () => {
+    const now = 1_000_000;
+    const tokens = new AuthTokens([
+      entry("dead", now - 1),
+      entry("live", null),
+    ]);
+    tokens.adoptWithGrace(new AuthTokens([entry("live", null)]), 60_000, now);
+    // dead pruned, live deduped against the adopted set → exactly one entry
+    expect(tokens.liveCount(now)).toBe(1);
+    expect(tokens.verify("live", now)).toBe(true);
+    expect(tokens.verify("dead", now)).toBe(false);
   });
 });

--- a/test/unit/ccu-tls-verify.test.ts
+++ b/test/unit/ccu-tls-verify.test.ts
@@ -105,7 +105,10 @@ describe.skipIf(!HAVE_OPENSSL)("CcuClient TLS verification (real HTTPS server)",
       expect.unreachable("should have rejected the cert");
     } catch (err) {
       expect(err).toBeInstanceOf(CcuError);
-      expect((err as CcuError).structured.error).toBe("UNREACHABLE");
+      // Deterministic pin failure: its own non-retriable category with the
+      // mismatch surfaced (not a generic "fetch failed" UNREACHABLE).
+      expect((err as CcuError).structured.error).toBe("TLS_ERROR");
+      expect((err as CcuError).structured.message).toMatch(/fingerprint mismatch/);
     }
   });
 

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -190,7 +190,7 @@ describe("loadConfig", () => {
     process.env.CCU_HOST = "test";
     process.env.CCU_PASSWORD = "pw";
     process.env.MCP_PORT = "4567";
-    expect(loadConfig().mcp.allowedHosts).toEqual(["127.0.0.1:4567", "localhost:4567"]);
+    expect(loadConfig().mcp.allowedHosts).toEqual(["127.0.0.1:4567", "localhost:4567", "[::1]:4567"]);
   });
 
   it("MCP_ALLOWED_HOSTS extends the default host allowlist (trimmed, no blanks)", () => {
@@ -201,6 +201,7 @@ describe("loadConfig", () => {
     expect(loadConfig().mcp.allowedHosts).toEqual([
       "127.0.0.1:3000",
       "localhost:3000",
+      "[::1]:3000",
       "mcp.lan:3000",
       "proxy.example",
     ]);
@@ -211,8 +212,20 @@ describe("loadConfig", () => {
     process.env.CCU_PASSWORD = "pw";
     expect(loadConfig().ccu.tlsVerify).toBe(false);
 
+    process.env.CCU_HTTPS = "true";
     process.env.CCU_TLS_VERIFY = "true";
     expect(loadConfig().ccu.tlsVerify).toBe(true);
+  });
+
+  it("rejects TLS settings when HTTPS is disabled (would be silently ignored)", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+    process.env.CCU_TLS_VERIFY = "true";
+    expect(() => loadConfig()).toThrow(/HTTPS is disabled/);
+
+    delete process.env.CCU_TLS_VERIFY;
+    process.env.CCU_TLS_FINGERPRINT = "AB:CD";
+    expect(() => loadConfig()).toThrow(/HTTPS is disabled/);
   });
 
   // Issue #51: CCU TLS verification via fingerprint pin or CA cert
@@ -227,6 +240,7 @@ describe("loadConfig", () => {
   it("parses CCU_TLS_FINGERPRINT", () => {
     process.env.CCU_HOST = "test";
     process.env.CCU_PASSWORD = "pw";
+    process.env.CCU_HTTPS = "true";
     process.env.CCU_TLS_FINGERPRINT = "AB:CD:EF:01";
     expect(loadConfig().ccu.tlsFingerprint).toBe("AB:CD:EF:01");
   });
@@ -238,6 +252,7 @@ describe("loadConfig", () => {
     try {
       process.env.CCU_HOST = "test";
       process.env.CCU_PASSWORD = "pw";
+      process.env.CCU_HTTPS = "true";
       process.env.CCU_CA_CERT = caPath;
       expect(loadConfig().ccu.caCert).toContain("BEGIN CERTIFICATE");
     } finally {

--- a/test/unit/health-handler.test.ts
+++ b/test/unit/health-handler.test.ts
@@ -19,12 +19,12 @@ function createMockCache(size: number, warming: boolean) {
 }
 
 describe("handleHealthRequest", () => {
-  it("returns healthy when session is valid", () => {
+  it("returns healthy with detailed checks for authenticated callers", () => {
     const res = createMockRes();
     handleHealthRequest({} as IncomingMessage, res, {
       session: createMockSession(true),
       deviceTypeCache: createMockCache(10, false),
-    });
+    }, true);
 
     expect(res.writeHead).toHaveBeenCalledWith(200, { "Content-Type": "application/json" });
     const body = JSON.parse((res.end as any).mock.calls[0][0]);
@@ -39,11 +39,25 @@ describe("handleHealthRequest", () => {
     handleHealthRequest({} as IncomingMessage, res, {
       session: createMockSession(false),
       deviceTypeCache: createMockCache(0, true),
-    });
+    }, true);
 
     expect(res.writeHead).toHaveBeenCalledWith(503, { "Content-Type": "application/json" });
     const body = JSON.parse((res.end as any).mock.calls[0][0]);
     expect(body.status).toBe("degraded");
     expect(body.checks.session_valid).toBe(false);
+  });
+
+  it("omits the detailed checks for unauthenticated callers (status only)", () => {
+    // Pre-auth, session_valid would leak whether the configured CCU admin
+    // credentials currently work to any unauthenticated scanner.
+    const res = createMockRes();
+    handleHealthRequest({} as IncomingMessage, res, {
+      session: createMockSession(true),
+      deviceTypeCache: createMockCache(10, false),
+    });
+
+    const body = JSON.parse((res.end as any).mock.calls[0][0]);
+    expect(body.status).toBe("healthy");
+    expect(body.checks).toBeUndefined();
   });
 });

--- a/test/unit/health-handler.test.ts
+++ b/test/unit/health-handler.test.ts
@@ -47,17 +47,20 @@ describe("handleHealthRequest", () => {
     expect(body.checks.session_valid).toBe(false);
   });
 
-  it("omits the detailed checks for unauthenticated callers (status only)", () => {
-    // Pre-auth, session_valid would leak whether the configured CCU admin
-    // credentials currently work to any unauthenticated scanner.
-    const res = createMockRes();
-    handleHealthRequest({} as IncomingMessage, res, {
-      session: createMockSession(true),
-      deviceTypeCache: createMockCache(10, false),
-    });
-
-    const body = JSON.parse((res.end as any).mock.calls[0][0]);
-    expect(body.status).toBe("healthy");
-    expect(body.checks).toBeUndefined();
+  it("answers unauthenticated callers with liveness only (no session state)", () => {
+    // Pre-auth, healthy/degraded (and 200/503) is a pure function of
+    // session_valid — it would tell any unauthenticated scanner whether the
+    // configured CCU admin credentials currently work.
+    for (const loggedIn of [true, false]) {
+      const res = createMockRes();
+      handleHealthRequest({} as IncomingMessage, res, {
+        session: createMockSession(loggedIn),
+        deviceTypeCache: createMockCache(10, false),
+      });
+      expect(res.writeHead).toHaveBeenCalledWith(200, { "Content-Type": "application/json" });
+      const body = JSON.parse((res.end as any).mock.calls[0][0]);
+      expect(body.status).toBe("ok"); // identical regardless of session state
+      expect(body.checks).toBeUndefined();
+    }
   });
 });

--- a/test/unit/rate-limiter.test.ts
+++ b/test/unit/rate-limiter.test.ts
@@ -64,4 +64,16 @@ describe("RateLimiter", () => {
       expect((err as CcuError).structured.message).toMatch(/shutting down/);
     });
   });
+
+  it("acquire after destroy rejects instead of re-arming the refill timer", async () => {
+    // A tool's SECOND acquire racing shutdown must fail like the queued
+    // waiters did — not park in a fresh queue and fire into a session being
+    // logged out.
+    limiter = new RateLimiter(10, 10);
+    limiter.destroy();
+    await expect(limiter.acquire()).rejects.toBeInstanceOf(CcuError);
+    await limiter.acquire().catch((err) => {
+      expect((err as CcuError).structured.message).toMatch(/shutting down/);
+    });
+  });
 });

--- a/test/unit/rate-limiter.test.ts
+++ b/test/unit/rate-limiter.test.ts
@@ -46,22 +46,22 @@ describe("RateLimiter", () => {
       expect((err as CcuError).structured.error).toBe("RATE_LIMITED");
     });
 
-    // The two genuinely-queued waiters are still pending; destroy releases them
-    // so the test doesn't leak unsettled promises.
+    // The two genuinely-queued waiters are still pending; destroy settles them
+    // (by rejection) so the test doesn't leak unsettled promises.
     limiter.destroy();
-    await Promise.all([queued1, queued2]);
+    await expect(queued1).rejects.toBeInstanceOf(CcuError);
+    await expect(queued2).rejects.toBeInstanceOf(CcuError);
   });
 
-  it("destroy releases waiting requests", async () => {
+  it("destroy rejects waiting requests (shutdown must not fire queued CCU calls)", async () => {
     limiter = new RateLimiter(0, 0); // No tokens, no refill
 
-    let resolved = false;
-    const promise = limiter.acquire().then(() => {
-      resolved = true;
-    });
+    const promise = limiter.acquire();
 
     limiter.destroy();
-    await promise;
-    expect(resolved).toBe(true);
+    await expect(promise).rejects.toBeInstanceOf(CcuError);
+    await promise.catch((err) => {
+      expect((err as CcuError).structured.message).toMatch(/shutting down/);
+    });
   });
 });

--- a/test/unit/resource-poller.test.ts
+++ b/test/unit/resource-poller.test.ts
@@ -85,8 +85,8 @@ describe("ResourcePoller", () => {
 
     await vi.advanceTimersByTimeAsync(10_000);
 
-    // Should have been called for all 5 POLLABLE resources despite first failing
-    expect(mocks.session.call.mock.calls.length).toBe(5);
+    // Should have been called for all 6 POLLABLE resources despite first failing
+    expect(mocks.session.call.mock.calls.length).toBe(6);
     poller.stop();
   });
 
@@ -97,8 +97,8 @@ describe("ResourcePoller", () => {
 
     await vi.advanceTimersByTimeAsync(10_000);
 
-    // 5 resources = 5 acquire calls
-    expect(mocks.rateLimiter.acquire).toHaveBeenCalledTimes(5);
+    // 6 resources = 6 acquire calls
+    expect(mocks.rateLimiter.acquire).toHaveBeenCalledTimes(6);
     poller.stop();
   });
 });

--- a/test/unit/resources-registry.test.ts
+++ b/test/unit/resources-registry.test.ts
@@ -41,6 +41,16 @@ describe("resource registry", () => {
     });
   }
 
+  it("a CCU list resource surfaces a malformed (null) result as a CCU_ERROR, not literal 'null'", async () => {
+    // Guard parity with the sibling list_* tools: a subscriber must not be
+    // handed the text "null" indistinguishable from an empty payload.
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockResolvedValue(null), // CCU/proxy returns result:null
+    });
+    await expect(readResource(server, "homematic://devices")).rejects.toThrow(/non-array result/i);
+    cleanupDeps(deps);
+  });
+
   it("homematic://device-types serves the local cache", async () => {
     const { server, deps } = createServerWithCcu();
     const result: any = await readResource(server, "homematic://device-types");

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -179,21 +179,46 @@ describe("SessionManager", () => {
       session.destroy();
     });
 
-    it("re-logins and retries on AUTH error", async () => {
+    it("re-logins and retries on AUTH error when the session is truly expired", async () => {
       const client = createMockClient();
       const authError = new CcuError({ error: "AUTH", code: 400, message: "access denied", hint: "" });
 
       client.call
         .mockResolvedValueOnce("old-sess")     // login
         .mockRejectedValueOnce(authError)       // first call fails
-        .mockResolvedValueOnce("new-sess")      // re-login
+        .mockRejectedValueOnce(authError)       // in-memory Session.renew fails → truly expired
+        .mockResolvedValueOnce("new-sess")      // fresh re-login
         .mockResolvedValueOnce("success");      // retry
 
       const session = createSession(client);
+      vi.spyOn(session as any, "tryRestoreSession").mockResolvedValue(false);
       await session.login();
       const result = await session.call("Interface.getValue", {});
 
       expect(result).toBe("success");
+      session.destroy();
+    });
+
+    // CCU 400 "access denied" also fires for a VALID session whose user lacks
+    // the method's privilege level — that must not loop through re-login+retry.
+    it("maps a 400 on a still-valid session to a privilege error without a doomed retry", async () => {
+      const client = createMockClient();
+      const authError = new CcuError({ error: "AUTH", code: 400, message: "access denied", hint: "" });
+
+      client.call
+        .mockResolvedValueOnce("sess-1")        // login
+        .mockRejectedValueOnce(authError)       // ADMIN-only method denied
+        .mockResolvedValueOnce(true);           // in-memory Session.renew SUCCEEDS → session valid
+
+      const session = createSession(client);
+      vi.spyOn(session as any, "tryRestoreSession").mockResolvedValue(false);
+      await session.login();
+
+      await expect(session.call("ReGa.runScript", {})).rejects.toThrow(/privilege level/);
+      // login + denied call + renew — the denied method is NOT re-sent
+      expect(client.call.mock.calls.length).toBe(3);
+      // the still-valid session is kept (no leaked re-login)
+      expect(session.getSessionId()).toBe("sess-1");
       session.destroy();
     });
 
@@ -414,7 +439,10 @@ describe("renewal double failure (coverage round)", () => {
     await vi.advanceTimersByTimeAsync(60_000); // renew fails
     await vi.advanceTimersByTimeAsync(15_000); // login retries exhaust without throwing out of the timer
 
-    expect(session.isLoggedIn()).toBe(true); // old session id kept; no crash
+    // The dead session id is cleared (renew AND re-login failed), so /health
+    // reports degraded instead of healthy through a total CCU outage; the next
+    // call() lazily re-attempts login. No crash either way.
+    expect(session.isLoggedIn()).toBe(false);
     session.destroy();
     vi.useRealTimers();
   });

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SessionManager } from "../../src/ccu/session.js";
+import { createHash } from "node:crypto";
 import { CcuError } from "../../src/middleware/error-mapper.js";
 import { Logger } from "../../src/logger.js";
 
@@ -333,8 +334,12 @@ describe("session persistence and restore (coverage round)", () => {
     return session;
   }
 
-  it("restores a persisted session when host, port, and user match", async () => {
-    await writeSessionFile({ sessionId: "persisted", host: "test", port: 80, user: "Admin" });
+  // cred = truncated sha256("<user>:<password>") — must match baseConfig (Admin/pw)
+  const credOf = (user: string, password: string) =>
+    createHash("sha256").update(`${user}:${password}`).digest("hex").slice(0, 16);
+
+  it("restores a persisted session when host, port, user, and credentials match", async () => {
+    await writeSessionFile({ sessionId: "persisted", host: "test", port: 80, user: "Admin", cred: credOf("Admin", "pw") });
     const client = createMockClient();
     client.call.mockResolvedValue(true); // Session.renew
     const session = createSessionWithDir(client);
@@ -343,6 +348,22 @@ describe("session persistence and restore (coverage round)", () => {
 
     expect(session.getSessionId()).toBe("persisted");
     expect(client.call).not.toHaveBeenCalledWith("Session.login", expect.anything());
+    session.destroy();
+  });
+
+  it("ignores a persisted session minted with different credentials (password rotation)", async () => {
+    // Restoring across a password change would keep renewing the old session
+    // forever — the new password would never be exercised, and rotation would
+    // not cut off access.
+    await writeSessionFile({ sessionId: "stale-cred", host: "test", port: 80, user: "Admin", cred: credOf("Admin", "OLD-password") });
+    const client = createMockClient();
+    client.call.mockImplementation(async (method: string) =>
+      method === "Session.login" ? "fresh" : true);
+    const session = createSessionWithDir(client);
+
+    await session.login();
+
+    expect(session.getSessionId()).toBe("fresh");
     session.destroy();
   });
 

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SessionManager } from "../../src/ccu/session.js";
-import { createHash } from "node:crypto";
+import { scryptSync } from "node:crypto";
 import { CcuError } from "../../src/middleware/error-mapper.js";
 import { Logger } from "../../src/logger.js";
 
@@ -334,12 +334,16 @@ describe("session persistence and restore (coverage round)", () => {
     return session;
   }
 
-  // cred = truncated sha256("<user.length>:<user>:<password>") — must match baseConfig (Admin/pw)
-  const credOf = (user: string, password: string) =>
-    createHash("sha256").update(`${user.length}:${user}:${password}`).digest("hex").slice(0, 16);
+  // {credSalt, cred}: scrypt("<user.length>:<user>:<password>", salt) — matches
+  // credVerifier() in session.ts. baseConfig is Admin/pw.
+  const SALT = "00112233445566778899aabbccddeeff";
+  const credOf = (user: string, password: string, saltHex = SALT) => ({
+    credSalt: saltHex,
+    cred: scryptSync(`${user.length}:${user}:${password}`, Buffer.from(saltHex, "hex"), 32).toString("hex"),
+  });
 
   it("restores a persisted session when host, port, user, and credentials match", async () => {
-    await writeSessionFile({ sessionId: "persisted", host: "test", port: 80, user: "Admin", cred: credOf("Admin", "pw") });
+    await writeSessionFile({ sessionId: "persisted", host: "test", port: 80, user: "Admin", ...credOf("Admin", "pw") });
     const client = createMockClient();
     client.call.mockResolvedValue(true); // Session.renew
     const session = createSessionWithDir(client);
@@ -355,7 +359,7 @@ describe("session persistence and restore (coverage round)", () => {
     // Restoring across a password change would keep renewing the old session
     // forever — the new password would never be exercised, and rotation would
     // not cut off access.
-    await writeSessionFile({ sessionId: "stale-cred", host: "test", port: 80, user: "Admin", cred: credOf("Admin", "OLD-password") });
+    await writeSessionFile({ sessionId: "stale-cred", host: "test", port: 80, user: "Admin", ...credOf("Admin", "OLD-password") });
     const client = createMockClient();
     client.call.mockImplementation(async (method: string) =>
       method === "Session.login" ? "fresh" : true);

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -334,7 +334,7 @@ describe("session persistence and restore (coverage round)", () => {
     return session;
   }
 
-  // cred = truncated sha256("<user>:<password>") — must match baseConfig (Admin/pw)
+  // cred = truncated sha256("<user.length>:<user>:<password>") — must match baseConfig (Admin/pw)
   const credOf = (user: string, password: string) =>
     createHash("sha256").update(`${user.length}:${user}:${password}`).digest("hex").slice(0, 16);
 

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -336,7 +336,7 @@ describe("session persistence and restore (coverage round)", () => {
 
   // cred = truncated sha256("<user>:<password>") — must match baseConfig (Admin/pw)
   const credOf = (user: string, password: string) =>
-    createHash("sha256").update(`${user}:${password}`).digest("hex").slice(0, 16);
+    createHash("sha256").update(`${user.length}:${user}:${password}`).digest("hex").slice(0, 16);
 
   it("restores a persisted session when host, port, user, and credentials match", async () => {
     await writeSessionFile({ sessionId: "persisted", host: "test", port: 80, user: "Admin", cred: credOf("Admin", "pw") });

--- a/test/unit/target-registry.test.ts
+++ b/test/unit/target-registry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { TargetRegistry, resolveTarget, assertWritable } from "../../src/ccu/target-registry.js";
+import { TargetRegistry, TargetSelection, resolveTarget, assertWritable } from "../../src/ccu/target-registry.js";
 import { Logger } from "../../src/logger.js";
 import type { AppConfig } from "../../src/config.js";
 import type { CcuProfile } from "../../src/ccu/types.js";
@@ -39,8 +39,11 @@ describe("TargetRegistry", () => {
   it("builds one target per profile and makes the default active", () => {
     const reg = new TargetRegistry(appConfig([profile("prod", { protected: true }), profile("dev")], "prod", tempDir), logger, tempDir);
     expect(reg.list().map((t) => t.profile.name)).toEqual(["prod", "dev"]);
-    expect(reg.active.profile.name).toBe("prod");
-    expect(reg.active.profile.protected).toBe(true);
+    expect(reg.default.profile.name).toBe("prod");
+    expect(reg.default.profile.protected).toBe(true);
+    // A fresh per-MCP-session selection starts on the default target.
+    const sel = new TargetSelection(reg);
+    expect(sel.active.profile.name).toBe("prod");
   });
 
   it("getByName / has are case-insensitive; unknown is undefined", () => {
@@ -51,17 +54,22 @@ describe("TargetRegistry", () => {
     expect(reg.has("nope")).toBe(false);
   });
 
-  it("use() switches the active target and returns it", () => {
+  it("use() switches only that selection's active target and returns it", () => {
     const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
-    const t = reg.use("dev");
+    const sel = new TargetSelection(reg);
+    const other = new TargetSelection(reg);
+    const t = sel.use("dev");
     expect(t.profile.name).toBe("dev");
-    expect(reg.active.profile.name).toBe("dev");
+    expect(sel.active.profile.name).toBe("dev");
+    // Another MCP session's selection is unaffected (issue: shared active pointer).
+    expect(other.active.profile.name).toBe("prod");
   });
 
   it("use() on an unknown target throws a NOT_FOUND CcuError", () => {
     const reg = new TargetRegistry(appConfig([profile("prod")], "prod", tempDir), logger, tempDir);
-    expect(() => reg.use("ghost")).toThrowError(CcuError);
-    try { reg.use("ghost"); } catch (e) { expect((e as CcuError).structured.error).toBe("NOT_FOUND"); }
+    const sel = new TargetSelection(reg);
+    expect(() => sel.use("ghost")).toThrowError(CcuError);
+    try { sel.use("ghost"); } catch (e) { expect((e as CcuError).structured.error).toBe("NOT_FOUND"); }
   });
 
   it("each target gets its own resolver, caches, and sysvar holder", () => {
@@ -70,7 +78,7 @@ describe("TargetRegistry", () => {
     expect(prod!.resolver).not.toBe(dev!.resolver);
     expect(prod!.deviceTypeCache).not.toBe(dev!.deviceTypeCache);
     expect(prod!.sysVarTypeCache).not.toBe(dev!.sysVarTypeCache);
-    expect(prod!.unlocked).toBe(false);
+    expect(new TargetSelection(reg).isUnlocked(prod!)).toBe(false);
   });
 
   it("saveCaches writes a distinct file per target; default keeps the legacy name", async () => {
@@ -105,20 +113,23 @@ describe("resolveTarget", () => {
   beforeEach(async () => { tempDir = await mkdtemp(join(tmpdir(), "ccu-resolve-")); });
   afterEach(async () => { await rm(tempDir, { recursive: true, force: true }); });
 
-  it("returns the active target when no name is given", () => {
+  it("returns the selection's active target when no name is given", () => {
     const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
-    expect(resolveTarget(reg).profile.name).toBe("prod");
+    const sel = new TargetSelection(reg);
+    expect(resolveTarget(sel).profile.name).toBe("prod");
   });
 
   it("returns the named target without switching active", () => {
     const reg = new TargetRegistry(appConfig([profile("prod"), profile("dev")], "prod", tempDir), logger, tempDir);
-    expect(resolveTarget(reg, "dev").profile.name).toBe("dev");
-    expect(reg.active.profile.name).toBe("prod"); // unchanged
+    const sel = new TargetSelection(reg);
+    expect(resolveTarget(sel, "dev").profile.name).toBe("dev");
+    expect(sel.active.profile.name).toBe("prod"); // unchanged
   });
 
   it("throws NOT_FOUND for an unknown name", () => {
     const reg = new TargetRegistry(appConfig([profile("prod")], "prod", tempDir), logger, tempDir);
-    expect(() => resolveTarget(reg, "ghost")).toThrowError(/Unknown CCU target/);
+    const sel = new TargetSelection(reg);
+    expect(() => resolveTarget(sel, "ghost")).toThrowError(/Unknown CCU target/);
   });
 });
 
@@ -127,52 +138,68 @@ describe("assertWritable", () => {
   beforeEach(async () => { tempDir = await mkdtemp(join(tmpdir(), "ccu-guard-")); });
   afterEach(async () => { await rm(tempDir, { recursive: true, force: true }); });
 
-  function target(opts?: Partial<Pick<CcuProfile, "protected" | "readonly">>) {
+  function setup(opts?: Partial<Pick<CcuProfile, "protected" | "readonly">>) {
     const reg = new TargetRegistry(appConfig([profile("t", opts)], "t", tempDir), logger, tempDir);
-    return reg.active;
+    const sel = new TargetSelection(reg);
+    return { sel, t: sel.active };
   }
 
   it("allows writes to an unprotected target", () => {
-    expect(() => assertWritable(target(), undefined)).not.toThrow();
+    const { sel, t } = setup();
+    expect(() => assertWritable(sel, t, undefined)).not.toThrow();
   });
 
   it("refuses a read-only target even with confirm", () => {
-    expect(() => assertWritable(target({ readonly: true }), true)).toThrowError(/read-only/);
+    const { sel, t } = setup({ readonly: true });
+    expect(() => assertWritable(sel, t, true)).toThrowError(/read-only/);
   });
 
   it("refuses a protected target without confirm, then unlocks with confirm:true", () => {
-    const t = target({ protected: true });
-    expect(() => assertWritable(t, undefined)).toThrowError(/protected/);
-    expect(t.unlocked).toBe(false);
+    const { sel, t } = setup({ protected: true });
+    expect(() => assertWritable(sel, t, undefined)).toThrowError(/protected/);
+    expect(sel.isUnlocked(t)).toBe(false);
     // confirm unlocks for the session
-    expect(() => assertWritable(t, true)).not.toThrow();
-    expect(t.unlocked).toBe(true);
+    expect(() => assertWritable(sel, t, true)).not.toThrow();
+    expect(sel.isUnlocked(t)).toBe(true);
     // subsequent writes no longer need confirm
-    expect(() => assertWritable(t, undefined)).not.toThrow();
+    expect(() => assertWritable(sel, t, undefined)).not.toThrow();
+  });
+
+  it("an unlock in one selection does not leak into another (per-MCP-session)", () => {
+    const reg = new TargetRegistry(appConfig([profile("t", { protected: true })], "t", tempDir), logger, tempDir);
+    const a = new TargetSelection(reg);
+    const b = new TargetSelection(reg);
+    assertWritable(a, a.active, true); // client A unlocks
+    expect(a.isUnlocked(a.active)).toBe(true);
+    // client B still needs its own confirm
+    expect(b.isUnlocked(b.active)).toBe(false);
+    expect(() => assertWritable(b, b.active, undefined)).toThrowError(/protected/);
   });
 
   // Issue #72: high-blast-radius tools (run_script, delete_system_variable)
   // never ride on the session unlock — every call needs its own confirm.
   it("alwaysConfirm ignores the session unlock: each call needs confirm:true", () => {
-    const t = target({ protected: true });
-    assertWritable(t, true); // ordinary write unlocks the session
-    expect(t.unlocked).toBe(true);
+    const { sel, t } = setup({ protected: true });
+    assertWritable(sel, t, true); // ordinary write unlocks the session
+    expect(sel.isUnlocked(t)).toBe(true);
     // ...but an alwaysConfirm tool still refuses without its own confirm
-    expect(() => assertWritable(t, undefined, { alwaysConfirm: true })).toThrowError(/EVERY call/);
-    expect(() => assertWritable(t, true, { alwaysConfirm: true })).not.toThrow();
+    expect(() => assertWritable(sel, t, undefined, { alwaysConfirm: true })).toThrowError(/EVERY call/);
+    expect(() => assertWritable(sel, t, true, { alwaysConfirm: true })).not.toThrow();
     // and refuses again on the next call — no per-call carryover
-    expect(() => assertWritable(t, undefined, { alwaysConfirm: true })).toThrowError(/EVERY call/);
+    expect(() => assertWritable(sel, t, undefined, { alwaysConfirm: true })).toThrowError(/EVERY call/);
   });
 
   it("a confirmed alwaysConfirm call does not unlock the session for other writes", () => {
-    const t = target({ protected: true });
-    expect(() => assertWritable(t, true, { alwaysConfirm: true })).not.toThrow();
-    expect(t.unlocked).toBe(false);
-    expect(() => assertWritable(t, undefined)).toThrowError(/protected/);
+    const { sel, t } = setup({ protected: true });
+    expect(() => assertWritable(sel, t, true, { alwaysConfirm: true })).not.toThrow();
+    expect(sel.isUnlocked(t)).toBe(false);
+    expect(() => assertWritable(sel, t, undefined)).toThrowError(/protected/);
   });
 
   it("alwaysConfirm is a no-op gate on unprotected targets and still refuses readonly", () => {
-    expect(() => assertWritable(target(), undefined, { alwaysConfirm: true })).not.toThrow();
-    expect(() => assertWritable(target({ readonly: true }), true, { alwaysConfirm: true })).toThrowError(/read-only/);
+    const open = setup();
+    expect(() => assertWritable(open.sel, open.t, undefined, { alwaysConfirm: true })).not.toThrow();
+    const ro = setup({ readonly: true });
+    expect(() => assertWritable(ro.sel, ro.t, true, { alwaysConfirm: true })).toThrowError(/read-only/);
   });
 });

--- a/test/unit/tools-control.test.ts
+++ b/test/unit/tools-control.test.ts
@@ -105,6 +105,7 @@ describe("set_system_variable handler", () => {
   it("caches sysvar types so repeated writes fetch SysVar.getAll only once", async () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => {
       if (method === "SysVar.getAll") return [{ name: "Anwesenheit", type: "BOOL" }];
+      if (method === "SysVar.getValueByName") return "current";
       return true;
     });
     const { server, deps } = createTestServer({ sessionCall });
@@ -126,6 +127,7 @@ describe("set_system_variable handler", () => {
           ? [{ name: "Anwesenheit", type: "BOOL" }]
           : [{ name: "Anwesenheit", type: "BOOL" }, { name: "NeueVariable", type: "FLOAT" }];
       }
+      if (method === "SysVar.getValueByName") return "current";
       return true;
     });
     const { server, deps } = createTestServer({ sessionCall });
@@ -141,6 +143,7 @@ describe("set_system_variable handler", () => {
   it("uses ReGa.runScript for string variables, with escaping and scoped lookup", async () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => {
       if (method === "SysVar.getAll") return [{ name: "Notiz", type: "STRING" }];
+      if (method === "SysVar.getValueByName") return "current";
       return "OK"; // the write script confirms with WriteLine("OK")
     });
     const { server, deps } = createTestServer({ sessionCall });
@@ -169,28 +172,35 @@ describe("set_system_variable handler", () => {
     cleanupDeps(deps);
   });
 
+  // Last RPC is now the post-write verification, so assert on the setter call itself.
+  const lastCallTo = (sessionCall: any, method: string) =>
+    sessionCall.mock.calls.filter((c: unknown[]) => c[0] === method).at(-1);
+
   it("uses SysVar.setFloat for enum (LIST) variables and accepts a valid index", async () => {
-    const sessionCall = vi.fn()
-      .mockResolvedValueOnce([{ name: "Modus", type: "LIST", valueList: "off;low;high" }])
-      .mockResolvedValueOnce(true);
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [{ name: "Modus", type: "LIST", valueList: "off;low;high" }];
+      if (method === "SysVar.getValueByName") return "high";
+      return true;
+    });
     const { server, deps } = createTestServer({ sessionCall });
 
     const result = parseToolResult(await callTool(server, "set_system_variable", { name: "Modus", value: 2 }));
 
     expect((result as any).method).toBe("SysVar.setFloat");
-    expect(sessionCall).toHaveBeenLastCalledWith("SysVar.setFloat", { name: "Modus", value: 2 });
+    expect(lastCallTo(sessionCall, "SysVar.setFloat")).toEqual(["SysVar.setFloat", { name: "Modus", value: 2 }]);
     cleanupDeps(deps);
   });
 
   it("converts an enum label to its index and rejects out-of-range/unknown values", async () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => {
       if (method === "SysVar.getAll") return [{ name: "Modus", type: "LIST", valueList: "off;low;high" }];
+      if (method === "SysVar.getValueByName") return "current";
       return true;
     });
     const { server, deps } = createTestServer({ sessionCall });
 
     const byLabel = parseToolResult(await callTool(server, "set_system_variable", { name: "Modus", value: "low" })) as any;
-    expect(sessionCall).toHaveBeenLastCalledWith("SysVar.setFloat", { name: "Modus", value: 1 });
+    expect(lastCallTo(sessionCall, "SysVar.setFloat")).toEqual(["SysVar.setFloat", { name: "Modus", value: 1 }]);
     expect(byLabel.value).toBe(1);
 
     const outOfRange: any = await callTool(server, "set_system_variable", { name: "Modus", value: 99 });
@@ -207,6 +217,7 @@ describe("set_system_variable handler", () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => {
       // the CCU's real type string for a plain bool sysvar is LOGIC, not BOOL
       if (method === "SysVar.getAll") return [{ name: "Anwesenheit", type: "LOGIC" }];
+      if (method === "SysVar.getValueByName") return "current";
       return true;
     });
     const { server, deps } = createTestServer({ sessionCall });
@@ -215,10 +226,10 @@ describe("set_system_variable handler", () => {
     expect((result as any).method).toBe("SysVar.setBool");
     // setbool.tcl string-compares non-0/1 values ("false" >= 1 is true!), so
     // the tool must send numeric 0/1 — never a JSON boolean.
-    expect(sessionCall).toHaveBeenLastCalledWith("SysVar.setBool", { name: "Anwesenheit", value: 1 });
+    expect(lastCallTo(sessionCall, "SysVar.setBool")).toEqual(["SysVar.setBool", { name: "Anwesenheit", value: 1 }]);
 
     await callTool(server, "set_system_variable", { name: "Anwesenheit", value: false });
-    expect(sessionCall).toHaveBeenLastCalledWith("SysVar.setBool", { name: "Anwesenheit", value: 0 });
+    expect(lastCallTo(sessionCall, "SysVar.setBool")).toEqual(["SysVar.setBool", { name: "Anwesenheit", value: 0 }]);
 
     const junk: any = await callTool(server, "set_system_variable", { name: "Anwesenheit", value: "maybe" });
     expect(junk.isError).toBe(true);

--- a/test/unit/tools-control.test.ts
+++ b/test/unit/tools-control.test.ts
@@ -236,6 +236,38 @@ describe("set_system_variable handler", () => {
     expect(JSON.parse(junk.content[0].text).error).toBe("INVALID_INPUT");
     cleanupDeps(deps);
   });
+
+  it("reports NOT_FOUND when the write verification finds no target (deleted concurrently)", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [{ name: "Anwesenheit", type: "LOGIC" }];
+      if (method === "SysVar.getValueByName") return ""; // variable vanished
+      return true;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "set_system_variable", { name: "Anwesenheit", value: true });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("NOT_FOUND");
+    cleanupDeps(deps);
+  });
+
+  it("returns success flagged verified:false when only the verification read fails", async () => {
+    // The write already landed — a transport failure of the extra read must
+    // not be reported as a failed write.
+    const { CcuError } = await import("../../src/middleware/error-mapper.js");
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [{ name: "Anwesenheit", type: "LOGIC" }];
+      if (method === "SysVar.getValueByName") {
+        throw new CcuError({ error: "UNREACHABLE", code: 0, message: "down", hint: "" });
+      }
+      return true;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const result = parseToolResult(await callTool(server, "set_system_variable", { name: "Anwesenheit", value: true })) as any;
+    expect(result.method).toBe("SysVar.setBool");
+    expect(result.verified).toBe(false);
+    expect(result.note).toMatch(/could not be verified/);
+    cleanupDeps(deps);
+  });
 });
 
 describe("create_system_variable handler", () => {

--- a/test/unit/tools-control.test.ts
+++ b/test/unit/tools-control.test.ts
@@ -138,10 +138,10 @@ describe("set_system_variable handler", () => {
     cleanupDeps(deps);
   });
 
-  it("uses ReGa.runScript for string variables, with escaping", async () => {
+  it("uses ReGa.runScript for string variables, with escaping and scoped lookup", async () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => {
       if (method === "SysVar.getAll") return [{ name: "Notiz", type: "STRING" }];
-      return "";
+      return "OK"; // the write script confirms with WriteLine("OK")
     });
     const { server, deps } = createTestServer({ sessionCall });
 
@@ -151,31 +151,78 @@ describe("set_system_variable handler", () => {
     const scriptCall = sessionCall.mock.calls.find((c: unknown[]) => c[0] === "ReGa.runScript");
     const script = (scriptCall![1] as { script: string }).script;
     expect(script).toContain('say \\"hi\\" #1'); // quotes escaped, # untouched (issue #16)
+    // Lookup is scoped to the sysvar list — a channel/program with the same
+    // name must not shadow the variable (global dom.GetObject name match).
+    expect(script).toContain('dom.GetObject(ID_SYSTEM_VARIABLES).Get(');
     cleanupDeps(deps);
   });
 
-  it("uses SysVar.setFloat for enum variables", async () => {
+  it("string write surfaces a ReGa failure (empty output) instead of fake success", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [{ name: "Notiz", type: "STRING" }];
+      return ""; // hmscript returns "" on any ReGa error
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "set_system_variable", { name: "Notiz", value: "x" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("CCU_ERROR");
+    cleanupDeps(deps);
+  });
+
+  it("uses SysVar.setFloat for enum (LIST) variables and accepts a valid index", async () => {
     const sessionCall = vi.fn()
-      .mockResolvedValueOnce([{ name: "Modus", type: "ENUM" }])
+      .mockResolvedValueOnce([{ name: "Modus", type: "LIST", valueList: "off;low;high" }])
       .mockResolvedValueOnce(true);
     const { server, deps } = createTestServer({ sessionCall });
 
     const result = parseToolResult(await callTool(server, "set_system_variable", { name: "Modus", value: 2 }));
 
     expect((result as any).method).toBe("SysVar.setFloat");
+    expect(sessionCall).toHaveBeenLastCalledWith("SysVar.setFloat", { name: "Modus", value: 2 });
     cleanupDeps(deps);
   });
 
-  it("uses SysVar.setBool for bool variables", async () => {
-    const sessionCall = vi.fn()
-      .mockResolvedValueOnce([{ name: "Anwesenheit", type: "BOOL" }]) // SysVar.getAll
-      .mockResolvedValueOnce(true);                                    // SysVar.setBool
+  it("converts an enum label to its index and rejects out-of-range/unknown values", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [{ name: "Modus", type: "LIST", valueList: "off;low;high" }];
+      return true;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const byLabel = parseToolResult(await callTool(server, "set_system_variable", { name: "Modus", value: "low" })) as any;
+    expect(sessionCall).toHaveBeenLastCalledWith("SysVar.setFloat", { name: "Modus", value: 1 });
+    expect(byLabel.value).toBe(1);
+
+    const outOfRange: any = await callTool(server, "set_system_variable", { name: "Modus", value: 99 });
+    expect(outOfRange.isError).toBe(true);
+    expect(JSON.parse(outOfRange.content[0].text).error).toBe("INVALID_INPUT");
+
+    const unknown: any = await callTool(server, "set_system_variable", { name: "Modus", value: "turbo" });
+    expect(unknown.isError).toBe(true);
+    expect(JSON.parse(unknown.content[0].text).error).toBe("INVALID_INPUT");
+    cleanupDeps(deps);
+  });
+
+  it("uses SysVar.setBool for LOGIC variables, sending numeric 0/1", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      // the CCU's real type string for a plain bool sysvar is LOGIC, not BOOL
+      if (method === "SysVar.getAll") return [{ name: "Anwesenheit", type: "LOGIC" }];
+      return true;
+    });
     const { server, deps } = createTestServer({ sessionCall });
 
     const result = parseToolResult(await callTool(server, "set_system_variable", { name: "Anwesenheit", value: true }));
-
     expect((result as any).method).toBe("SysVar.setBool");
-    expect(sessionCall).toHaveBeenLastCalledWith("SysVar.setBool", { name: "Anwesenheit", value: true });
+    // setbool.tcl string-compares non-0/1 values ("false" >= 1 is true!), so
+    // the tool must send numeric 0/1 — never a JSON boolean.
+    expect(sessionCall).toHaveBeenLastCalledWith("SysVar.setBool", { name: "Anwesenheit", value: 1 });
+
+    await callTool(server, "set_system_variable", { name: "Anwesenheit", value: false });
+    expect(sessionCall).toHaveBeenLastCalledWith("SysVar.setBool", { name: "Anwesenheit", value: 0 });
+
+    const junk: any = await callTool(server, "set_system_variable", { name: "Anwesenheit", value: "maybe" });
+    expect(junk.isError).toBe(true);
+    expect(JSON.parse(junk.content[0].text).error).toBe("INVALID_INPUT");
     cleanupDeps(deps);
   });
 });
@@ -189,6 +236,7 @@ describe("create_system_variable handler", () => {
   it("creates a bool variable via ReGa and reports created:true", async () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => {
       if (method === "SysVar.getAll") return []; // no existing vars
+      if (method === "ReGa.runScript") return "Urlaub"; // script echoes the stored name
       return null;
     });
     const { server, deps } = createTestServer({ sessionCall });
@@ -223,8 +271,44 @@ describe("create_system_variable handler", () => {
     cleanupDeps(deps);
   });
 
-  it("creates a float variable with unit/min/max", async () => {
+  it("reports CCU_ERROR when the create script produces no output (ReGa failure)", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [];
+      if (method === "ReGa.runScript") return ""; // hmscript returns "" on script error
+      return null;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "create_system_variable", { name: "Urlaub", type: "bool" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("CCU_ERROR");
+    cleanupDeps(deps);
+  });
+
+  it("rejects enum labels containing the CCU's ';' value-list separator", async () => {
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "create_system_variable", { name: "Modus", type: "enum", values: ["off", "eco;comfort"] });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    expect(sessionCall).not.toHaveBeenCalled();
+    cleanupDeps(deps);
+  });
+
+  it("rejects min/max magnitudes that stringify to exponent notation", async () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => (method === "SysVar.getAll" ? [] : null));
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "create_system_variable", { name: "Tiny", type: "float", min: 1e-7, max: 1 });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    cleanupDeps(deps);
+  });
+
+  it("creates a float variable with unit/min/max", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [];
+      if (method === "ReGa.runScript") return "Soll";
+      return null;
+    });
     const { server, deps } = createTestServer({ sessionCall });
 
     await callTool(server, "create_system_variable", { name: "Soll", type: "float", unit: "°C", min: 5, max: 30 });
@@ -284,6 +368,7 @@ describe("sysvar type cache invalidation (issue #24)", () => {
   it("create_system_variable invalidates the shared type cache so the next set re-fetches", async () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => {
       if (method === "SysVar.getAll") return [{ name: "Anwesenheit", type: "BOOL" }];
+      if (method === "ReGa.runScript") return "Neu"; // create script echoes the stored name
       return null;
     });
     const { server, deps } = createTestServer({ sessionCall });

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -47,13 +47,14 @@ describe("get_service_messages handler", () => {
     cleanupDeps(deps);
   });
 
-  it("returns raw string when script output is not JSON", async () => {
+  it("reports CCU_ERROR when script output is not parseable — never a fake 'no alarms'", async () => {
     const { server, deps } = createTestServer({
       sessionCall: vi.fn().mockResolvedValue("raw output"),
     });
 
-    const result = parseToolResult(await callTool(server, "get_service_messages"));
-    expect(result).toBe("raw output");
+    const result: any = await callTool(server, "get_service_messages");
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("CCU_ERROR");
     cleanupDeps(deps);
   });
 });

--- a/test/unit/tools-read.test.ts
+++ b/test/unit/tools-read.test.ts
@@ -186,12 +186,25 @@ describe("error and edge paths (coverage round)", () => {
     cleanupDeps(deps);
   });
 
-  it("get_values returns object results from the CCU as-is", async () => {
+  it("get_values returns object results from the CCU (datapoints untouched when absent)", async () => {
     const { server, deps } = createTestServer({
       sessionCall: vi.fn().mockResolvedValue([{ already: "parsed" }]),
     });
     const result = parseToolResult(await callTool(server, "get_values", { channels: ["AAA:1"] })) as any;
     expect(result).toEqual([{ already: "parsed" }]);
+    cleanupDeps(deps);
+  });
+
+  it("get_values parses datapoint values to native types (matches get_value)", async () => {
+    // The HM-script emits every value as a quoted string; the tool must parse
+    // them so a value read in bulk matches what the single get_value returns.
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn().mockResolvedValue(
+        '[{"address":"A:1","name":"Ch","datapoints":{"STATE":"true","ACTUAL_TEMPERATURE":"19.000000","NOTE":"hi","EMPTY":""}}]',
+      ),
+    });
+    const result = parseToolResult(await callTool(server, "get_values", { channels: ["A:1"] })) as any;
+    expect(result[0].datapoints).toEqual({ STATE: true, ACTUAL_TEMPERATURE: 19, NOTE: "hi", EMPTY: null });
     cleanupDeps(deps);
   });
 });

--- a/test/unit/tools-read.test.ts
+++ b/test/unit/tools-read.test.ts
@@ -72,13 +72,16 @@ describe("get_values handler", () => {
     cleanupDeps(deps);
   });
 
-  it("returns raw string when result is not JSON", async () => {
+  it("reports CCU_ERROR when the script output is not parseable (ReGa failure)", async () => {
+    // runscript returns "" (or garbage) whenever the ReGa script fails; that
+    // must NOT read as a successful empty result.
     const { server, deps } = createTestServer({
       sessionCall: vi.fn().mockResolvedValue("raw output"),
     });
 
-    const result = parseToolResult(await callTool(server, "get_values", { channels: ["A:1"] }));
-    expect(result).toBe("raw output");
+    const result: any = await callTool(server, "get_values", { channels: ["A:1"] });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("CCU_ERROR");
     cleanupDeps(deps);
   });
 });

--- a/test/unit/tools-read.test.ts
+++ b/test/unit/tools-read.test.ts
@@ -150,12 +150,28 @@ describe("error and edge paths (coverage round)", () => {
     cleanupDeps(deps);
   });
 
-  it("get_paramset passes arrays through unparsed", async () => {
+  it("get_paramset passes arrays through unparsed (link paramset via partner address)", async () => {
     const { server, deps } = createTestServer({
       sessionCall: vi.fn().mockResolvedValue([1, 2, 3]),
     });
-    const result = parseToolResult(await callTool(server, "get_paramset", { address: "AAA:1", paramsetKey: "LINK", interface: "HmIP-RF" })) as any;
+    // Link paramsets are read by passing the link PARTNER's channel address.
+    const result = parseToolResult(await callTool(server, "get_paramset", { address: "AAA:1", paramsetKey: "BBB:2", interface: "HmIP-RF" })) as any;
     expect(result.params).toEqual([1, 2, 3]);
+    cleanupDeps(deps);
+  });
+
+  it("get_paramset rejects the literal LINK key with guidance (invalid on the CCU)", async () => {
+    // Verified live: the XML-RPC layer accepts MASTER, VALUES, or a partner
+    // channel address — the literal "LINK" fails 502 "unknown device or
+    // channel", which would surface as a misleading NOT_FOUND.
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "get_paramset", { address: "AAA:1", paramsetKey: "LINK", interface: "HmIP-RF" });
+    expect(result.isError).toBe(true);
+    const structured = JSON.parse(result.content[0].text);
+    expect(structured.error).toBe("INVALID_INPUT");
+    expect(structured.hint).toMatch(/partner/i);
+    expect(sessionCall).not.toHaveBeenCalled();
     cleanupDeps(deps);
   });
 


### PR DESCRIPTION
## Release v1.7.0 — execution-safety audit

Six-cycle execution-safety audit of the whole codebase (~119 verified fixes), now landing on `main`. Full details in **CHANGELOG.md → v1.7.0** (behavior changes are called out at the top — read before upgrading).

### What's in it
- **Cycle 1** (~100 fixes): broken bool sysvars (CCU type is `LOGIC`, not `BOOL`; `false` stored as `true`), per-MCP-session target/confirm isolation, auth-token runtime rotation, stale-session 404, ACTION double-fire, ReGa-failure-as-success across five tools, and ~60 more.
- **Cycles 2–3** (16 fixes): live-verified `get_paramset` LINK bug, sysvar type-cache race, password-rotation session restore, sysvar write verification, `/` and `/mcp`-only routing.
- **Cycle 5** (2 fixes): `get_values` native-typed datapoints (parity with `get_value`), resource null-guards.
- **Cycle 6 hardening**: credential fingerprint now uses **salted scrypt** (resolved a CodeQL `js/insufficient-password-hash` high alert introduced mid-audit).
- Cycles 4 and 6 — the most aggressive angles (fuzz/soak, property-testing ~330k inputs) — found **zero real bugs**, confirming convergence.

### Validation
- Full suite **380 passing / 26 live-gated skips**; lint clean; build reproducible.
- **Live against prod (debmatic:443): 404/404**, including real ReGa create→set→verify→delete and assign→revert round-trips.
- CI green on the merged work: `build-and-test`, CodeQL (0 open high alerts).

### After merge (owner, YubiKey-gated — per docs/release-runbook.md)
1. Tag `v1.7.0` on `main`, push the tag.
2. `npm publish` (YubiKey touch) + `mcp-publisher publish` (device-code login).
3. Fast-forward `dev` back to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnpDrJ1ib6DWqhQGAser4Q
