### PR TITLE
fix: keep exactly one session-renewal timer across a relogin

### DIFF
--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -308,15 +308,21 @@ export class SessionManager {
   // CCU_TIMEOUT (> the 60s interval) can never stack overlapping calls against
   // an already-struggling box. Mirrors ResourcePoller.schedule().
   private scheduleRenewal(): void {
-    this.renewTimer = setTimeout(() => {
+    const handle = setTimeout(() => {
       this.renewOnce().finally(() => {
-        // Only re-arm if we weren't stopped/destroyed while the renew was in flight.
-        if (!this.closed && this.renewTimer !== null) {
+        // Re-arm only if THIS timer is still the active one and we weren't
+        // stopped/destroyed. A plain `renewTimer !== null` check is not enough:
+        // renewOnce()'s relogin path calls login() → startRenewal(), which
+        // already re-arms the timer mid-flight; without the identity check this
+        // finally would arm a SECOND timer and leak an overlapping renewal loop
+        // per relogin — the exact overlap this setTimeout design exists to avoid.
+        if (!this.closed && this.renewTimer === handle) {
           this.scheduleRenewal();
         }
       });
     }, SESSION_RENEW_INTERVAL);
-    this.renewTimer.unref();
+    this.renewTimer = handle;
+    handle.unref();
   }
 
   private async renewOnce(): Promise<void> {

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -290,6 +290,40 @@ describe("SessionManager", () => {
       expect(session.getSessionId()).toBe("new-sess");
       session.destroy();
     });
+
+    // Regression: a relogin must leave EXACTLY ONE renewal timer. The relogin
+    // path (renewOnce → login → startRenewal) re-arms the timer mid-flight; the
+    // outer scheduleRenewal().finally must not then arm a SECOND one, or an
+    // overlapping renewal loop leaks per relogin (the overlap this design avoids).
+    it("keeps exactly one renewal timer after a relogin", async () => {
+      const client = createMockClient();
+      client.call.mockResolvedValueOnce("sess"); // initial login
+      const session = createSession(client);
+      await session.login();
+
+      vi.spyOn(session as any, "tryRestoreSession").mockResolvedValue(false);
+      vi.spyOn(session as any, "persistSession").mockResolvedValue(undefined);
+
+      // t=60s: renew fails → relogin succeeds → new session, renewal re-armed.
+      client.call.mockImplementation(async (method: string) => {
+        if (method === "Session.renew") throw new Error("renew fail");
+        if (method === "Session.login") return "new-sess";
+        return null;
+      });
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(session.getSessionId()).toBe("new-sess");
+
+      // Renew now succeeds. Advancing one interval must fire the renewal EXACTLY
+      // once — two calls would prove a leaked, overlapping second timer.
+      client.call.mockReset();
+      client.call.mockResolvedValue(true);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const renews = client.call.mock.calls.filter((c) => c[0] === "Session.renew");
+      expect(renews.length).toBe(1);
+      session.destroy();
+    });
   });
 
   describe("destroy", () => {


### PR DESCRIPTION
Follow-up to #89, from the final review of that diff.

**The regression (introduced in #89):** the new self-rescheduling `setTimeout` renewal re-armed on a `renewTimer !== null` check. But `renewOnce()`'s relogin path calls `login()` → `startRenewal()`, which re-arms the timer *mid-flight*; the outer `scheduleRenewal().finally` then armed a **second** timer — leaking an overlapping renewal loop per relogin. That's exactly the overlap the `setTimeout` redesign was meant to prevent (the old `setInterval` could not do this — `startRenewal` always left exactly one).

**Fix:** guard the re-arm on timer-handle **identity** (`renewTimer === handle`), so only the still-active timer reschedules.

**Verified:** new regression test asserts exactly one `Session.renew` fires in the interval after a relogin. Toggling the fix off reproduces the bug as `expected 2 to be 1`; on, it passes. Full suite green (383 passed; the 2 `CCU_HOST`-gated integration files are the pre-existing no-hardware failures).