### PR TITLE
Release v1.8.1

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,219 @@
+name: Dependency audit
+
+# NON-HERMETIC BY CONSTRUCTION — never make this a required status check.
+# Its verdict is a function of the GitHub Advisory DB (global mutable state),
+# not of the commit under test. A required check whose result can flip
+# overnight with no diff deadlocks every open PR: that is exactly why the
+# `npm audit` step was removed from ci.yml's `build-and-test`.
+#
+# Scope: PRODUCTION dependencies only, high + critical only.
+#   - prod-only: package.json `files` publishes dist/ alone, so a
+#     devDependency advisory (vitest -> vite -> postcss) never reaches a user.
+#   - high+critical only: moderate and low ride the weekly Dependabot cadence.
+#
+# Signal: ONE long-lived tracking issue, found by the `dependency-audit`
+# label. Dirty -> open it, or rewrite it in place. Clean -> comment + close.
+# The JOB stays GREEN whenever the audit ran, however ugly the findings; it
+# goes red only when the audit could NOT run. A red scheduled workflow must
+# mean "no audit happened", not "an advisory exists" — otherwise the daily
+# failure mail earns a filter rule within a week and the mechanism is dead.
+#
+# Uses only the preinstalled `gh` CLI + the built-in GITHUB_TOKEN — no
+# third-party actions, so there is no SHA to pin. Same convention as
+# dependabot-auto-merge.yml.
+#
+# Scheduled workflows only run from the DEFAULT branch (`dev`), so this file
+# must be on `dev` to fire at all, and it audits dev's lockfile. `main` is
+# covered by the `release-audit` job in release-gate.yml.
+
+on:
+  schedule:
+    # 04:17 UTC daily. Deliberately off the hour: GitHub's cron queue is
+    # heavily oversubscribed at :00 and delays runs by tens of minutes.
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read # checkout, to read the committed package-lock.json
+  issues: write # create/edit/comment/close the tracking issue + its label
+
+# A scheduled run racing a manual dispatch would file two tracking issues.
+concurrency:
+  group: dependency-audit
+  cancel-in-progress: false
+
+env:
+  AUDIT_LABEL: dependency-audit
+  ISSUE_TITLE: "Dependency audit: high/critical advisories in production dependencies"
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+
+      - name: Audit production dependencies
+        id: audit
+        run: |
+          set -uo pipefail
+
+          # --package-lock-only audits the committed lockfile directly: no
+          # `npm ci`, no node_modules, nothing built. That removes an install
+          # step whose failure would masquerade as an audit result.
+          #
+          # npm audit exits 1 whenever it finds anything, and `run:` uses
+          # `bash -e`, so the exit code MUST be captured here or the step dies
+          # before the tracking issue is ever filed.
+          rc=0
+          npm audit --omit=dev --package-lock-only --json > audit.json || rc=$?
+          echo "npm audit exit code: $rc"
+
+          # Exit 1 == "vulnerabilities found" and is expected. Anything else,
+          # or an unparseable report, means the audit did not run (registry
+          # 5xx, DNS, npm bug). Fail loudly rather than let a broken audit be
+          # mistaken for a clean one and auto-close the tracking issue.
+          if ! jq -e 'has("metadata") and (.metadata.vulnerabilities | type == "object")' \
+               audit.json >/dev/null 2>&1; then
+            echo "::error::npm audit produced no parseable report (exit $rc) — infrastructure failure, NOT a clean audit."
+            head -c 4000 audit.json || true
+            exit 1
+          fi
+
+          high=$(jq -r '.metadata.vulnerabilities.high' audit.json)
+          crit=$(jq -r '.metadata.vulnerabilities.critical' audit.json)
+          count=$(( high + crit ))
+
+          # Fingerprint the SET of high/critical findings. The issue body is
+          # rewritten every run (editing a body notifies nobody); a comment is
+          # posted only when this fingerprint changes, so a long-lived
+          # advisory does not generate a notification every single morning.
+          fingerprint=$(jq -r '
+            [ .vulnerabilities[]
+              | select(.severity == "high" or .severity == "critical")
+              | "\(.name)@\(.range)" ] | sort | join(" ")' audit.json)
+          fingerprint=$(printf '%s' "$fingerprint" | sha256sum | cut -c1-12)
+
+          {
+            echo "count=$count"
+            echo "high=$high"
+            echo "critical=$crit"
+            echo "fingerprint=$fingerprint"
+          } >> "$GITHUB_OUTPUT"
+
+          # Human-readable report -> report.md, reused verbatim as the issue body.
+          {
+            echo "\`npm audit --omit=dev --package-lock-only\` on \`${GITHUB_REF_NAME}\` @ \`${GITHUB_SHA:0:7}\`"
+            echo
+            if [ "$count" -eq 0 ]; then
+              echo "**No high or critical advisories in production dependencies.**"
+            else
+              echo "**${count} high/critical in production dependencies** (${high} high, ${crit} critical)."
+            fi
+            echo
+            jq -r '
+              .vulnerabilities
+              | to_entries
+              | map(select(.value.severity == "high" or .value.severity == "critical"))
+              | sort_by(.key)[]
+              | .value as $v
+              | "### `\($v.name)` \($v.range) — \($v.severity)\n"
+                + "- direct dependency: `\($v.isDirect)`\n"
+                + "- fix available: " + (
+                    $v.fixAvailable
+                    | if type == "boolean" then (if . then "`yes` (in-range lockfile bump)" else "`no`" end)
+                      else "`\(.name)@\(.version)` — **semver-major: \(.isSemVerMajor)**"
+                      end
+                  ) + "\n"
+                + ( [ $v.via[] | select(type == "object") | "- \(.title)\n  \(.url)" ] | join("\n") )
+                + "\n"
+            ' audit.json
+          } > report.md
+
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Sync the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          COUNT: ${{ steps.audit.outputs.count }}
+          FINGERPRINT: ${{ steps.audit.outputs.fingerprint }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Idempotent: creates the label on the first run, refreshes it after.
+          # Labels live under the Issues API, so `issues: write` covers this.
+          gh label create "$AUDIT_LABEL" \
+            --color EE9900 \
+            --description "Automated production-dependency audit tracking issue" \
+            --force
+
+          # Label filter, NOT --search. `gh issue list --label` hits the REST
+          # list endpoint, which is read-your-writes. `--search` hits the
+          # search index, which lags by seconds to minutes and would let two
+          # runs each conclude "nothing open" and file a duplicate.
+          issue=$(gh issue list --state open --label "$AUDIT_LABEL" --limit 1 \
+                  --json number --jq '.[0].number // empty')
+
+          # ---- now clean -------------------------------------------------
+          if [ "$COUNT" -eq 0 ]; then
+            if [ -n "$issue" ]; then
+              gh issue comment "$issue" --body \
+                "Production dependencies are clean — no high or critical advisories in \`npm audit --omit=dev\`. Closing. ([run]($RUN_URL))"
+              gh issue close "$issue" --reason completed
+              echo "Closed tracking issue #$issue."
+            else
+              echo "Clean, no tracking issue open. Nothing to do."
+            fi
+            exit 0
+          fi
+
+          # ---- dirty: build the issue body -------------------------------
+          {
+            cat report.md
+            echo
+            echo "---"
+            echo
+            echo "### Remediation"
+            echo
+            echo "These are almost always TRANSITIVE. Dependabot bumps direct dependencies one"
+            echo "PR at a time and structurally cannot clear a transitive advisory that is"
+            echo "already fixable inside the existing semver ranges. The fix is a lockfile-only"
+            echo "re-resolution — run it from a worktree, per CLAUDE.md:"
+            echo
+            echo '```sh'
+            echo "git worktree add ../ccu-mcp-audit -b fix/audit-$FINGERPRINT origin/dev"
+            echo "cd ../ccu-mcp-audit"
+            echo "npm audit fix --package-lock-only"
+            echo "npm ci && npm run lint && npm test    # a lockfile bump is still a code change"
+            echo "git commit -am 'fix(deps): clear high/critical prod advisories (lockfile only)'"
+            echo '```'
+            echo
+            echo "If \`fix available\` above reports **semver-major: true**, the fix needs a"
+            echo "deliberate direct-dependency major bump instead — do NOT reach for"
+            echo "\`npm audit fix --force\`."
+            echo
+            echo "<sub>Maintained automatically by [\`.github/workflows/audit.yml\`]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/dev/.github/workflows/audit.yml). The body is rewritten on every run; a comment is added only when the advisory set changes; the issue closes itself when clean. Do not rename or unlabel it — the \`$AUDIT_LABEL\` label is how the workflow finds it.</sub>"
+            echo "<!-- audit-fingerprint: $FINGERPRINT -->"
+          } > issue-body.md
+
+          if [ -z "$issue" ]; then
+            url=$(gh issue create --title "$ISSUE_TITLE" \
+                    --label "$AUDIT_LABEL" --body-file issue-body.md)
+            echo "Opened tracking issue: $url"
+          else
+            prev=$(gh issue view "$issue" --json body --jq '.body' \
+                   | grep -oE 'audit-fingerprint: [0-9a-f]+' | head -1 | cut -d' ' -f2 || true)
+            gh issue edit "$issue" --body-file issue-body.md
+            if [ "${prev:-}" != "$FINGERPRINT" ]; then
+              gh issue comment "$issue" --body \
+                "Advisory set changed (\`${prev:-none}\` → \`$FINGERPRINT\`): now $COUNT high/critical in production dependencies. ([run]($RUN_URL))"
+              echo "Advisory set changed on #$issue; commented."
+            else
+              echo "Advisory set unchanged on #$issue; body refreshed silently."
+            fi
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       # Third-party actions pinned to a commit SHA (supply-chain hardening):
       # a retargeted mutable tag can't inject code into CI. Dependabot bumps
       # the SHA + comment together.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       # the SHA + comment together.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,18 @@ permissions:
   contents: read
 
 jobs:
+  # HERMETIC ONLY. Every step below is a function of the commit under test:
+  # same tree in, same verdict out. That contract is what makes this a
+  # required status check on main and dev.
+  #
+  # `npm audit` used to live here and broke it. Its verdict is a function of
+  # the GitHub Advisory DB — global mutable state that moves with no diff. Two
+  # advisories landing against TRANSITIVE deps turned every branch red at 11s
+  # and deadlocked Dependabot, whose PRs bump one DIRECT dep at a time and so
+  # can never clear a transitive advisory. Scanning now lives where state
+  # belongs:
+  #   - .github/workflows/audit.yml          — daily, prod-only, files ONE issue
+  #   - release-gate.yml job `release-audit` — blocks PRs into main
   build-and-test:
     runs-on: ubuntu-latest
 
@@ -30,9 +42,6 @@ jobs:
 
       - name: Version sync check
         run: npm run check:versions
-
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
 
       - name: Type check
         run: npm run lint

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,15 +1,15 @@
 name: Release gate
 
-# Enforce the release convention (see CLAUDE.md): main only advances via a PR
-# titled "Release vX.Y.Z". Runs solely on PRs targeting main, so everyday dev
-# PRs are unaffected. It's a required status check, but branch protection keeps
-# enforce_admins off, so an admin can still override for emergency hotfixes.
+# Gates on PRs into main — the deliberate, attended moment. Runs solely on PRs
+# targeting main, so everyday dev PRs are unaffected. Both jobs are required
+# status checks (see CLAUDE.md), but branch protection keeps enforce_admins
+# off, so an admin can still override for emergency hotfixes.
 on:
   pull_request:
     branches: [main]
     types: [opened, edited, reopened, synchronize]
 
-# No repo access needed: the title comes from the event payload.
+# Default for jobs that declare nothing: no token scopes at all.
 permissions: {}
 
 jobs:
@@ -29,3 +29,46 @@ jobs:
             echo "::error::PRs into main must be titled 'Release vX.Y.Z' (e.g. 'Release v1.3.0'). See CLAUDE.md. An admin can override for hotfixes."
             exit 1
           fi
+
+  # NON-HERMETIC, and deliberately so — same GitHub Advisory DB dependency as
+  # audit.yml. It belongs here and NOT in ci.yml's `build-and-test` because of
+  # who is standing in front of it: a human, opening a release PR, who can read
+  # the finding, fix the lockfile, or knowingly override. That is a completely
+  # different cost from a Dependabot PR deadlocking at 03:00 with nobody
+  # watching and no path to a fix.
+  #
+  # Scope matches audit.yml: production dependencies only (package.json `files`
+  # ships dist/ alone, so a devDependency advisory never reaches a user), high
+  # and critical only, read straight from the committed lockfile.
+  #
+  # Consequence to accept knowingly: a release PR that was green yesterday can
+  # be red today with no diff, because a new advisory landed. That is the
+  # correct behaviour AT THIS gate — you should not tag and npm-publish a
+  # known-vulnerable tree just because the advisory is newer than the branch.
+  release-audit:
+    runs-on: ubuntu-latest
+    # release-title needs no repo access; this job needs the lockfile. A
+    # job-level permissions block replaces the workflow-level {} for this job
+    # only, so release-title keeps its zero-scope token.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+
+      - name: No high/critical advisories in shipped dependencies
+        run: |
+          set -uo pipefail
+          # --package-lock-only: audit exactly the dependency set that will be
+          # resolved at install time. No `npm ci`, nothing built — this job
+          # asserts one thing and can only fail for that one reason.
+          rc=0
+          npm audit --omit=dev --package-lock-only --audit-level=high || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::Release blocked: high/critical advisories in production dependencies. Fix on dev with 'npm audit fix --package-lock-only', re-run 'npm ci && npm run lint && npm test', land it, then update this release PR. If the advisory is genuinely unreachable from shipped code, an admin can override (enforce_admins is off) — but record the reasoning in the PR."
+            exit 1
+          fi
+          echo "No high or critical advisories in production dependencies."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,58 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
+## v1.8.1 — 2026-07-28
+
+Security patch release. Clears all six open dependency advisories — two of them
+high severity — and fixes the CI gate that had made them unfixable. No source
+changes; no behavior changes.
+
+### Security
+
+- **`fast-uri` (high)** — host confusion via literal backslash authority
+  delimiter and via failed IDN canonicalization (GHSA-v2hh-gcrm-f6hx,
+  GHSA-4c8g-83qw-93j6). Reached as `@modelcontextprotocol/sdk → ajv → fast-uri`;
+  resolved to 3.1.4.
+- **`postcss` (high)** — path traversal in source-map auto-loading
+  (GHSA-r28c-9q8g-f849). A devDependency (`vitest → vite`), so it never shipped;
+  fixed anyway.
+- **`@hono/node-server` (moderate)** — path traversal in `serve-static` on
+  Windows via encoded backslash (GHSA-frvp-7c67-39w9). This one is on the live
+  HTTP code path: the SDK's streamable-HTTP transport imports `getRequestListener`
+  from it. Resolved to 2.0.12.
+- **`hono` (moderate)** — three advisories covering JSX per-request context
+  isolation, `cx()` escaping bypass, and API-Gateway header de-duplication. None
+  of those surfaces are used here; resolved to 4.12.32 regardless.
+- **`body-parser` (moderate)** — denial of service when an invalid `limit`
+  silently disables size enforcement (GHSA-v422-hmwv-36x6). Dormant — reachable
+  only through SDK modules this server never imports.
+- **The floor for `@modelcontextprotocol/sdk` is now `^1.30.0`** (was `^1.29.0`).
+  This is the part of the fix that reaches you: `package-lock.json` is not
+  published, so an installed copy resolves from the declared ranges. SDK 1.29.0
+  pins `@hono/node-server: ^1.19.9`, a range with no non-vulnerable member — only
+  1.30.0 widens it to `^1.19.9 || ^2.0.5`. Raising the floor is what makes the
+  patched transport binding rather than incidental.
+
+### Internal
+
+- **CI now separates hermetic from non-hermetic checks.** `npm audit` ran inside
+  `build-and-test`, a required status check on both branches, but its verdict
+  depends on the GitHub Advisory DB rather than on the commit under test. When
+  the two transitive advisories landed, every branch went red at 11s — before
+  lint, build, or tests ran — and Dependabot, which bumps one direct dependency
+  per PR, could not clear a transitive advisory no matter how many PRs it opened.
+  `build-and-test` is now hermetic only. Scanning moved to a daily workflow that
+  maintains a single tracking issue, plus a `release-audit` gate on PRs into
+  `main` where a human is present to act on it.
+- The release runbook no longer claims this repo has no changelog.
+
+### Dependencies
+
+- `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0, `@hono/node-server` 1.19.14 →
+  2.0.12, `hono` 4.12.25 → 4.12.32, `fast-uri` 3.1.2 → 3.1.4, `postcss` 8.5.16 →
+  8.5.24, `body-parser` 2.2.2 → 2.3.0, plus `type-is`, `nanoid`, and a nested
+  `content-type` carried along by the re-resolution.
+
 ## v1.8.0 — 2026-07-05
 
 Post-1.7.0 audit-fix release: a fresh multi-agent source review (six dimensions,

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -145,21 +145,43 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    harder, not to wave through. Then still read the README top-to-bottom for
    anything the per-PR pass missed.
 
-4. **Write the release notes.** This repo has no `RELEASE_NOTES.md` /
-   `CHANGELOG.md`; the notes live in the **GitHub Release body** (step 8).
-   Draft them now while the change set is fresh — summarise in user-visible
-   terms and call out any compatibility notes (new required env var, changed
-   tool contract, dropped behaviour). If you'd rather have an in-repo
-   changelog, that's a separate decision — introduce it before, not during, a
-   release.
+4. **Write the release notes — into `CHANGELOG.md`, then reuse them.** Add a
+   `## vX.Y.Z — YYYY-MM-DD` section at the top of `CHANGELOG.md` following the
+   existing convention: a short prose paragraph summarising the release, then
+   `###` subsections (`Security`, `Behavior changes (read before upgrading)`,
+   `Fixed`, `Added`, `Internal`, `Dependencies` — only the ones that apply).
+   Draft it while the change set is fresh; summarise in user-visible terms and
+   call out compatibility notes (new required env var, changed tool contract,
+   dropped behaviour). The same text becomes the **GitHub Release body** in
+   step 8, so write it once here.
 
-5. **PR `release/vX.Y.Z` → `dev`.** Required check: `CI` (build + test +
-   `npm audit --audit-level=high`). Merge when green.
+   `CHANGELOG.md` is **not** covered by `npm run check:versions` — nothing
+   fails if you forget it. It's on you.
+
+5. **PR `release/vX.Y.Z` → `dev`.** Required check: `build-and-test` (version
+   sync + type check + build + test). Merge when green.
+
+   Note it does **not** include a dependency audit: `build-and-test` is
+   hermetic by contract, and `npm audit`'s verdict depends on the GitHub
+   Advisory DB rather than on the commit. Scanning happens in
+   `.github/workflows/audit.yml` (daily, files a tracking issue) and at the
+   release gate in step 6.
 
 6. **Open the release PR `dev` → `main`** titled `Release vX.Y.Z`, with a
    `Closes #N` line for **every issue** in the milestone — that list is what
    auto-closes them and lets the milestone close. `main` is protected, so
-   this PR is the only way in; merge it when CI is green.
+   this PR is the only way in; merge it when the checks are green.
+
+   Required checks here: `build-and-test`, `release-title`, and
+   **`release-audit`** — the last asserts no high/critical advisories in
+   production dependencies (`npm audit --omit=dev`). It is the one gate that
+   can go red with no diff, because a new advisory landed since the branch was
+   cut; that is deliberate and correct at this point — don't tag and publish a
+   known-vulnerable tree. To clear it, fix on `dev` with
+   `npm audit fix --package-lock-only`, re-run `npm ci && npm run lint &&
+   npm test`, land it, then update the release PR. If the advisory is
+   genuinely unreachable from shipped code, an admin can override
+   (`enforce_admins` is off) — record the reasoning in the PR.
 
 7. **Tag `vX.Y.Z` on `main`:**
    ```sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,9 +555,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2840,9 +2840,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.8.0.tgz",
-      "integrity": "sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2449,9 +2449,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.6.0.tgz",
-      "integrity": "sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
+      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -565,14 +565,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
-      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.10",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -586,8 +586,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.9",
-        "vitest": "4.1.9"
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -596,16 +596,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -614,13 +614,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.9",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -641,9 +641,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -654,13 +654,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -668,14 +668,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -684,9 +684,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -694,13 +694,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2561,19 +2561,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/runner": "4.1.9",
-        "@vitest/snapshot": "4.1.9",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2601,12 +2601,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.9",
-        "@vitest/browser-preview": "4.1.9",
-        "@vitest/browser-webdriverio": "4.1.9",
-        "@vitest/coverage-istanbul": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9",
-        "@vitest/ui": "4.1.9",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2810,9 +2810,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
-      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.8.0.tgz",
+      "integrity": "sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/node": "^26.1.0",
         "@vitest/coverage-v8": "^4.1.8",
-        "typescript": "^6.0.3",
+        "typescript": "^7.0.2",
         "vitest": "^4.1.8"
       },
       "engines": {
@@ -562,6 +562,346 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -2435,17 +2775,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "undici": "^8.5.0",
         "zod": "^4.4.3"
       },
@@ -121,12 +121,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -161,12 +161,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1117,21 +1117,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1492,9 +1505,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -1672,9 +1685,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2199,9 +2212,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2344,9 +2357,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -2364,7 +2377,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2761,17 +2774,34 @@
       "optional": true
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "homepage": "https://github.com/claymore666/ccu-mcp#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "undici": "^8.5.0",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/node": "^26.1.0",
     "@vitest/coverage-v8": "^4.1.8",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.8.0",
+  "version": "1.8.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Security patch release. Clears all six open dependency advisories — two high — and fixes the CI gate that had made them unfixable.

## Contents

| PR | |
|---|---|
| #106 | `ci`: split hermetic from non-hermetic checks |
| #108 | `fix(deps)`: clear all six advisories; raise the SDK floor to `^1.30.0` |
| #109 | `chore(release)`: v1.8.1 |

## Security

Two high (`fast-uri` via `sdk→ajv`, `postcss` via `vitest→vite`) and four moderate, all transitive. `npm audit` now reports 0 vulnerabilities.

The consumer-facing part is **`@modelcontextprotocol/sdk` floor raised `^1.29.0` → `^1.30.0`**. `package-lock.json` isn't published (`files` ships `dist/` alone), so an install resolves from declared ranges — and SDK 1.29.0 pins `@hono/node-server: ^1.19.9`, a range with no non-vulnerable member. Only 1.30.0 widens it to `^1.19.9 || ^2.0.5`.

`@hono/node-server` crosses a major (1.19.14 → 2.0.12) and is on the live HTTP path — the SDK's streamable-HTTP transport imports `getRequestListener` from it.

## CI change

`npm audit` ran inside `build-and-test`, a required check on both branches, but its verdict depends on the GitHub Advisory DB rather than the commit. When the two transitive advisories landed, every branch went red at 11s and Dependabot — one direct dep per PR — could not clear a transitive advisory. `build-and-test` is now hermetic only; scanning moved to a daily tracking-issue workflow plus the `release-audit` gate on this PR.

## Verification

- `npm ci && npm run lint && npm test` → 385 passed, 26 skipped, 0 failed
- HTTP mode smoke: `/health` 200, `initialize` returns session id + correct handshake over SSE
- **Live prod CCU** over stdio on the built v1.8.1 artifact: 28 tools, `get_system_info` and `list_devices` return real data (read-only tools only)
- `npm publish --dry-run` clean; `mcp-publisher validate` ✅
- `audit.yml` verified end-to-end: filed issue #107 while dev was vulnerable, then commented and auto-closed it once fixed

## Note

`release-audit` runs here for the first time. Once it has reported, add it to `main`'s branch protection as a required check — GitHub only offers checks it has already seen.