### PR TITLE
test: cover the token-not-echoed-when-saved security fix

### DIFF
--- a/test/unit/auth-token.test.ts
+++ b/test/unit/auth-token.test.ts
@@ -209,6 +209,31 @@ describe("resolveAuthTokens", () => {
     expect(tokens.verify("definitely-not-it")).toBe(false);
     expect(tokens.liveCount()).toBe(1);
   });
+
+  // Security regression (CWE-532): a saved token must NOT be echoed to stderr —
+  // stderr (journald/`docker logs`/log shippers) outlives and outreaches the
+  // 0600 .env. Point the operator at the file instead.
+  it("does not print the generated token to stderr when it was saved 0600", async () => {
+    const tokens = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    const token = await fileToken(dir); // the real, persisted token
+    const stderr = (process.stderr.write as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls.map((c) => String(c[0])).join("");
+
+    expect(tokens.verify(token)).toBe(true);   // sanity: this is the live token
+    expect(stderr).not.toContain(token);       // the fix: never on stderr
+    expect(stderr).toContain(".env");          // it points at the file instead
+  });
+
+  // The counterpart: when persistence FAILS, stderr is the operator's only copy,
+  // so the token MUST be echoed there.
+  it("echoes the token to stderr when it could not be saved", async () => {
+    await resolveAuthTokens({ dataDir: "/dev/null/nope", graceMs: 24 * HOUR }, logger);
+    const stderr = (process.stderr.write as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls.map((c) => String(c[0])).join("");
+
+    expect(stderr).toContain("could NOT be saved");
+    expect(stderr).toMatch(/auth token: \S+/); // the token value is present
+  });
 });
 
 describe("AuthTokens grace-entry retention (recovery after broken data dir)", () => {


### PR DESCRIPTION
Closes the one test gap from the audit-fix review: the CWE-532 fix in #89 (bearer token not printed to stderr when saved 0600) had no direct regression test.

Adds both branches to `auth-token.test.ts`:
- **saved** — reads the persisted token from `.env`, asserts it is NOT in the stderr writes and that stderr points at the file.
- **unsaved** (`/dev/null/nope`) — asserts the token IS echoed (operator's only copy) plus the "could NOT be saved" warning.

Verified discriminating: reintroducing the token echo in the saved branch fails the first test (`expected … not to contain <token>`). Full suite green — 385 passed; the 2 `CCU_HOST`-gated integration files are the pre-existing no-hardware failures.