### PR TITLE
chore: ignore local drafts of upstream OCCU issue reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ coverage/
 
 # Local review reports
 code-review-report.md
+
+# Drafts of upstream (OCCU/OpenCCU) issue reports — written here, filed there
+occu-issue-*.md


### PR DESCRIPTION
`occu-issue-draft.md` and `occu-issue-eq3loop-draft.md` are drafts of issues filed against OCCU/OpenCCU — not project docs. They were untracked *and* unignored, so they appeared as `??` noise in every `git status`.

Ignored via `occu-issue-*.md`, alongside the other local-only docs (`CLAUDE.md`, `QA-FINDINGS.md`, `code-review-report.md`).

Verified: the pattern matches both files and nothing else — no tracked file matches it (`git ls-files 'occu-issue*'` is empty), and `README.md` / `CHANGELOG.md` / `docs/release-runbook.md` remain unignored.