### PR TITLE
Release v1.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       # Third-party actions pinned to a commit SHA (supply-chain hardening):
       # a retargeted mutable tag can't inject code into CI. Dependabot bumps
       # the SHA + comment together.
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+# Arm auto-merge on Dependabot PRs into dev. GitHub holds the merge until the
+# required `build-and-test` check (dev branch protection) goes green, then
+# squash-merges and deletes the branch (repo setting). Nothing merges on red CI.
+#
+# Uses only the preinstalled `gh` CLI + the built-in GITHUB_TOKEN — no
+# third-party actions, so there is no SHA to pin. `pull_request_target` runs in
+# the base-repo context so the token can enable auto-merge; we never check out
+# or execute the PR's code, so the untrusted-code risk of that trigger does not
+# apply here.
+
+on:
+  pull_request_target:
+    branches: [dev]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,54 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
+## v1.8.0 — 2026-07-05
+
+Post-1.7.0 audit-fix release: a fresh multi-agent source review (six dimensions,
+every finding adversarially verified) found no real bugs, and its handful of
+confirmed low/medium items are fixed here. A final review of the fix commit
+itself caught — and this release also fixes — a regression it had introduced.
+
+### Security
+
+- **The auto-generated bearer token is no longer echoed to stderr when it was
+  persisted 0600** (CWE-532). stderr (journald / `docker logs` / log shippers)
+  is retained longer and readable by more principals than the `0600` `.env`, so
+  printing the token there defeated storing it restricted. It is now only echoed
+  when persistence FAILED — then stderr is the operator's sole copy. Nothing
+  changes for an operator-supplied `MCP_AUTH_TOKEN`.
+- The redacting logger now recurses into arrays as well as objects, so a
+  secret-named key nested inside an array element can no longer log in cleartext.
+
+### Behavior changes (read before upgrading)
+
+- **`list_devices` now returns `NOT_FOUND` for an unknown `room` or `function`
+  filter** instead of an empty device list. A typo'd filter name previously
+  looked like a genuinely empty room; it now fails loud with the valid names,
+  matching the write tools and the documented contract. If you relied on the
+  empty-list response for an unknown filter, handle the error instead.
+
+### Fixed
+
+- Session renewal no longer overlaps itself. It moved from `setInterval` to a
+  self-rescheduling `setTimeout` (a slow renew/relogin under a raised
+  `CCU_TIMEOUT` can't stack calls against a struggling box), guarded on timer
+  handle identity so the relogin path can't leak a second, overlapping renewal
+  loop.
+
+### Internal
+
+- Shared `tools/fields.ts` for the `targetField` / `confirmField` schemas (they
+  had drifted between copies).
+- CI: Dependabot PRs into `dev` now auto-merge once `build-and-test` passes;
+  `dev` is branch-protected with that required check.
+- New regression tests for every fix above (array redaction, `list_devices`
+  `NOT_FOUND`, single-renewal-timer-after-relogin, token-not-echoed-when-saved).
+
+### Dependencies
+
+- undici 8.5.0 → 8.6.0, @types/node 25.9.3 → 26.1.0, vitest / @vitest/coverage-v8
+  4.1.8 → 4.1.9, actions/checkout 6 → 7.
+
 ## v1.7.0 — 2026-07-04
 
 Execution-safety audit release: seven adversarial review rounds plus two

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,21 +87,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -201,14 +201,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -220,9 +220,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -264,9 +264,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -315,13 +315,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -332,13 +335,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -349,13 +355,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -366,13 +375,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -383,13 +395,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -400,13 +415,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -417,9 +435,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -434,9 +452,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
       ],
@@ -444,18 +462,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -470,9 +488,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -501,9 +519,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -547,14 +565,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
-      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -568,8 +586,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.8",
-        "vitest": "4.1.8"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -578,16 +596,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -596,13 +614,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -623,9 +641,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -636,13 +654,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -650,14 +668,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -666,9 +684,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -676,13 +694,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1611,6 +1629,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1632,6 +1653,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1653,6 +1677,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1674,6 +1701,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1829,9 +1859,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -1952,9 +1982,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1974,9 +2004,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -2064,13 +2094,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.138.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -2080,21 +2110,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/router": {
@@ -2453,16 +2483,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -2479,7 +2509,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -2531,19 +2561,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2571,12 +2601,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ccu-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^25.9.3",
+        "@types/node": "^26.1.0",
         "@vitest/coverage-v8": "^4.1.8",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8"
