### PR TITLE
chore(release): v1.8.1 — version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.8.0",
+  "version": "1.8.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump for the v1.8.1 security patch release. `npm version patch` — `package.json`, `server.json` root and `packages[0]`, all in sync (`npm run check:versions` green).

Pre-flight done: `npm publish --dry-run` builds a clean 116-file tarball (`dist/` + README + LICENSE), `mcp-publisher validate` returns ✅.

Release content is already on `dev`: #106 (CI hermetic split) and #108 (all six advisories cleared + SDK floor raised to `^1.30.0`). Changelog entry landed with #108.