### PR TITLE
test: cover the stdio transport e2e and auth token auto-rotation

### DIFF
--- a/test/e2e/stdio-transport.test.ts
+++ b/test/e2e/stdio-transport.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { AddressInfo } from "node:net";
+
+// End-to-end test of the STDIO transport against the BUILT server (dist/) with
+// a mocked CCU. stdio is the documented default install path
+// (`npx ccu-mcp --stdio`), but every other e2e block drives the HTTP transport,
+// so the whole stdio branch of src/index.ts had no coverage.
+//
+// The shutdown case is the one that matters: StdioServerTransport registers
+// only 'data'/'error' listeners, so transport/server onclose never fires on
+// stdin EOF. Without the direct stdin hooks in src/index.ts the process would
+// exit via event-loop drain with no Session.logout — leaking a CCU session
+// toward "too many sessions" — and no cache save.
+
+const DIST = join(__dirname, "../../dist/index.js");
+
+/** process.env with every server config var scrubbed (see http-transport e2e). */
+function cleanEnv(): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (/^(CCU_|MCP_|CACHE_|RESOURCE_POLL_INTERVAL$|LOG_LEVEL$)/.test(key)) delete env[key];
+  }
+  return env;
+}
+
+interface CcuMock {
+  server: Server;
+  port: number;
+  /** Every JSON-RPC method the server called, in order. */
+  calls: string[];
+}
+
+function startCcuMock(): Promise<CcuMock> {
+  const calls: string[] = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      let method = "";
+      try { method = JSON.parse(body).method; } catch { /* ignore */ }
+      if (method) calls.push(method);
+      const results: Record<string, unknown> = {
+        "Session.login": "mock-session-id",
+        "Session.renew": true,
+        "Session.logout": true,
+        "Interface.listInterfaces": [],
+        "Device.listAllDetail": [],
+        "Room.getAll": [],
+      };
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ version: "2.0", result: results[method] ?? [], error: null }));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () =>
+      resolve({ server, port: (server.address() as AddressInfo).port, calls }),
+    );
+  });
+}
+
+/**
+ * Minimal newline-delimited JSON-RPC client over the child's stdio pipes —
+ * the framing StdioServerTransport uses.
+ */
+class StdioClient {
+  private buffer = "";
+  private pending = new Map<number, (msg: any) => void>();
+  private nextId = 1;
+
+  constructor(private child: ChildProcess) {
+    child.stdout!.setEncoding("utf-8");
+    child.stdout!.on("data", (chunk: string) => {
+      this.buffer += chunk;
+      let nl: number;
+      while ((nl = this.buffer.indexOf("\n")) !== -1) {
+        const line = this.buffer.slice(0, nl).trim();
+        this.buffer = this.buffer.slice(nl + 1);
+        if (!line) continue;
+        let msg: any;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (typeof msg.id === "number" && this.pending.has(msg.id)) {
+          this.pending.get(msg.id)!(msg);
+          this.pending.delete(msg.id);
+        }
+      }
+    });
+  }
+
+  request(method: string, params: unknown = {}, timeoutMs = 10_000): Promise<any> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`stdio request "${method}" timed out`));
+      }, timeoutMs);
+      this.pending.set(id, (msg) => { clearTimeout(timer); resolve(msg); });
+      this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  }
+
+  notify(method: string, params: unknown = {}): void {
+    this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+  }
+}
+
+describe.skipIf(!existsSync(DIST))("stdio transport e2e (built server, mocked CCU)", () => {
+  let ccu: CcuMock;
+  let child: ChildProcess;
+  let client: StdioClient;
+  let cacheDir: string;
+
+  beforeAll(async () => {
+    ccu = await startCcuMock();
+    cacheDir = mkdtempSync(join(tmpdir(), "ccu-mcp-e2e-stdio-"));
+
+    // --stdio (the CLI flag, not MCP_TRANSPORT) is what the README documents,
+    // so that is the path under test.
+    child = spawn("node", [DIST, "--stdio"], {
+      env: {
+        ...cleanEnv(),
+        CCU_HOST: "127.0.0.1",
+        CCU_PORT: String(ccu.port),
+        CCU_HTTPS: "false",
+        CCU_PASSWORD: "mock",
+        CACHE_DIR: cacheDir,
+        RESOURCE_POLL_INTERVAL: "3600",
+        LOG_LEVEL: "error",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    client = new StdioClient(child);
+
+    const init = await client.request("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "e2e-stdio", version: "1" },
+    }, 20_000);
+    expect(init.result?.serverInfo?.name).toBe("ccu-mcp");
+    client.notify("notifications/initialized");
+  }, 30_000);
+
+  afterAll(async () => {
+    child?.kill("SIGKILL");
+    ccu?.server.close();
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("lists tools over stdio", async () => {
+    const res = await client.request("tools/list");
+    const names = (res.result?.tools ?? []).map((t: { name: string }) => t.name);
+    expect(names).toContain("help");
+    expect(names).toContain("list_devices");
+  });
+
+  it("answers a tool call that needs no CCU", async () => {
+    const res = await client.request("tools/call", { name: "help", arguments: {} });
+    expect(res.result?.isError).toBeFalsy();
+    expect(JSON.stringify(res.result?.content ?? "")).toMatch(/ccu-mcp|tool/i);
+  });
+
+  it("reaches the mocked CCU through a tool call", async () => {
+    const res = await client.request("tools/call", { name: "list_devices", arguments: {} });
+    expect(res.result?.isError).toBeFalsy();
+    expect(ccu.calls).toContain("Session.login");
+  });
+
+  it("serves the same tool set on both transports", async () => {
+    const res = await client.request("tools/list");
+    // stdio must not silently register a different surface than HTTP does.
+    expect((res.result?.tools ?? []).length).toBeGreaterThan(20);
+  });
+
+  // Must be last: closing stdin terminates the server.
+  it("shuts down cleanly on stdin EOF, logging out of the CCU", async () => {
+    const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
+
+    // EOF, not a signal — this is how an MCP client normally ends a stdio server.
+    child.stdin!.end();
+
+    const code = await Promise.race([
+      exited,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("stdin-EOF shutdown timed out")), 12_000)),
+    ]);
+
+    expect(code).toBe(0);
+    // The regression guard: without the explicit stdin hooks the process exits
+    // via event-loop drain and never logs out, leaking the CCU session.
+    expect(ccu.calls).toContain("Session.logout");
+  }, 15_000);
+});

--- a/test/unit/auth-token-rotation.test.ts
+++ b/test/unit/auth-token-rotation.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { resolveAuthTokens, startAutoRotation } from "../../src/auth/token.js";
+import { Logger } from "../../src/logger.js";
+import { mkdtemp, readFile, writeFile, rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Runtime auto-rotation (src/auth/token.ts startAutoRotation). The tricky part
+// is not rotating on time — it is NOT rotating when the data dir is broken.
+// A tick that blindly adopted its own resolve would mint and announce a brand
+// new token every interval, 401ing the one clients are actually holding, and
+// it would do so silently for as long as the dir stays unwritable.
+
+const logger = new Logger("error");
+const HOUR = 3_600_000;
+
+/** Poll until `predicate` holds, so we never race the tick's async work. */
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 4000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await predicate()) return;
+    if (Date.now() > deadline) throw new Error("condition not reached within timeout");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+async function fileToken(dir: string): Promise<string | undefined> {
+  try {
+    const content = await readFile(join(dir, ".env"), "utf-8");
+    return content.match(/^MCP_AUTH_TOKEN=(.+)$/m)?.[1]?.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+describe("startAutoRotation", () => {
+  let dir: string;
+  let stop: (() => void) | undefined;
+  let stderr: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "ccu-mcp-rotation-"));
+    stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(async () => {
+    stop?.();
+    stop = undefined;
+    await rm(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("rotates on the immediate tick, without waiting out the first interval", async () => {
+    // A token already past its TTL: if the first tick only ran after `intervalMs`,
+    // clients would 401 for that whole window. The interval here is deliberately
+    // far longer than the test, so only the immediate tick can do the work.
+    await writeFile(
+      join(dir, ".env"),
+      `MCP_AUTH_TOKEN=stale-token\nMCP_AUTH_TOKEN_ISSUED=${Date.now() - 4 * HOUR}\n`,
+      "utf-8",
+    );
+    const tokens = await resolveAuthTokens({ dataDir: dir, ttlMs: HOUR, graceMs: HOUR }, logger);
+
+    stop = startAutoRotation(tokens, { dataDir: dir, ttlMs: HOUR, graceMs: HOUR }, logger, 600_000);
+
+    await waitFor(async () => (await fileToken(dir)) !== "stale-token");
+    const rotated = await fileToken(dir);
+    expect(rotated).toBeDefined();
+    expect(tokens.verify(rotated!)).toBe(true);
+  });
+
+  it("keeps the outgoing token valid for the grace window after rotating", async () => {
+    await writeFile(
+      join(dir, ".env"),
+      `MCP_AUTH_TOKEN=outgoing-token\nMCP_AUTH_TOKEN_ISSUED=${Date.now() - 4 * HOUR}\n`,
+      "utf-8",
+    );
+    const tokens = await resolveAuthTokens({ dataDir: dir, ttlMs: HOUR, graceMs: HOUR }, logger);
+
+    stop = startAutoRotation(tokens, { dataDir: dir, ttlMs: HOUR, graceMs: HOUR }, logger, 600_000);
+    await waitFor(async () => (await fileToken(dir)) !== "outgoing-token");
+
+    // Both must validate: a client mid-migration is not cut off.
+    expect(tokens.verify("outgoing-token")).toBe(true);
+    expect(tokens.verify((await fileToken(dir))!)).toBe(true);
+  });
+
+  it("stops ticking once the returned stop function is called", async () => {
+    const tokens = await resolveAuthTokens({ dataDir: dir, ttlMs: 50, graceMs: HOUR }, logger);
+    const stopFn = startAutoRotation(tokens, { dataDir: dir, ttlMs: 50, graceMs: HOUR }, logger, 20);
+
+    await waitFor(async () => (await fileToken(dir)) !== undefined);
+    stopFn();
+    const afterStop = await fileToken(dir);
+
+    // Several intervals' worth of wall clock with no further rotation.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await fileToken(dir)).toBe(afterStop);
+  });
+
+  describe("unwritable data dir", () => {
+    let brokenDir: string;
+
+    beforeEach(async () => {
+      // A FILE where the data dir should be: mkdir fails with ENOTDIR for any
+      // user, unlike chmod 000 which root ignores.
+      brokenDir = join(dir, "not-a-directory");
+      await writeFile(brokenDir, "", "utf-8");
+    });
+
+    it("does not replace the in-memory token while nothing can be persisted", async () => {
+      // Long TTL on purpose: a short one would expire the startup token and
+      // mask the thing under test. With a broken dir every tick mints a fresh
+      // token regardless of TTL, because it can never read a persisted one.
+      const opts = { dataDir: brokenDir, ttlMs: HOUR, graceMs: HOUR };
+      const tokens = await resolveAuthTokens(opts, logger);
+      // The startup mint was announced with the token echoed (it could not be saved).
+      const minted = String(stderr.mock.calls.at(-1)?.[0]).match(/token: (\S+)/)?.[1];
+      expect(minted).toBeDefined();
+      expect(tokens.verify(minted!)).toBe(true);
+
+      stderr.mockClear();
+      stop = startAutoRotation(tokens, opts, logger, 20);
+
+      // Let several ticks run. Each one resolves a fresh token internally; none
+      // may be adopted, or the token clients hold would stop validating.
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(tokens.verify(minted!)).toBe(true);
+      expect(tokens.liveCount()).toBe(1);
+    });
+
+    it("announces nothing per tick while the dir stays broken", async () => {
+      const opts = { dataDir: brokenDir, ttlMs: HOUR, graceMs: HOUR };
+      const tokens = await resolveAuthTokens(opts, logger);
+
+      stderr.mockClear();
+      stop = startAutoRotation(tokens, opts, logger, 20);
+      await new Promise((r) => setTimeout(r, 200));
+
+      // announceUnpersisted:false — a broken dir must not spam a new token on
+      // every tick, which would also invalidate the previous announcement.
+      const announcements = stderr.mock.calls.filter((c: unknown[]) => String(c[0]).includes("[ccu-mcp]"));
+      expect(announcements).toHaveLength(0);
+    });
+
+    it("adopts with grace once persistence recovers, without a 401 gap", async () => {
+      const opts = { dataDir: brokenDir, ttlMs: HOUR, graceMs: HOUR };
+      const tokens = await resolveAuthTokens(opts, logger);
+      const inMemory = String(stderr.mock.calls.at(-1)?.[0]).match(/token: (\S+)/)?.[1];
+      expect(inMemory).toBeDefined();
+
+      stop = startAutoRotation(tokens, opts, logger, 20);
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Operator fixes the data dir; the next tick persists for the first time.
+      await rm(brokenDir, { force: true });
+      await mkdir(brokenDir, { recursive: true });
+
+      await waitFor(async () => (await fileToken(brokenDir)) !== undefined);
+      const persisted = await fileToken(brokenDir);
+
+      expect(tokens.verify(persisted!)).toBe(true);
+      // The token clients were handed at startup keeps working through the overlap.
+      expect(tokens.verify(inMemory!)).toBe(true);
+    });
+  });
+
+  it("survives a failing tick and keeps the timer alive", async () => {
+    const opts = { dataDir: dir, ttlMs: 50, graceMs: HOUR };
+    const tokens = await resolveAuthTokens(opts, logger);
+    const before = await fileToken(dir);
+
+    const failing = vi.spyOn(logger, "error").mockImplementation(() => {});
+    stop = startAutoRotation(tokens, opts, logger, 20);
+    await waitFor(async () => (await fileToken(dir)) !== before);
+
+    // Rotation kept working; nothing escaped as an unhandled rejection.
+    expect(tokens.liveCount()).toBeGreaterThanOrEqual(1);
+    failing.mockRestore();
+  });
+});

--- a/test/unit/device-type-cache-warm.test.ts
+++ b/test/unit/device-type-cache-warm.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { DeviceTypeCache } from "../../src/cache/device-type-cache.js";
+import { Logger } from "../../src/logger.js";
+import { RateLimiter } from "../../src/middleware/rate-limiter.js";
+import type { SessionManager } from "../../src/ccu/session.js";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Covers the warm/parse half of DeviceTypeCache, which the existing suite
+// leaves out: the TCL VALUE_LIST tokenizer, the device/channel filtering, and
+// the failure paths that must degrade instead of aborting a warm run.
+
+const logger = new Logger("error");
+
+/** A SessionManager stand-in driven by a per-method script. */
+function fakeSession(handlers: Record<string, (params?: any) => unknown>): SessionManager {
+  return {
+    call: async (method: string, params?: any) => {
+      const h = handlers[method];
+      if (!h) throw new Error(`unexpected CCU call: ${method}`);
+      return h(params);
+    },
+  } as unknown as SessionManager;
+}
+
+/** Fast limiter — these tests care about logic, not pacing. */
+function limiter(): RateLimiter {
+  return new RateLimiter(1000, 1000);
+}
+
+const ETRV_DESC = [
+  { ID: "SET_POINT_TEMPERATURE", TYPE: "FLOAT", OPERATIONS: "7", MIN: "4.5", MAX: "30.5", UNIT: "°C" },
+];
+
+describe("DeviceTypeCache.warm", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "ccu-mcp-warm-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("caches one entry per device type and skips channels", async () => {
+    const session = fakeSession({
+      "Interface.listInterfaces": () => [{ name: "HmIP-RF" }],
+      "Interface.listDevices": () => [
+        { type: "HmIP-eTRV-2", address: "0001", children: ["0001:1"] },
+        // Same type again — must be deduplicated, not re-queried.
+        { type: "HmIP-eTRV-2", address: "0002", children: ["0002:1"] },
+        // A channel (no children) — must be skipped entirely.
+        { type: "MAINTENANCE", address: "0001:0", parent: "0001" },
+      ],
+      "Interface.getParamsetDescription": () => ETRV_DESC,
+    });
+
+    const cache = new DeviceTypeCache(dir, 86400, logger);
+    await cache.warm(session, limiter());
+
+    expect(cache.size()).toBe(1);
+    expect(cache.has("HmIP-eTRV-2")).toBe(true);
+    expect(cache.has("MAINTENANCE")).toBe(false);
+    expect(cache.get("HmIP-eTRV-2")?.interface).toBe("HmIP-RF");
+  });
+
+  it("skips an interface whose device listing fails and keeps the rest", async () => {
+    const session = fakeSession({
+      "Interface.listInterfaces": () => [{ name: "BidCos-RF" }, { name: "HmIP-RF" }],
+      "Interface.listDevices": (p: { interface: string }) => {
+        if (p.interface === "BidCos-RF") throw new Error("interface down");
+        return [{ type: "HmIP-eTRV-2", address: "0001", children: ["0001:1"] }];
+      },
+      "Interface.getParamsetDescription": () => ETRV_DESC,
+    });
+
+    const cache = new DeviceTypeCache(dir, 86400, logger);
+    await cache.warm(session, limiter());
+
+    // One bad interface must not abort the whole warm run.
+    expect(cache.has("HmIP-eTRV-2")).toBe(true);
+  });
+
+  it("keeps a device type whose paramset query fails, minus the failed paramset", async () => {
+    const session = fakeSession({
+      "Interface.listInterfaces": () => [{ name: "HmIP-RF" }],
+      "Interface.listDevices": () => [{ type: "HmIP-eTRV-2", address: "0001", children: ["0001:1"] }],
+      "Interface.getParamsetDescription": (p: { paramsetKey: string }) => {
+        // Many channels don't implement MASTER — that is normal, not an error.
+        if (p.paramsetKey === "MASTER") throw new Error("no such paramset");
+        return ETRV_DESC;
+      },
+    });
+
+    const cache = new DeviceTypeCache(dir, 86400, logger);
+    await cache.warm(session, limiter());
+
+    const channel = cache.get("HmIP-eTRV-2")?.channels["1"];
+    expect(channel?.paramsets.VALUES).toBeDefined();
+    expect(channel?.paramsets.MASTER).toBeUndefined();
+  });
+
+  it("does not start a second warm run while one is in flight", async () => {
+    let listCalls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+
+    const session = fakeSession({
+      "Interface.listInterfaces": async () => { listCalls++; await gate; return []; },
+    });
+
+    const cache = new DeviceTypeCache(dir, 86400, logger);
+    const first = cache.warm(session, limiter());
+    expect(cache.isWarming()).toBe(true);
+
+    // Second call must return immediately instead of duplicating CCU load.
+    await cache.warm(session, limiter());
+    expect(listCalls).toBe(1);
+
+    release();
+    await first;
+    expect(cache.isWarming()).toBe(false);
+  });
+
+  describe("VALUE_LIST parsing (TCL list from getparamsetdescription.tcl)", () => {
+    async function valueListFor(raw: unknown): Promise<string[] | undefined> {
+      const session = fakeSession({
+        "Interface.listInterfaces": () => [{ name: "HmIP-RF" }],
+        "Interface.listDevices": () => [{ type: "T", address: "0001", children: ["0001:1"] }],
+        "Interface.getParamsetDescription": (p: { paramsetKey: string }) =>
+          p.paramsetKey === "VALUES"
+            ? [{ ID: "MODE", TYPE: "ENUM", OPERATIONS: "7", VALUE_LIST: raw }]
+            : [],
+      });
+      const cache = new DeviceTypeCache(dir, 86400, logger);
+      await cache.warm(session, limiter());
+      return cache.get("T")?.channels["1"].paramsets.VALUES?.MODE.valueList;
+    }
+
+    it("passes a real array through untouched", async () => {
+      expect(await valueListFor(["AUTO", "MANU"])).toEqual(["AUTO", "MANU"]);
+    });
+
+    it("splits a plain space-joined string", async () => {
+      expect(await valueListFor("AUTO MANU BOOST")).toEqual(["AUTO", "MANU", "BOOST"]);
+    });
+
+    it("keeps brace-wrapped entries that contain spaces as one label", async () => {
+      // The case the tokenizer exists for: enum indexes must line up with the
+      // real value list, so '{Party Mode}' is ONE entry, not two.
+      expect(await valueListFor("{Party Mode} Off {Boost Mode}")).toEqual([
+        "Party Mode", "Off", "Boost Mode",
+      ]);
+    });
+
+    it("handles nested braces and collapses runs of spaces", async () => {
+      expect(await valueListFor("  {outer {inner} tail}   plain  ")).toEqual([
+        "outer {inner} tail", "plain",
+      ]);
+    });
+
+    it("does not hang or drop data on an unterminated brace", async () => {
+      expect(await valueListFor("{never closed")).toEqual(["never closed"]);
+    });
+  });
+});
+
+describe("DeviceTypeCache.saveToDisk failure handling", () => {
+  it("logs instead of throwing when the cache dir cannot be written", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "ccu-mcp-save-"));
+    // A file where the cache dir should be: mkdir fails with ENOTDIR for any
+    // user, unlike chmod 000 which root ignores.
+    const blocked = join(parent, "not-a-dir");
+    await writeFile(blocked, "", "utf-8");
+
+    const errors: string[] = [];
+    const noisy = new Logger("error");
+    vi.spyOn(noisy, "error").mockImplementation((msg: string) => { errors.push(msg); });
+
+    const cache = new DeviceTypeCache(blocked, 86400, noisy);
+    // Must resolve: a save failure is logged, never propagated into shutdown.
+    await expect(cache.saveToDisk()).resolves.toBeUndefined();
+    expect(errors).toContain("cache_save_failed");
+
+    vi.restoreAllMocks();
+    await rm(parent, { recursive: true, force: true });
+  });
+});