@@ -537,13 +537,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -2428,9 +2428,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2419,9 +2419,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.6.0.tgz",
+      "integrity": "sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^25.9.3",
+    "@types/node": "^26.1.0",
     "@vitest/coverage-v8": "^4.1.8",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.7.0",
+  "version": "1.8.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -185,16 +185,24 @@ async function persist(dataDir: string, state: PersistedToken, logger: Logger): 
 function announce(token: string, dataDir: string, rotated: boolean, saved: boolean): void {
   const envPath = join(dataDir, ENV_FILENAME);
   const what = rotated ? "Rotated auth token" : "Generated auth token";
-  // stderr so the operator can copy it; never goes through the structured logger.
-  process.stderr.write(`\n[ccu-mcp] ${what}: ${token}\n`);
+  // stderr so the operator can find it; never goes through the structured logger.
+  // When the token was persisted 0600, point at the file rather than echoing the
+  // secret: stderr (journald / `docker logs` / a log shipper) is retained longer
+  // and readable by more principals than the 0600 .env, so printing the token
+  // here would defeat storing it restricted (CWE-532). Only echo it when it could
+  // NOT be saved — then stderr is the operator's sole way to recover it.
   if (saved) {
-    process.stderr.write(`[ccu-mcp] Token saved to ${envPath}\n`);
+    process.stderr.write(
+      `\n[ccu-mcp] ${what}, saved to ${envPath} (mode 0600).\n` +
+        `[ccu-mcp] Read MCP_AUTH_TOKEN from that file for your MCP client configuration.\n\n`,
+    );
   } else {
     process.stderr.write(
-      `[ccu-mcp] WARNING: the token could NOT be saved to ${envPath} — it is valid for this run only. Fix the data dir permissions.\n`,
+      `\n[ccu-mcp] ${what}: ${token}\n` +
+        `[ccu-mcp] WARNING: the token could NOT be saved to ${envPath} — it is valid for this run only. Fix the data dir permissions.\n` +
+        `[ccu-mcp] Use this token in your MCP client configuration.\n\n`,
     );
   }
-  process.stderr.write(`[ccu-mcp] Use this token in your MCP client configuration.\n\n`);
 }
 
 /**

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
+import { readFile, writeFile, rename, mkdir, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { scryptSync, randomBytes, timingSafeEqual } from "node:crypto";
 import type { CcuConfig } from "./types.js";
@@ -18,7 +18,7 @@ export class SessionManager {
   private readonly cacheDir: string;
   private readonly sessionFile: string;
   private sessionId: string | null = null;
-  private renewTimer: ReturnType<typeof setInterval> | null = null;
+  private renewTimer: ReturnType<typeof setTimeout> | null = null;
   private loginPromise: Promise<void> | null = null;
   // Set on logout/destroy: an in-flight call failing AUTH after logout must
   // not lazily re-login — that would mint a CCU session nobody ever logs out,
@@ -292,7 +292,6 @@ export class SessionManager {
 
   private async clearPersistedSession(): Promise<void> {
     try {
-      const { unlink } = await import("node:fs/promises");
       await unlink(join(this.cacheDir, this.sessionFile));
     } catch {
       // Ignore
@@ -301,26 +300,43 @@ export class SessionManager {
 
   private startRenewal(): void {
     this.stopRenewal();
-    this.renewTimer = setInterval(async () => {
-      if (!this.sessionId) return;
-      try {
-        await this.client.call("Session.renew", { _session_id_: this.sessionId });
-        this.logger.debug("session_renewed");
-      } catch {
-        this.logger.warn("session_renew_failed");
-        try {
-          await this.login();
-        } catch (loginErr) {
-          this.logger.error("session_relogin_failed", { error: (loginErr as Error).message });
+    this.scheduleRenewal();
+  }
+
+  // Self-rescheduling setTimeout (not setInterval): the next renew is armed only
+  // AFTER the current one settles, so a slow renew/relogin under a raised
+  // CCU_TIMEOUT (> the 60s interval) can never stack overlapping calls against
+  // an already-struggling box. Mirrors ResourcePoller.schedule().
+  private scheduleRenewal(): void {
+    this.renewTimer = setTimeout(() => {
+      this.renewOnce().finally(() => {
+        // Only re-arm if we weren't stopped/destroyed while the renew was in flight.
+        if (!this.closed && this.renewTimer !== null) {
+          this.scheduleRenewal();
         }
-      }
+      });
     }, SESSION_RENEW_INTERVAL);
     this.renewTimer.unref();
   }
 
+  private async renewOnce(): Promise<void> {
+    if (!this.sessionId) return;
+    try {
+      await this.client.call("Session.renew", { _session_id_: this.sessionId });
+      this.logger.debug("session_renewed");
+    } catch {
+      this.logger.warn("session_renew_failed");
+      try {
+        await this.login();
+      } catch (loginErr) {
+        this.logger.error("session_relogin_failed", { error: (loginErr as Error).message });
+      }
+    }
+  }
+
   private stopRenewal(): void {
     if (this.renewTimer) {
-      clearInterval(this.renewTimer);
+      clearTimeout(this.renewTimer);
       this.renewTimer = null;
     }
   }

--- a/src/ccu/session.ts
+++ b/src/ccu/session.ts
@@ -308,15 +308,21 @@ export class SessionManager {
   // CCU_TIMEOUT (> the 60s interval) can never stack overlapping calls against
   // an already-struggling box. Mirrors ResourcePoller.schedule().
   private scheduleRenewal(): void {
-    this.renewTimer = setTimeout(() => {
+    const handle = setTimeout(() => {
       this.renewOnce().finally(() => {
-        // Only re-arm if we weren't stopped/destroyed while the renew was in flight.
-        if (!this.closed && this.renewTimer !== null) {
+        // Re-arm only if THIS timer is still the active one and we weren't
+        // stopped/destroyed. A plain `renewTimer !== null` check is not enough:
+        // renewOnce()'s relogin path calls login() → startRenewal(), which
+        // already re-arms the timer mid-flight; without the identity check this
+        // finally would arm a SECOND timer and leak an overlapping renewal loop
+        // per relogin — the exact overlap this setTimeout design exists to avoid.
+        if (!this.closed && this.renewTimer === handle) {
           this.scheduleRenewal();
         }
       });
     }, SESSION_RENEW_INTERVAL);
-    this.renewTimer.unref();
+    this.renewTimer = handle;
+    handle.unref();
   }
 
   private async renewOnce(): Promise<void> {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,15 +12,22 @@ const REDACTED_KEYS = new Set(["password", "_session_id_", "MCP_AUTH_TOKEN"]);
 function redact(obj: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
-    if (REDACTED_KEYS.has(key)) {
-      result[key] = "[REDACTED]";
-    } else if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-      result[key] = redact(value as Record<string, unknown>);
-    } else {
-      result[key] = value;
-    }
+    result[key] = REDACTED_KEYS.has(key) ? "[REDACTED]" : redactValue(value);
   }
   return result;
+}
+
+// Recurse through both objects AND arrays so a secret-named key nested inside an
+// array element (e.g. { params: [{ password: "…" }] }) is redacted too — a plain
+// object walk would emit it in cleartext.
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactValue);
+  }
+  if (typeof value === "object" && value !== null) {
+    return redact(value as Record<string, unknown>);
+  }
+  return value;
 }
 
 export class Logger {

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -7,11 +7,7 @@ import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable } from "../ccu/target-registry.js";
 import { toolResult, parseValue, escapeHmScript, expectArray } from "../utils.js";
-
-// Optional `confirm` field for write tools: required (true) to authorize a write
-// against a `protected` CCU target (e.g. prod). Harmless on unprotected targets.
-const confirmField = z.boolean().optional()
-  .describe("Set true to authorize this write against a protected CCU target (e.g. prod). Unlocks writes to that target for the rest of the session.");
+import { confirmField } from "./fields.js";
 
 export function registerControlTools(server: McpServer, deps: ServerDeps): void {
   registerSetValue(server, deps);

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -7,6 +7,7 @@ import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { assertWritable, resolveTarget } from "../ccu/target-registry.js";
 import { toolResult, structuredResult, tryParseJson, escapeHmScript, VERSION, loadBuildInfo, expectArray } from "../utils.js";
+import { targetField, confirmField } from "./fields.js";
 
 export function registerDiagnosticsTools(server: McpServer, deps: ServerDeps): void {
   registerGetServiceMessages(server, deps);
@@ -29,7 +30,7 @@ function registerGetServiceMessages(server: McpServer, deps: ServerDeps): void {
       description:
         "Get all active service messages (low battery, unreachable, etc.) with device details and timestamps.",
       inputSchema: {
-        target: z.string().optional().describe("CCU target to read from (default: active). See list_ccu_targets."),
+        target: targetField,
       },
       outputSchema: { messages: z.array(z.unknown()).describe("Active alarms: {id, type, address, channelName, timestamp}") },
       annotations: { readOnlyHint: true, openWorldHint: true },
@@ -159,7 +160,7 @@ function registerAcknowledgeServiceMessages(server: McpServer, deps: ServerDeps)
       inputSchema: {
         id: z.string().optional().describe("Alarm id from get_service_messages (confirm a single message)"),
         address: z.string().optional().describe("Channel address — confirm all active messages on this channel (e.g. '000A1BE9A71F15:0')"),
-        confirm: z.boolean().optional().describe("Set true to authorize this write against a protected CCU target (e.g. prod)."),
+        confirm: confirmField,
       },
       annotations: {
         destructiveHint: true,
@@ -292,7 +293,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
         "on the CCU, so they show \"N/A\" for a non-admin (USER) login. Also reports the running " +
         "server's build identification (git branch/commit/tag and build time) under `build`.",
       inputSchema: {
-        target: z.string().optional().describe("CCU target to read from (default: active). See list_ccu_targets."),
+        target: targetField,
       },
       outputSchema: {
         serverVersion: z.string().optional(),
@@ -386,7 +387,7 @@ function registerGetRssi(server: McpServer, deps: ServerDeps): void {
         "Use to answer 'why is this sensor flaky?'. Higher (closer to 0) dBm is better; null = no measurement.",
       inputSchema: {
         name: z.string().optional().describe("Filter by device name or address (substring, case-insensitive)"),
-        target: z.string().optional().describe("CCU target to read from (default: active). See list_ccu_targets."),
+        target: targetField,
       },
       outputSchema: {
         devices: z.array(z.unknown()).describe("Per device: {address, name, interface, links:[{peer, rssiDevice, rssiPeer}]}"),

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -2,14 +2,12 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerDeps } from "../server.js";
 import type { CcuDevice } from "../ccu/types.js";
+import { CcuError } from "../middleware/error-mapper.js";
 import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { resolveTarget } from "../ccu/target-registry.js";
 import { structuredResult, expectArray } from "../utils.js";
-
-// Optional per-call target override (route one read to a named CCU).
-const targetField = z.string().optional()
-  .describe("CCU target to read from (default: active). See list_ccu_targets.");
+import { targetField } from "./fields.js";
 
 export function registerDiscoveryTools(server: McpServer, deps: ServerDeps): void {
   registerListDevices(server, deps);
@@ -72,7 +70,18 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             { rateLimiter },
           ).then((r) => expectArray<{ id: string; name: string; channelIds: string[] }>(r));
           const room = rooms.find((r) => r.name === args.room);
-          filterSets.push(new Set(room?.channelIds ?? []));
+          if (!room) {
+            // Fail loud on an unknown filter name rather than returning an empty
+            // list that looks like a genuinely empty room — mirrors the write
+            // tools (assign_channel) and the help text's NOT_FOUND promise.
+            throw new CcuError({
+              error: "NOT_FOUND",
+              code: 0,
+              message: `Room not found: ${args.room}`,
+              hint: `Valid rooms: ${rooms.map((r) => r.name).join(", ")}`,
+            });
+          }
+          filterSets.push(new Set(room.channelIds ?? []));
         }
 
         if (args.function) {
@@ -84,7 +93,15 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             { rateLimiter },
           ).then((r) => expectArray<{ id: string; name: string; channelIds: string[] }>(r));
           const func = functions.find((f) => f.name === args.function);
-          filterSets.push(new Set(func?.channelIds ?? []));
+          if (!func) {
+            throw new CcuError({
+              error: "NOT_FOUND",
+              code: 0,
+              message: `Function not found: ${args.function}`,
+              hint: `Valid functions: ${functions.map((f) => f.name).join(", ")}`,
+            });
+          }
+          filterSets.push(new Set(func.channelIds ?? []));
         }
 
         devices = devices.filter((d) =>

--- a/src/tools/fields.ts
+++ b/src/tools/fields.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+// Shared zod field definitions reused across tool modules so their descriptions
+// stay identical (they previously drifted between copies).
+
+// Optional per-call target override for read tools: route this one read to a
+// named CCU without switching the active target (handy for prod-vs-dev compares).
+export const targetField = z.string().optional()
+  .describe("CCU target to read from (default: active). See list_ccu_targets.");
+
+// Optional `confirm` field for write tools: required (true) to authorize a write
+// against a `protected` CCU target (e.g. prod). Harmless on unprotected targets.
+export const confirmField = z.boolean().optional()
+  .describe("Set true to authorize this write against a protected CCU target (e.g. prod). Unlocks writes to that target for the rest of the session.");

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -6,11 +6,7 @@ import { withRetry } from "../middleware/retry.js";
 import { runTool } from "../middleware/tool-handler.js";
 import { resolveTarget } from "../ccu/target-registry.js";
 import { structuredResult, tryParseJson, escapeHmScript, parseValue, parseValues } from "../utils.js";
-
-// Optional per-call target override for read tools: route this one read to a
-// named CCU without switching the active target (handy for prod-vs-dev compares).
-const targetField = z.string().optional()
-  .describe("CCU target to read from (default: active). See list_ccu_targets.");
+import { targetField } from "./fields.js";
 
 export function registerReadTools(server: McpServer, deps: ServerDeps): void {
   registerGetValue(server, deps);

--- a/test/unit/auth-token.test.ts
+++ b/test/unit/auth-token.test.ts
@@ -209,6 +209,31 @@ describe("resolveAuthTokens", () => {
     expect(tokens.verify("definitely-not-it")).toBe(false);
     expect(tokens.liveCount()).toBe(1);
   });
+
+  // Security regression (CWE-532): a saved token must NOT be echoed to stderr —
+  // stderr (journald/`docker logs`/log shippers) outlives and outreaches the
+  // 0600 .env. Point the operator at the file instead.
+  it("does not print the generated token to stderr when it was saved 0600", async () => {
+    const tokens = await resolveAuthTokens({ dataDir: dir, graceMs: 24 * HOUR }, logger);
+    const token = await fileToken(dir); // the real, persisted token
+    const stderr = (process.stderr.write as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls.map((c) => String(c[0])).join("");
+
+    expect(tokens.verify(token)).toBe(true);   // sanity: this is the live token
+    expect(stderr).not.toContain(token);       // the fix: never on stderr
+    expect(stderr).toContain(".env");          // it points at the file instead
+  });
+
+  // The counterpart: when persistence FAILS, stderr is the operator's only copy,
+  // so the token MUST be echoed there.
+  it("echoes the token to stderr when it could not be saved", async () => {
+    await resolveAuthTokens({ dataDir: "/dev/null/nope", graceMs: 24 * HOUR }, logger);
+    const stderr = (process.stderr.write as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls.map((c) => String(c[0])).join("");
+
+    expect(stderr).toContain("could NOT be saved");
+    expect(stderr).toMatch(/auth token: \S+/); // the token value is present
+  });
 });
 
 describe("AuthTokens grace-entry retention (recovery after broken data dir)", () => {

--- a/test/unit/logger.test.ts
+++ b/test/unit/logger.test.ts
@@ -60,4 +60,14 @@ describe("Logger", () => {
     expect(line.params.password).toBe("[REDACTED]");
     expect(line.params.user).toBe("admin");
   });
+
+  it("redacts sensitive fields nested inside arrays", () => {
+    const logger = new Logger("debug");
+    logger.debug("array", { items: [{ password: "secret", user: "admin" }], _session_id_: "top" });
+
+    const line = JSON.parse((stderrSpy.mock.calls[0]![0] as string).trim());
+    expect(line.items[0].password).toBe("[REDACTED]");
+    expect(line.items[0].user).toBe("admin");
+    expect(line._session_id_).toBe("[REDACTED]");
+  });
 });

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -290,6 +290,40 @@ describe("SessionManager", () => {
       expect(session.getSessionId()).toBe("new-sess");
       session.destroy();
     });
+
+    // Regression: a relogin must leave EXACTLY ONE renewal timer. The relogin
+    // path (renewOnce → login → startRenewal) re-arms the timer mid-flight; the
+    // outer scheduleRenewal().finally must not then arm a SECOND one, or an
+    // overlapping renewal loop leaks per relogin (the overlap this design avoids).
+    it("keeps exactly one renewal timer after a relogin", async () => {
+      const client = createMockClient();
+      client.call.mockResolvedValueOnce("sess"); // initial login
+      const session = createSession(client);
+      await session.login();
+
+      vi.spyOn(session as any, "tryRestoreSession").mockResolvedValue(false);
+      vi.spyOn(session as any, "persistSession").mockResolvedValue(undefined);
+
+      // t=60s: renew fails → relogin succeeds → new session, renewal re-armed.
+      client.call.mockImplementation(async (method: string) => {
+        if (method === "Session.renew") throw new Error("renew fail");
+        if (method === "Session.login") return "new-sess";
+        return null;
+      });
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(session.getSessionId()).toBe("new-sess");
+
+      // Renew now succeeds. Advancing one interval must fire the renewal EXACTLY
+      // once — two calls would prove a leaked, overlapping second timer.
+      client.call.mockReset();
+      client.call.mockResolvedValue(true);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const renews = client.call.mock.calls.filter((c) => c[0] === "Session.renew");
+      expect(renews.length).toBe(1);
+      session.destroy();
+    });
   });
 
   describe("destroy", () => {

--- a/test/unit/tools-discovery.test.ts
+++ b/test/unit/tools-discovery.test.ts
@@ -55,10 +55,25 @@ describe("list_devices handler", () => {
     cleanupDeps(deps);
   });
 
-  it("returns empty when room not found", async () => {
+  it("throws NOT_FOUND (with valid names) when the room filter is unknown", async () => {
     const { server, deps } = createServer();
-    const result = parseToolResult(await callTool(server, "list_devices", { room: "Nonexistent" })) as any[];
-    expect(result.length).toBe(0);
+    // An unknown filter name must fail loud, not return an empty list that looks
+    // like a genuinely empty room — consistent with the write tools.
+    const result = await callTool(server, "list_devices", { room: "Nonexistent" }) as any;
+    expect(result.isError).toBe(true);
+    const err = JSON.parse(result.content[0].text);
+    expect(err.error).toBe("NOT_FOUND");
+    expect(err.hint).toContain("Wohnzimmer");
+    cleanupDeps(deps);
+  });
+
+  it("throws NOT_FOUND (with valid names) when the function filter is unknown", async () => {
+    const { server, deps } = createServer();
+    const result = await callTool(server, "list_devices", { function: "Nonexistent" }) as any;
+    expect(result.isError).toBe(true);
+    const err = JSON.parse(result.content[0].text);
+    expect(err.error).toBe("NOT_FOUND");
+    expect(err.hint).toContain("Heizung");
     cleanupDeps(deps);
   });
 


### PR DESCRIPTION
## v1.8.0 — audit-fix release

A fresh multi-agent source review (6 dimensions, every finding adversarially verified) found **no real bugs**; its confirmed low/medium items are fixed here, plus a regression the final review caught in the fix commit itself.

### Security
- Auto-generated bearer token no longer echoed to stderr when persisted 0600 (CWE-532); only printed when saving fails.
- Redacting logger now recurses into arrays.

### Behavior change (read before upgrading)
- `list_devices` returns **NOT_FOUND** for an unknown `room`/`function` filter instead of an empty list.

### Fixed
- Session renewal moved to a self-rescheduling `setTimeout` with a handle-identity guard — no overlapping renewal loops (incl. the #90 regression fix).

### Internal / deps
- Shared `tools/fields.ts`; Dependabot auto-merge + `dev` branch protection; dep bumps (undici 8.6.0, @types/node 26.1.0, vitest 4.1.9, actions/checkout 7).
- Regression tests for every fix.

Rolls up #82–#86, #88, #89, #90, #91. Full suite green (385 passed; 2 CCU_HOST-gated integration files are the pre-existing no-hardware failures).