### PR TITLE
ci: split hermetic from non-hermetic checks

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,219 @@
+name: Dependency audit
+
+# NON-HERMETIC BY CONSTRUCTION — never make this a required status check.
+# Its verdict is a function of the GitHub Advisory DB (global mutable state),
+# not of the commit under test. A required check whose result can flip
+# overnight with no diff deadlocks every open PR: that is exactly why the
+# `npm audit` step was removed from ci.yml's `build-and-test`.
+#
+# Scope: PRODUCTION dependencies only, high + critical only.
+#   - prod-only: package.json `files` publishes dist/ alone, so a
+#     devDependency advisory (vitest -> vite -> postcss) never reaches a user.
+#   - high+critical only: moderate and low ride the weekly Dependabot cadence.
+#
+# Signal: ONE long-lived tracking issue, found by the `dependency-audit`
+# label. Dirty -> open it, or rewrite it in place. Clean -> comment + close.
+# The JOB stays GREEN whenever the audit ran, however ugly the findings; it
+# goes red only when the audit could NOT run. A red scheduled workflow must
+# mean "no audit happened", not "an advisory exists" — otherwise the daily
+# failure mail earns a filter rule within a week and the mechanism is dead.
+#
+# Uses only the preinstalled `gh` CLI + the built-in GITHUB_TOKEN — no
+# third-party actions, so there is no SHA to pin. Same convention as
+# dependabot-auto-merge.yml.
+#
+# Scheduled workflows only run from the DEFAULT branch (`dev`), so this file
+# must be on `dev` to fire at all, and it audits dev's lockfile. `main` is
+# covered by the `release-audit` job in release-gate.yml.
+
+on:
+  schedule:
+    # 04:17 UTC daily. Deliberately off the hour: GitHub's cron queue is
+    # heavily oversubscribed at :00 and delays runs by tens of minutes.
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read # checkout, to read the committed package-lock.json
+  issues: write # create/edit/comment/close the tracking issue + its label
+
+# A scheduled run racing a manual dispatch would file two tracking issues.
+concurrency:
+  group: dependency-audit
+  cancel-in-progress: false
+
+env:
+  AUDIT_LABEL: dependency-audit
+  ISSUE_TITLE: "Dependency audit: high/critical advisories in production dependencies"
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+
+      - name: Audit production dependencies
+        id: audit
+        run: |
+          set -uo pipefail
+
+          # --package-lock-only audits the committed lockfile directly: no
+          # `npm ci`, no node_modules, nothing built. That removes an install
+          # step whose failure would masquerade as an audit result.
+          #
+          # npm audit exits 1 whenever it finds anything, and `run:` uses
+          # `bash -e`, so the exit code MUST be captured here or the step dies
+          # before the tracking issue is ever filed.
+          rc=0
+          npm audit --omit=dev --package-lock-only --json > audit.json || rc=$?
+          echo "npm audit exit code: $rc"
+
+          # Exit 1 == "vulnerabilities found" and is expected. Anything else,
+          # or an unparseable report, means the audit did not run (registry
+          # 5xx, DNS, npm bug). Fail loudly rather than let a broken audit be
+          # mistaken for a clean one and auto-close the tracking issue.
+          if ! jq -e 'has("metadata") and (.metadata.vulnerabilities | type == "object")' \
+               audit.json >/dev/null 2>&1; then
+            echo "::error::npm audit produced no parseable report (exit $rc) — infrastructure failure, NOT a clean audit."
+            head -c 4000 audit.json || true
+            exit 1
+          fi
+
+          high=$(jq -r '.metadata.vulnerabilities.high' audit.json)
+          crit=$(jq -r '.metadata.vulnerabilities.critical' audit.json)
+          count=$(( high + crit ))
+
+          # Fingerprint the SET of high/critical findings. The issue body is
+          # rewritten every run (editing a body notifies nobody); a comment is
+          # posted only when this fingerprint changes, so a long-lived
+          # advisory does not generate a notification every single morning.
+          fingerprint=$(jq -r '
+            [ .vulnerabilities[]
+              | select(.severity == "high" or .severity == "critical")
+              | "\(.name)@\(.range)" ] | sort | join(" ")' audit.json)
+          fingerprint=$(printf '%s' "$fingerprint" | sha256sum | cut -c1-12)
+
+          {
+            echo "count=$count"
+            echo "high=$high"
+            echo "critical=$crit"
+            echo "fingerprint=$fingerprint"
+          } >> "$GITHUB_OUTPUT"
+
+          # Human-readable report -> report.md, reused verbatim as the issue body.
+          {
+            echo "\`npm audit --omit=dev --package-lock-only\` on \`${GITHUB_REF_NAME}\` @ \`${GITHUB_SHA:0:7}\`"
+            echo
+            if [ "$count" -eq 0 ]; then
+              echo "**No high or critical advisories in production dependencies.**"
+            else
+              echo "**${count} high/critical in production dependencies** (${high} high, ${crit} critical)."
+            fi
+            echo
+            jq -r '
+              .vulnerabilities
+              | to_entries
+              | map(select(.value.severity == "high" or .value.severity == "critical"))
+              | sort_by(.key)[]
+              | .value as $v
+              | "### `\($v.name)` \($v.range) — \($v.severity)\n"
+                + "- direct dependency: `\($v.isDirect)`\n"
+                + "- fix available: " + (
+                    $v.fixAvailable
+                    | if type == "boolean" then (if . then "`yes` (in-range lockfile bump)" else "`no`" end)
+                      else "`\(.name)@\(.version)` — **semver-major: \(.isSemVerMajor)**"
+                      end
+                  ) + "\n"
+                + ( [ $v.via[] | select(type == "object") | "- \(.title)\n  \(.url)" ] | join("\n") )
+                + "\n"
+            ' audit.json
+          } > report.md
+
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Sync the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          COUNT: ${{ steps.audit.outputs.count }}
+          FINGERPRINT: ${{ steps.audit.outputs.fingerprint }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Idempotent: creates the label on the first run, refreshes it after.
+          # Labels live under the Issues API, so `issues: write` covers this.
+          gh label create "$AUDIT_LABEL" \
+            --color EE9900 \
+            --description "Automated production-dependency audit tracking issue" \
+            --force
+
+          # Label filter, NOT --search. `gh issue list --label` hits the REST
+          # list endpoint, which is read-your-writes. `--search` hits the
+          # search index, which lags by seconds to minutes and would let two
+          # runs each conclude "nothing open" and file a duplicate.
+          issue=$(gh issue list --state open --label "$AUDIT_LABEL" --limit 1 \
+                  --json number --jq '.[0].number // empty')
+
+          # ---- now clean -------------------------------------------------
+          if [ "$COUNT" -eq 0 ]; then
+            if [ -n "$issue" ]; then
+              gh issue comment "$issue" --body \
+                "Production dependencies are clean — no high or critical advisories in \`npm audit --omit=dev\`. Closing. ([run]($RUN_URL))"
+              gh issue close "$issue" --reason completed
+              echo "Closed tracking issue #$issue."
+            else
+              echo "Clean, no tracking issue open. Nothing to do."
+            fi
+            exit 0
+          fi
+
+          # ---- dirty: build the issue body -------------------------------
+          {
+            cat report.md
+            echo
+            echo "---"
+            echo
+            echo "### Remediation"
+            echo
+            echo "These are almost always TRANSITIVE. Dependabot bumps direct dependencies one"
+            echo "PR at a time and structurally cannot clear a transitive advisory that is"
+            echo "already fixable inside the existing semver ranges. The fix is a lockfile-only"
+            echo "re-resolution — run it from a worktree, per CLAUDE.md:"
+            echo
+            echo '```sh'
+            echo "git worktree add ../ccu-mcp-audit -b fix/audit-$FINGERPRINT origin/dev"
+            echo "cd ../ccu-mcp-audit"
+            echo "npm audit fix --package-lock-only"
+            echo "npm ci && npm run lint && npm test    # a lockfile bump is still a code change"
+            echo "git commit -am 'fix(deps): clear high/critical prod advisories (lockfile only)'"
+            echo '```'
+            echo
+            echo "If \`fix available\` above reports **semver-major: true**, the fix needs a"
+            echo "deliberate direct-dependency major bump instead — do NOT reach for"
+            echo "\`npm audit fix --force\`."
+            echo
+            echo "<sub>Maintained automatically by [\`.github/workflows/audit.yml\`]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/dev/.github/workflows/audit.yml). The body is rewritten on every run; a comment is added only when the advisory set changes; the issue closes itself when clean. Do not rename or unlabel it — the \`$AUDIT_LABEL\` label is how the workflow finds it.</sub>"
+            echo "<!-- audit-fingerprint: $FINGERPRINT -->"
+          } > issue-body.md
+
+          if [ -z "$issue" ]; then
+            url=$(gh issue create --title "$ISSUE_TITLE" \
+                    --label "$AUDIT_LABEL" --body-file issue-body.md)
+            echo "Opened tracking issue: $url"
+          else
+            prev=$(gh issue view "$issue" --json body --jq '.body' \
+                   | grep -oE 'audit-fingerprint: [0-9a-f]+' | head -1 | cut -d' ' -f2 || true)
+            gh issue edit "$issue" --body-file issue-body.md
+            if [ "${prev:-}" != "$FINGERPRINT" ]; then
+              gh issue comment "$issue" --body \
+                "Advisory set changed (\`${prev:-none}\` → \`$FINGERPRINT\`): now $COUNT high/critical in production dependencies. ([run]($RUN_URL))"
+              echo "Advisory set changed on #$issue; commented."
+            else
+              echo "Advisory set unchanged on #$issue; body refreshed silently."
+            fi
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,18 @@ permissions:
   contents: read
 
 jobs:
+  # HERMETIC ONLY. Every step below is a function of the commit under test:
+  # same tree in, same verdict out. That contract is what makes this a
+  # required status check on main and dev.
+  #
+  # `npm audit` used to live here and broke it. Its verdict is a function of
+  # the GitHub Advisory DB — global mutable state that moves with no diff. Two
+  # advisories landing against TRANSITIVE deps turned every branch red at 11s
+  # and deadlocked Dependabot, whose PRs bump one DIRECT dep at a time and so
+  # can never clear a transitive advisory. Scanning now lives where state
+  # belongs:
+  #   - .github/workflows/audit.yml          — daily, prod-only, files ONE issue
+  #   - release-gate.yml job `release-audit` — blocks PRs into main
   build-and-test:
     runs-on: ubuntu-latest
 
@@ -30,9 +42,6 @@ jobs:
 
       - name: Version sync check
         run: npm run check:versions
-
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
 
       - name: Type check
         run: npm run lint

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,15 +1,15 @@
 name: Release gate
 
-# Enforce the release convention (see CLAUDE.md): main only advances via a PR
-# titled "Release vX.Y.Z". Runs solely on PRs targeting main, so everyday dev
-# PRs are unaffected. It's a required status check, but branch protection keeps
-# enforce_admins off, so an admin can still override for emergency hotfixes.
+# Gates on PRs into main — the deliberate, attended moment. Runs solely on PRs
+# targeting main, so everyday dev PRs are unaffected. Both jobs are required
+# status checks (see CLAUDE.md), but branch protection keeps enforce_admins
+# off, so an admin can still override for emergency hotfixes.
 on:
   pull_request:
     branches: [main]
     types: [opened, edited, reopened, synchronize]
 
-# No repo access needed: the title comes from the event payload.
+# Default for jobs that declare nothing: no token scopes at all.
 permissions: {}
 
 jobs:
@@ -29,3 +29,46 @@ jobs:
             echo "::error::PRs into main must be titled 'Release vX.Y.Z' (e.g. 'Release v1.3.0'). See CLAUDE.md. An admin can override for hotfixes."
             exit 1
           fi
+
+  # NON-HERMETIC, and deliberately so — same GitHub Advisory DB dependency as
+  # audit.yml. It belongs here and NOT in ci.yml's `build-and-test` because of
+  # who is standing in front of it: a human, opening a release PR, who can read
+  # the finding, fix the lockfile, or knowingly override. That is a completely
+  # different cost from a Dependabot PR deadlocking at 03:00 with nobody
+  # watching and no path to a fix.
+  #
+  # Scope matches audit.yml: production dependencies only (package.json `files`
+  # ships dist/ alone, so a devDependency advisory never reaches a user), high
+  # and critical only, read straight from the committed lockfile.
+  #
+  # Consequence to accept knowingly: a release PR that was green yesterday can
+  # be red today with no diff, because a new advisory landed. That is the
+  # correct behaviour AT THIS gate — you should not tag and npm-publish a
+  # known-vulnerable tree just because the advisory is newer than the branch.
+  release-audit:
+    runs-on: ubuntu-latest
+    # release-title needs no repo access; this job needs the lockfile. A
+    # job-level permissions block replaces the workflow-level {} for this job
+    # only, so release-title keeps its zero-scope token.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+
+      - name: No high/critical advisories in shipped dependencies
+        run: |
+          set -uo pipefail
+          # --package-lock-only: audit exactly the dependency set that will be
+          # resolved at install time. No `npm ci`, nothing built — this job
+          # asserts one thing and can only fail for that one reason.
+          rc=0
+          npm audit --omit=dev --package-lock-only --audit-level=high || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::Release blocked: high/critical advisories in production dependencies. Fix on dev with 'npm audit fix --package-lock-only', re-run 'npm ci && npm run lint && npm test', land it, then update this release PR. If the advisory is genuinely unreachable from shipped code, an admin can override (enforce_admins is off) — but record the reasoning in the PR."
+            exit 1
+          fi
+          echo "No high or critical advisories in production dependencies."

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -145,21 +145,43 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    harder, not to wave through. Then still read the README top-to-bottom for
    anything the per-PR pass missed.
 
-4. **Write the release notes.** This repo has no `RELEASE_NOTES.md` /
-   `CHANGELOG.md`; the notes live in the **GitHub Release body** (step 8).
-   Draft them now while the change set is fresh — summarise in user-visible
-   terms and call out any compatibility notes (new required env var, changed
-   tool contract, dropped behaviour). If you'd rather have an in-repo
-   changelog, that's a separate decision — introduce it before, not during, a
-   release.
+4. **Write the release notes — into `CHANGELOG.md`, then reuse them.** Add a
+   `## vX.Y.Z — YYYY-MM-DD` section at the top of `CHANGELOG.md` following the
+   existing convention: a short prose paragraph summarising the release, then
+   `###` subsections (`Security`, `Behavior changes (read before upgrading)`,
+   `Fixed`, `Added`, `Internal`, `Dependencies` — only the ones that apply).
+   Draft it while the change set is fresh; summarise in user-visible terms and
+   call out compatibility notes (new required env var, changed tool contract,
+   dropped behaviour). The same text becomes the **GitHub Release body** in
+   step 8, so write it once here.
 
-5. **PR `release/vX.Y.Z` → `dev`.** Required check: `CI` (build + test +
-   `npm audit --audit-level=high`). Merge when green.
+   `CHANGELOG.md` is **not** covered by `npm run check:versions` — nothing
+   fails if you forget it. It's on you.
+
+5. **PR `release/vX.Y.Z` → `dev`.** Required check: `build-and-test` (version
+   sync + type check + build + test). Merge when green.
+
+   Note it does **not** include a dependency audit: `build-and-test` is
+   hermetic by contract, and `npm audit`'s verdict depends on the GitHub
+   Advisory DB rather than on the commit. Scanning happens in
+   `.github/workflows/audit.yml` (daily, files a tracking issue) and at the
+   release gate in step 6.
 
 6. **Open the release PR `dev` → `main`** titled `Release vX.Y.Z`, with a
    `Closes #N` line for **every issue** in the milestone — that list is what
    auto-closes them and lets the milestone close. `main` is protected, so
-   this PR is the only way in; merge it when CI is green.
+   this PR is the only way in; merge it when the checks are green.
+
+   Required checks here: `build-and-test`, `release-title`, and
+   **`release-audit`** — the last asserts no high/critical advisories in
+   production dependencies (`npm audit --omit=dev`). It is the one gate that
+   can go red with no diff, because a new advisory landed since the branch was
+   cut; that is deliberate and correct at this point — don't tag and publish a
+   known-vulnerable tree. To clear it, fix on `dev` with
+   `npm audit fix --package-lock-only`, re-run `npm ci && npm run lint &&
+   npm test`, land it, then update the release PR. If the advisory is
+   genuinely unreachable from shipped code, an admin can override
+   (`enforce_admins` is off) — record the reasoning in the PR.
 
 7. **Tag `vX.Y.Z` on `main`:**
    ```sh


### PR DESCRIPTION
## Why

`npm audit --audit-level=high` ran inside the `build-and-test` job — a **required status check on both `main` and `dev`**. Its verdict is a function of the GitHub Advisory DB (global mutable state), not of the commit under test. A required check whose result is not a function of the diff turns red overnight with no code change and offers no in-diff path back to green.

That happened. Two advisories landed against **transitive** deps (`sdk→ajv→fast-uri`, `vitest→vite→postcss`). The job now dies at 11s, before lint/build/test run — which:

- blocks all four open Dependabot PRs (#102–#105); their auto-merge can never fire;
- can never be fixed by Dependabot, which bumps one **direct** dep per PR and structurally cannot clear a transitive advisory;
- hides whether the rest of the pipeline would even pass.

## What changes

| | |
|---|---|
| `ci.yml` | Audit step removed. `build-and-test` is now hermetic only: version sync, type check, build, test. **Job id unchanged**, so no branch-protection edit is needed. |
| `audit.yml` *(new)* | Daily (`17 4 * * *`) + `workflow_dispatch`. Prod deps only, high/critical only. Maintains **one** labelled tracking issue: opens it, rewrites the body each run, comments only when the advisory set changes (sha256 fingerprint), closes it when clean. |
| `release-gate.yml` | New `release-audit` job gating PRs into `main` — the attended moment, where a human can fix the lockfile or knowingly override. |
| `docs/release-runbook.md` | Step 4 claimed the repo has no `CHANGELOG.md` (it does); step 5 listed `npm audit` as part of the required check. |

## Design notes

- **The audit job stays green whenever the audit *ran***, however ugly the findings; red only when it *could not* run. A workflow that goes red daily earns a mail filter within a week and the mechanism dies. The issue is the signal.
- **Guards against a broken audit reading as clean** — `jq -e 'has("metadata")'` on the report. Without it a registry outage silently closes the security tracking issue.
- **Label lookup, not `--search`** — the search index is eventually consistent and would let a scheduled run racing a manual dispatch file duplicate issues.
- **`--package-lock-only`** — no `npm ci`, no `node_modules`. Removes an install step whose failure would masquerade as an audit result.
- **devDependency advisories are out of scope for both gates** — `files` ships `dist/` alone, so they never reach a user. (They're still fixed in the companion lockfile PR.)
- No auto-fix PR bot: a PR opened with `GITHUB_TOKEN` triggers no workflow runs, so `build-and-test` would never report on it — and it's a required check, so the PR would be permanently unmergeable. The tracking issue carries a copy-pasteable fix block instead.

## Verified locally

- All four workflow files parse as valid YAML.
- Ran the audit step's script against the real lockfile: exit-code capture works (`npm audit` exits 1 on findings), parse guard passes, `high=1 critical=0`, fingerprint `2689716b6450`, and the issue-body renderer produces correct Markdown for `fast-uri`.
- Ran it again against a fixed lockfile: exit 0, `count=0`, empty-set fingerprint handled — the clean/close branch works.

## Follow-ups (not in this PR)

- Companion PR fixes the lockfile + raises the SDK floor.
- #102–#105 need `@dependabot recreate` after that lands — a push event runs the workflow file *from the pushed branch*, so those branches still carry the old `ci.yml` and this change does not reach them retroactively.
- `release-audit` becomes a required check on `main` only after it has reported once (GitHub only offers checks it has seen). It must **not** be added to `dev`, where it would never report.