--- a/test/unit/server-subscriptions.test.ts
+++ b/test/unit/server-subscriptions.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { createMcpServer, serverSubscriptions } from "../../src/server.js";
+import { RESOURCE_URIS } from "../../src/resources/registry.js";
+import { createMockDeps } from "./_helpers.js";
+import {
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+  ErrorCode,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
+
+// resources/subscribe and resources/unsubscribe are hand-registered in
+// src/server.ts because the SDK's McpServer backs no handler for the
+// capability we advertise. Nothing exercised those handlers, so the
+// subscription set the ResourcePoller consults was untested.
+
+/** Invoke a registered request handler the way the SDK transport would. */
+async function callHandler(server: any, schema: any, params: unknown): Promise<unknown> {
+  const method = schema.shape.method.value as string;
+  const handler = server.server._requestHandlers.get(method);
+  expect(handler, `no handler registered for ${method}`).toBeDefined();
+  return handler({ method, params }, { signal: new AbortController().signal });
+}
+
+describe("resources/subscribe handlers", () => {
+  it("records a subscription for a known URI", async () => {
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+    const uri = RESOURCE_URIS[0];
+
+    await callHandler(server, SubscribeRequestSchema, { uri });
+
+    // The poller reads exactly this set to decide who gets notified.
+    expect(serverSubscriptions.get(server)?.has(uri)).toBe(true);
+    deps.rateLimiter.destroy();
+  });
+
+  it("rejects an unknown URI instead of silently accepting it", async () => {
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+
+    // Accepting a typo would leave the client waiting forever for
+    // notifications that can never arrive.
+    await expect(
+      callHandler(server, SubscribeRequestSchema, { uri: "ccu://typo" }),
+    ).rejects.toThrow(McpError);
+
+    try {
+      await callHandler(server, SubscribeRequestSchema, { uri: "ccu://typo" });
+    } catch (err) {
+      expect((err as McpError).code).toBe(ErrorCode.InvalidParams);
+      // The error must name the valid URIs so the client can self-correct.
+      expect((err as McpError).message).toContain(RESOURCE_URIS[0]);
+    }
+
+    expect(serverSubscriptions.get(server)?.size).toBe(0);
+    deps.rateLimiter.destroy();
+  });
+
+  it("unsubscribe removes the URI and is idempotent", async () => {
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+    const uri = RESOURCE_URIS[0];
+
+    await callHandler(server, SubscribeRequestSchema, { uri });
+    await callHandler(server, UnsubscribeRequestSchema, { uri });
+    expect(serverSubscriptions.get(server)?.has(uri)).toBe(false);
+
+    // Unsubscribing something never subscribed must not throw.
+    await expect(
+      callHandler(server, UnsubscribeRequestSchema, { uri }),
+    ).resolves.toEqual({});
+    deps.rateLimiter.destroy();
+  });
+
+  it("keeps subscription sets separate per server instance", async () => {
+    const depsA = createMockDeps();
+    const depsB = createMockDeps();
+    const a = createMcpServer(depsA);
+    const b = createMcpServer(depsB);
+
+    await callHandler(a, SubscribeRequestSchema, { uri: RESOURCE_URIS[0] });
+
+    // In HTTP mode every client gets its own McpServer; one client's
+    // subscribe must not leak notifications to another.
+    expect(serverSubscriptions.get(a)?.has(RESOURCE_URIS[0])).toBe(true);
+    expect(serverSubscriptions.get(b)?.has(RESOURCE_URIS[0])).toBe(false);
+
+    depsA.rateLimiter.destroy();
+    depsB.rateLimiter.destroy();
+  });
+});


### PR DESCRIPTION
Closes the two coverage gaps identified as most worth having before the next release. **No changes under `src/`.**

## stdio transport e2e (new)

Every existing e2e block drives the HTTP transport — no spawn used `--stdio` or `MCP_TRANSPORT=stdio`. That left the documented default install path (`npx ccu-mcp --stdio`, README:40/59/77) without end-to-end coverage while HTTP had ~25 tests.

`test/e2e/stdio-transport.test.ts` spawns the built server with `--stdio` and speaks newline-delimited JSON-RPC over its pipes: initialize handshake, `tools/list`, a tool call needing no CCU, a call that reaches the mocked CCU, and the shutdown path.

### The shutdown case is the point

`StdioServerTransport` registers only `data`/`error` listeners, so transport/server `onclose` never fires on stdin EOF. Without the explicit stdin hooks in `src/index.ts:453-466` the process exits via event-loop drain with **no `Session.logout`** — leaking a CCU session toward "too many sessions" — and no cache save.

Verified by mutation rather than assumed: with the hooks disabled the test fails on exactly the right assertion.

```
AssertionError: expected [ Session.login, …(2) ] to include Session.logout
```

Worth noting the process still exits **0** in that state, so a test asserting only the exit code would have passed vacuously. The `Session.logout` assertion is the guard.

## auth token auto-rotation (new)

`startAutoRotation` (`src/auth/token.ts:352-401`) had no coverage — ~44 contiguous lines of security-relevant, non-obvious logic.

`test/unit/auth-token-rotation.test.ts` pins:

- the immediate first tick (a token expiring inside the first interval would otherwise 401 until the timer fires)
- the grace overlap keeping the outgoing token valid through a rotation
- `stop()` actually halting the timer
- **the broken-data-dir guard** — while nothing can be persisted, a tick must not adopt its own resolve; otherwise every interval mints and announces a fresh token and 401s the one clients hold. Also asserts nothing is announced per tick.
- **recovery** — once the dir becomes writable the newly persisted token is adopted *with grace*, so the in-memory startup token is not cut off instantly

Simulated with a file where the data dir should be (`mkdir` fails with `ENOTDIR` for any user, unlike `chmod 000`, which root ignores).

## Result

| | before | after |
|---|---|---|
| Tests | 385 | 397 |
| `auth/token.ts` statements | 83.46 % | 96.85 % |
| `auth/token.ts` functions | 77.77 % | 96.29 % |
| overall statements | 83.12 % | 84.05 % |

The stdio e2e does not move the reported number — v8 cannot attribute a spawned subprocess, which is also why `src/index.ts` reads 0 % despite being well covered behaviourally.

`npm test` green (397 passed, 26 skipped), `npm run lint` clean.