### PR TITLE
fix(deps): clear all six advisories; raise the SDK floor to ^1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,58 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
+## v1.8.1 — 2026-07-28
+
+Security patch release. Clears all six open dependency advisories — two of them
+high severity — and fixes the CI gate that had made them unfixable. No source
+changes; no behavior changes.
+
+### Security
+
+- **`fast-uri` (high)** — host confusion via literal backslash authority
+  delimiter and via failed IDN canonicalization (GHSA-v2hh-gcrm-f6hx,
+  GHSA-4c8g-83qw-93j6). Reached as `@modelcontextprotocol/sdk → ajv → fast-uri`;
+  resolved to 3.1.4.
+- **`postcss` (high)** — path traversal in source-map auto-loading
+  (GHSA-r28c-9q8g-f849). A devDependency (`vitest → vite`), so it never shipped;
+  fixed anyway.
+- **`@hono/node-server` (moderate)** — path traversal in `serve-static` on
+  Windows via encoded backslash (GHSA-frvp-7c67-39w9). This one is on the live
+  HTTP code path: the SDK's streamable-HTTP transport imports `getRequestListener`
+  from it. Resolved to 2.0.12.
+- **`hono` (moderate)** — three advisories covering JSX per-request context
+  isolation, `cx()` escaping bypass, and API-Gateway header de-duplication. None
+  of those surfaces are used here; resolved to 4.12.32 regardless.
+- **`body-parser` (moderate)** — denial of service when an invalid `limit`
+  silently disables size enforcement (GHSA-v422-hmwv-36x6). Dormant — reachable
+  only through SDK modules this server never imports.
+- **The floor for `@modelcontextprotocol/sdk` is now `^1.30.0`** (was `^1.29.0`).
+  This is the part of the fix that reaches you: `package-lock.json` is not
+  published, so an installed copy resolves from the declared ranges. SDK 1.29.0
+  pins `@hono/node-server: ^1.19.9`, a range with no non-vulnerable member — only
+  1.30.0 widens it to `^1.19.9 || ^2.0.5`. Raising the floor is what makes the
+  patched transport binding rather than incidental.
+
+### Internal
+
+- **CI now separates hermetic from non-hermetic checks.** `npm audit` ran inside
+  `build-and-test`, a required status check on both branches, but its verdict
+  depends on the GitHub Advisory DB rather than on the commit under test. When
+  the two transitive advisories landed, every branch went red at 11s — before
+  lint, build, or tests ran — and Dependabot, which bumps one direct dependency
+  per PR, could not clear a transitive advisory no matter how many PRs it opened.
+  `build-and-test` is now hermetic only. Scanning moved to a daily workflow that
+  maintains a single tracking issue, plus a `release-audit` gate on PRs into
+  `main` where a human is present to act on it.
+- The release runbook no longer claims this repo has no changelog.
+
+### Dependencies
+
+- `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0, `@hono/node-server` 1.19.14 →
+  2.0.12, `hono` 4.12.25 → 4.12.32, `fast-uri` 3.1.2 → 3.1.4, `postcss` 8.5.16 →
+  8.5.24, `body-parser` 2.2.2 → 2.3.0, plus `type-is`, `nanoid`, and a nested
+  `content-type` carried along by the re-resolution.
+
 ## v1.8.0 — 2026-07-05
 
 Post-1.7.0 audit-fix release: a fresh multi-agent source review (six dimensions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "undici": "^8.5.0",
         "zod": "^4.4.3"
       },
@@ -121,12 +121,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -161,12 +161,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1117,21 +1117,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1492,9 +1505,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -1672,9 +1685,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2199,9 +2212,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2344,9 +2357,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -2364,7 +2377,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2761,17 +2774,34 @@
       "optional": true
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "homepage": "https://github.com/claymore666/ccu-mcp#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "undici": "^8.5.0",
     "zod": "^4.4.3"
   },


### PR DESCRIPTION
Clears every open advisory — two high, four moderate, all transitive. `npm audit` now reports **0 vulnerabilities**.

## The part that actually ships

`npm audit fix --package-lock-only` fixes CI and the Docker image (`Dockerfile` runs `npm ci` twice). It does **not** protect anyone installing this package: `files` publishes `dist/` alone, so `package-lock.json` never reaches a consumer — an install resolves from the declared ranges.

Under `^1.29.0`, npm may legitimately pick SDK 1.29.0, which pins `@hono/node-server: ^1.19.9` — a range with **no non-vulnerable member** (the fix is ≥2.0.5). SDK 1.30.0 widens it to `^1.19.9 || ^2.0.5`. So raising our floor to `^1.30.0` is what binds the patched transport for consumers; the lockfile change alone would have been invisible to them.

## Advisories cleared

| Package | Sev | Path | Note |
|---|---|---|---|
| `fast-uri` → 3.1.4 | **high** | `sdk → ajv` | host confusion, 2 GHSAs |
| `postcss` → 8.5.24 | **high** | `vitest → vite` | devDep — never shipped, fixed anyway |
| `@hono/node-server` → 2.0.12 | moderate | `sdk` | **live code path** — see below |
| `hono` → 4.12.32 | moderate | `sdk` | JSX/`cx()`/gateway surfaces, none used here |
| `body-parser` → 2.3.0 | moderate | `sdk → express` | dormant — never imported |
| (1 low) | low | — | swept along |

## The one bump that needed real testing

`@hono/node-server` crosses a **major** (1.19.14 → 2.0.12) and is *not* dormant — the SDK's `streamableHttp.js` imports `getRequestListener` from it, and `src/index.ts:13` imports that transport. Every HTTP-mode process loads it.

Verified beyond the suite by starting HTTP mode and driving a real session:

- `GET /health` → `200 {"status":"ok"}`
- `POST /mcp initialize` → `200`, `mcp-session-id` issued, correct capabilities handshake over SSE

## Verification

```
npm ci && npm run lint && npm test
→ 385 passed | 26 skipped (the CCU_HOST-gated live suite) | 0 failed
npm audit → found 0 vulnerabilities
```

`npm run lint` matters here specifically — it type-checks the test files, which `npm test` does not.

## Notes

- Ships alongside #106, which moved dependency scanning out of the required `build-and-test` check and into a daily workflow + a `release-audit` release gate. That PR is why this one could go green.
- Supersedes #102 (body-parser 2.3.0) and #103 (sdk 1.30.0) — both land here exactly. Expect them to auto-close on recreate.
- `undici` is untouched: `dev` is already at 8.8.0 and it carries no advisory. #104 (→8.9.0) still applies on top.