### PR TITLE
fix: audit round 1 — security, robustness, consistency, dedup

### DIFF
--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -185,16 +185,24 @@ async function persist(dataDir: string, state: PersistedToken, logger: Logger): 
 function announce(token: string, dataDir: string, rotated: boolean, saved: boolean): void {
   const envPath = join(dataDir, ENV_FILENAME);
   const what = rotated ? "Rotated auth token" : "Generated auth token";
-  // stderr so the operator can copy it; never goes through the structured logger.
-  process.stderr.write(`\n[ccu-mcp] ${what}: ${token}\n`);
+  // stderr so the operator can find it; never goes through the structured logger.
+  // When the token was persisted 0600, point at the file rather than echoing the
+  // secret: stderr (journald / `docker logs` / a log shipper) is retained longer
+  // and readable by more principals than the 0600 .env, so printing the token
+  // here would defeat storing it restricted (CWE-532). Only echo it when it could
+  // NOT be saved — then stderr is the operator's sole way to recover it.
   if (saved) {
-    process.stderr.write(`[ccu-mcp] Token saved to ${envPath}\n`);
+    process.stderr.write(
+      `\n[ccu-mcp] ${what}, saved to ${envPath} (mode 0600).\n` +
+        `[ccu-mcp] Read MCP_AUTH_TOKEN from that file for your MCP client configuration.\n\n`,
+    );
   } else {
     process.stderr.write(
-      `[ccu-mcp] WARNING: the token could NOT be saved to ${envPath} — it is valid for this run only. Fix the data dir permissions.\n`,
+      `\n[ccu-mcp] ${what}: ${token}\n` +
+        `[ccu-mcp] WARNING: the token could NOT be saved to ${envPath} — it is valid for this run only. Fix the data dir permissions.\n` +
+        `[ccu-mcp] Use this token in your MCP client configuration.\n\n`,
     );
   }
-  process.stderr.write(`[ccu-mcp] Use this token in your MCP client configuration.\n\n`);
 }
 
 /**

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
+import { readFile, writeFile, rename, mkdir, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { scryptSync, randomBytes, timingSafeEqual } from "node:crypto";
 import type { CcuConfig } from "./types.js";
@@ -18,7 +18,7 @@ export class SessionManager {
   private readonly cacheDir: string;
   private readonly sessionFile: string;
   private sessionId: string | null = null;
-  private renewTimer: ReturnType<typeof setInterval> | null = null;
+  private renewTimer: ReturnType<typeof setTimeout> | null = null;
   private loginPromise: Promise<void> | null = null;
   // Set on logout/destroy: an in-flight call failing AUTH after logout must
   // not lazily re-login — that would mint a CCU session nobody ever logs out,
@@ -292,7 +292,6 @@ export class SessionManager {
 
   private async clearPersistedSession(): Promise<void> {
     try {
-      const { unlink } = await import("node:fs/promises");
       await unlink(join(this.cacheDir, this.sessionFile));
     } catch {
       // Ignore
@@ -301,26 +300,43 @@ export class SessionManager {
 
   private startRenewal(): void {
     this.stopRenewal();
-    this.renewTimer = setInterval(async () => {
-      if (!this.sessionId) return;
-      try {
-        await this.client.call("Session.renew", { _session_id_: this.sessionId });
-        this.logger.debug("session_renewed");
-      } catch {
-        this.logger.warn("session_renew_failed");
-        try {
-          await this.login();
-        } catch (loginErr) {
-          this.logger.error("session_relogin_failed", { error: (loginErr as Error).message });
+    this.scheduleRenewal();
+  }
+
+  // Self-rescheduling setTimeout (not setInterval): the next renew is armed only
+  // AFTER the current one settles, so a slow renew/relogin under a raised
+  // CCU_TIMEOUT (> the 60s interval) can never stack overlapping calls against
+  // an already-struggling box. Mirrors ResourcePoller.schedule().
+  private scheduleRenewal(): void {
+    this.renewTimer = setTimeout(() => {
+      this.renewOnce().finally(() => {
+        // Only re-arm if we weren't stopped/destroyed while the renew was in flight.
+        if (!this.closed && this.renewTimer !== null) {
+          this.scheduleRenewal();
         }
-      }
+      });
     }, SESSION_RENEW_INTERVAL);
     this.renewTimer.unref();
   }
 
+  private async renewOnce(): Promise<void> {
+    if (!this.sessionId) return;
+    try {
+      await this.client.call("Session.renew", { _session_id_: this.sessionId });
+      this.logger.debug("session_renewed");
+    } catch {
+      this.logger.warn("session_renew_failed");
+      try {
+        await this.login();
+      } catch (loginErr) {
+        this.logger.error("session_relogin_failed", { error: (loginErr as Error).message });
+      }
+    }
+  }
+
   private stopRenewal(): void {
     if (this.renewTimer) {
-      clearInterval(this.renewTimer);
+      clearTimeout(this.renewTimer);
       this.renewTimer = null;
     }
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,15 +12,22 @@ const REDACTED_KEYS = new Set(["password", "_session_id_", "MCP_AUTH_TOKEN"]);
 function redact(obj: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
-    if (REDACTED_KEYS.has(key)) {
-      result[key] = "[REDACTED]";
-    } else if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-      result[key] = redact(value as Record<string, unknown>);
-    } else {
-      result[key] = value;
-    }
+    result[key] = REDACTED_KEYS.has(key) ? "[REDACTED]" : redactValue(value);
   }
   return result;
+}
+
+// Recurse through both objects AND arrays so a secret-named key nested inside an
+// array element (e.g. { params: [{ password: "…" }] }) is redacted too — a plain
+// object walk would emit it in cleartext.
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactValue);
+  }
+  if (typeof value === "object" && value !== null) {
+    return redact(value as Record<string, unknown>);
+  }
+  return value;
 }
 
 export class Logger {

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -7,11 +7,7 @@ import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult, parseValue, escapeHmScript, expectArray } from "../utils.js";
-
-// Optional `confirm` field for write tools: required (true) to authorize a write
-// against a `protected` CCU target (e.g. prod). Harmless on unprotected targets.
-const confirmField = z.boolean().optional()
-  .describe("Set true to authorize this write against a protected CCU target (e.g. prod). Unlocks writes to that target for the rest of the session.");
+import { confirmField } from "./fields.js";
 
 export function registerControlTools(server: McpServer, deps: ServerDeps): void {
   registerSetValue(server, deps);

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -7,6 +7,7 @@ import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable, resolveTarget } from "../ccu/target-registry.js";
 import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION, loadBuildInfo, expectArray } from "../utils.js";
+import { targetField, confirmField } from "./fields.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
   registerGetServiceMessages(server, deps);
@@ -29,7 +30,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
       description:
         "Get all active service messages (low battery, unreachable, etc.) with device details and timestamps.",
       inputSchema: {
-        target: z.string().optional().describe("CCU target to read from (default: active). See list_ccu_targets."),
+        target: targetField,
       },
       outputSchema: { messages: z.array(z.unknown()).describe("Active alarms: {id, type, address, channelName, timestamp}") },
       annotations: { readOnlyHint: true, openWorldHint: true },
@@ -159,7 +160,7 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
       inputSchema: {
         id: z.string().optional().describe("Alarm id from get_service_messages (confirm a single message)"),
         address: z.string().optional().describe("Channel address — confirm all active messages on this channel (e.g. '000A1BE9A71F15:0')"),
-        confirm: z.boolean().optional().describe("Set true to authorize this write against a protected CCU target (e.g. prod)."),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -292,7 +293,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
         "on the CCU, so they show \"N/A\" for a non-admin (USER) login. Also reports the running " +
         "server's build identification (git branch/commit/tag and build time) under `build`.",
       inputSchema: {
-        target: z.string().optional().describe("CCU target to read from (default: active). See list_ccu_targets."),
+        target: targetField,
       },
       outputSchema: {
         serverVersion: z.string().optional(),
@@ -386,7 +387,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
         "Use to answer 'why is this sensor flaky?'. Higher (closer to 0) dBm is better; null = no measurement.",
       inputSchema: {
         name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
-        target: z.string().optional().describe("CCU target to read from (default: active). See list_ccu_targets."),
+        target: targetField,
       },
       outputSchema: {
         devices: z.array(z.unknown()).describe("Per device: {address, name, interface, links:[{peer, rssiDevice, rssiPeer}]}"),

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -2,14 +2,12 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
+import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { resolveTarget } from "../ccu/target-registry.js";
 import { structuredResult, expectArray } from "../utils.js";
-
-// Optional per-call target override (route one read to a named CCU).
-const targetField = z.string().optional()
-  .describe("CCU target to read from (default: active). See list_ccu_targets.");
+import { targetField } from "./fields.js";
 
 export function registerDiscoveryTools(server: McpServer, deps: ServerDeps): void {
   registerListDevices(server, deps);
@@ -72,7 +70,18 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             { rateLimiter },
           ).then((r) => expectArray<{ id: string; name: string; channelIds: string[] }>(r));
           const room = rooms.find((r) => r.name === args.room);
-          filterSets.push(new Set(room?.channelIds ?? []));
+          if (!room) {
+            // Fail loud on an unknown filter name rather than returning an empty
+            // list that looks like a genuinely empty room — mirrors the write
+            // tools (assign_channel) and the help text's NOT_FOUND promise.
+            throw new CcuError({
+              error: "NOT_FOUND",
+              code: 0,
+              message: `Room not found: ${args.room}`,
+              hint: `Valid rooms: ${rooms.map((r) => r.name).join(", ")}`,
+            });
+          }
+          filterSets.push(new Set(room.channelIds ?? []));
         }
 
         if (args.function) {
@@ -84,7 +93,15 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             { rateLimiter },
           ).then((r) => expectArray<{ id: string; name: string; channelIds: string[] }>(r));
           const func = functions.find((f) => f.name === args.function);
-          filterSets.push(new Set(func?.channelIds ?? []));
+          if (!func) {
+            throw new CcuError({
+              error: "NOT_FOUND",
+              code: 0,
+              message: `Function not found: ${args.function}`,
+              hint: `Valid functions: ${functions.map((f) => f.name).join(", ")}`,
+            });
+          }
+          filterSets.push(new Set(func.channelIds ?? []));
         }
 
         devices = devices.filter((d) =>

--- a/src/tools/fields.ts
+++ b/src/tools/fields.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+// Shared zod field definitions reused across tool modules so their descriptions
+// stay identical (they previously drifted between copies).
+
+// Optional per-call target override for read tools: route this one read to a
+// named CCU without switching the active target (handy for prod-vs-dev compares).
+export const targetField = z.string().optional()
+  .describe("CCU target to read from (default: active). See list_ccu_targets.");
+
+// Optional `confirm` field for write tools: required (true) to authorize a write
+// against a `protected` CCU target (e.g. prod). Harmless on unprotected targets.
+export const confirmField = z.boolean().optional()
+  .describe("Set true to authorize this write against a protected CCU target (e.g. prod). Unlocks writes to that target for the rest of the session.");

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -6,11 +6,7 @@ import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { resolveTarget } from "../ccu/target-registry.js";
 import { structuredResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
-
-// Optional per-call target override for read tools: route this one read to a
-// named CCU without switching the active target (handy for prod-vs-dev compares).
-const targetField = z.string().optional()
-  .describe("CCU target to read from (default: active). See list_ccu_targets.");
+import { targetField } from "./fields.js";
 
 export function registerReadTools(server: McpServer, deps: ServerDeps): void {
   registerGetValue(server, deps);

--- a/test/unit/logger.test.ts
+++ b/test/unit/logger.test.ts
@@ -60,4 +60,14 @@ describe("Logger", () => {
     expect(line.params.password).toBe("[REDACTED]");
     expect(line.params.user).toBe("admin");
   });
+
+  it("redacts sensitive fields nested inside arrays", () => {
+    const logger = new Logger("debug");
+    logger.debug("array", { items: [{ password: "secret", user: "admin" }], _session_id_: "top" });
+
+    const line = JSON.parse((stderrSpy.mock.calls[0]![0] as string).trim());
+    expect(line.items[0].password).toBe("[REDACTED]");
+    expect(line.items[0].user).toBe("admin");
+    expect(line._session_id_).toBe("[REDACTED]");
+  });
 });

--- a/test/unit/tools-discovery.test.ts
+++ b/test/unit/tools-discovery.test.ts
@@ -55,10 +55,25 @@ describe("list_devices handler", () => {
     cleanupDeps(deps);
   });
 
-  it("returns empty when room not found", async () => {
+  it("throws NOT_FOUND (with valid names) when the room filter is unknown", async () => {
     const { server, deps } = createServer();
-    const result = parseToolResult(await callTool(server, "list_devices", { room: "Nonexistent" })) as any[];
-    expect(result.length).toBe(0);
+    // An unknown filter name must fail loud, not return an empty list that looks
+    // like a genuinely empty room — consistent with the write tools.
+    const result = await callTool(server, "list_devices", { room: "Nonexistent" }) as any;
+    expect(result.isError).toBe(true);
+    const err = JSON.parse(result.content[0].text);
+    expect(err.error).toBe("NOT_FOUND");
+    expect(err.hint).toContain("Wohnzimmer");
+    cleanupDeps(deps);
+  });
+
+  it("throws NOT_FOUND (with valid names) when the function filter is unknown", async () => {
+    const { server, deps } = createServer();
+    const result = await callTool(server, "list_devices", { function: "Nonexistent" }) as any;
+    expect(result.isError).toBe(true);
+    const err = JSON.parse(result.content[0].text);
+    expect(err.error).toBe("NOT_FOUND");
+    expect(err.hint).toContain("Heizung");
     cleanupDeps(deps);
   });
 


### PR DESCRIPTION
Batch 1 of the multi-agent source audit (6 dimensions — logic/security/bad-impl/maintainability/duplication/idiomatic — each finding adversarially verified). The audit produced **28 raw → 0 refuted, 12 confirmed, 16 nitpicks**; verification downgraded every claimed high/medium to low except one medium. This PR lands the localized, low-risk confirmed fixes.

## Changes
| Sev | Fix |
|-----|-----|
| **med** | `auth/token`: stop echoing the auto-generated bearer token to stderr when it was persisted 0600 (CWE-532). Only echo when it could NOT be saved. |
| low | `logger`: `redact()` recurses into arrays, not just objects — secrets nested in an array element no longer leak. |
| low | `tools/discovery`: `list_devices` throws NOT_FOUND (with valid names) on an unknown room/function filter instead of returning a misleading empty list. |
| low | `ccu/session`: renew via self-rescheduling `setTimeout` (no overlapping renews under a raised `CCU_TIMEOUT`); static `unlink` import. |
| low | `tools/fields.ts`: hoist duplicated `targetField`/`confirmField` (they had already drifted). |

## Tests
+array-redaction regression, +list_devices NOT_FOUND (room & function). Full suite green — 382 passed; the 2 `CCU_HOST`-gated integration files are the pre-existing no-hardware failures.

## Deferred to batch 2 (bigger refactors, held for reviewability)
- `callCcuList`/`callCcu` helper to collapse the ~16 `acquire()+withRetry()+expectArray()` sites and centralise the acquire-before-retry invariant.
- Shared ReGa JSON-escape fragment (`hmJsonEscape`) to dedupe the 5-copy escape block.
- Decompose the ~220-line `setSystemVariable` handler (extract pure coercers).
- `client.ts` `pipelining:0` only on the fingerprint-pin path (keep-alive for other HTTPS modes).