### PR TITLE
docs: record the undici bump and the release-PR approval step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ changes; no behavior changes.
   2.0.12, `hono` 4.12.25 → 4.12.32, `fast-uri` 3.1.2 → 3.1.4, `postcss` 8.5.16 →
   8.5.24, `body-parser` 2.2.2 → 2.3.0, plus `type-is`, `nanoid`, and a nested
   `content-type` carried along by the re-resolution.
+- `undici` 8.8.0 → 8.9.0 (#104) — a routine Dependabot bump, no advisory.
 
 ## v1.8.0 — 2026-07-05
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -172,6 +172,18 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    auto-closes them and lets the milestone close. `main` is protected, so
    this PR is the only way in; merge it when the checks are green.
 
+   **The workflow runs on this PR may sit at `action_required`** — GitHub
+   holds the `pull_request` runs on the merge ref pending approval, and the
+   PR stays `BLOCKED` with the required checks simply never reporting. It
+   looks like a broken gate; it is just an unapproved run. Approve both:
+   ```sh
+   gh run list --limit 6 --json databaseId,workflowName,conclusion \
+     --jq '.[] | select(.conclusion=="action_required") | .databaseId'
+   # then, per id:
+   gh api -X POST repos/claymore666/ccu-mcp/actions/runs/<id>/approve
+   ```
+   They re-queue immediately and report normally.
+
    Required checks here: `build-and-test`, `release-title`, and
    **`release-audit`** — the last asserts no high/critical advisories in
    production dependencies (`npm audit --omit=dev`). It is the one gate that


### PR DESCRIPTION
Dependabot's #104 (`undici` 8.8.0 → 8.9.0) auto-merged into `dev` while the v1.8.1 changelog entry was being written, so it shipped in the release but is missing from that entry's Dependencies list.

No advisory involved — a routine version bump — but the entry should account for everything in the tag. Documentation only; no code change.