### PR TITLE
feat(cli): support --version and --help without a configured CCU

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,31 @@ All configuration is via environment variables:
 | `CCU_RATE_LIMIT_RATE` | `10` | Sustained CCU requests per second |
 | `RESOURCE_POLL_INTERVAL` | `60` | Seconds between polls for MCP resource change notifications |
 
+To drive **several CCUs** from one server, these flat `CCU_*` vars are replaced
+by named profiles — see [Multiple CCU targets](#multiple-ccu-targets-profiles)
+below.
+
+### Command-line flags
+
+```sh
+ccu-mcp --stdio        # serve over stdin/stdout (overrides MCP_TRANSPORT)
+ccu-mcp --http         # serve over HTTP (default)
+ccu-mcp --version      # print the installed version and exit
+ccu-mcp --help         # print usage and exit
+```
+
+`--version` and `--help` need no configuration — use them to check what an
+installed copy actually is, e.g. after updating:
+
+```console
+$ npx ccu-mcp@latest --version
+1.8.1
+```
+
+Note that a bare `npx ccu-mcp` reuses the copy cached in `~/.npm/_npx` without
+re-resolving against the registry; pin `@latest` (or clear that cache) when you
+want the newest release.
+
 ### How to supply these (inline, `.env`, or export)
 
 The required `CCU_HOST` / `CCU_PASSWORD` (and everything else) are **environment

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,68 @@ import { ResourcePoller } from "./resources/poller.js";
 import { resolveAuthTokens, startAutoRotation } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
 import { createMcpServer, serverSubscriptions, type ServerDeps } from "./server.js";
-import { extractBearerToken, normalizeClientIp } from "./utils.js";
+import { extractBearerToken, normalizeClientIp, VERSION, loadBuildInfo } from "./utils.js";
+
+const USAGE = `ccu-mcp — MCP server for a HomeMatic CCU (debmatic, CCU3, OpenCCU/RaspberryMatic)
+
+Usage:
+  ccu-mcp [--stdio | --http]
+  ccu-mcp --version
+  ccu-mcp --help
+
+Options:
+  --stdio          Serve MCP over stdin/stdout (overrides MCP_TRANSPORT)
+  --http           Serve MCP over HTTP (default)
+  -v, --version    Print the version and exit
+  -h, --help       Print this help and exit
+
+Required environment:
+  CCU_HOST         Hostname or IP of the CCU
+  CCU_PASSWORD     Password for CCU_USER
+
+Common environment:
+  CCU_USER         CCU username (default: Admin)
+  CCU_PORT         API port (default: 80, or 443 with CCU_HTTPS=true)
+  CCU_HTTPS        Connect over HTTPS (default: false)
+  MCP_TRANSPORT    "http" or "stdio" (default: http)
+  MCP_PORT         HTTP listener port (default: 3000)
+  CACHE_DIR        Cache, session and generated token (default: /data)
+  LOG_LEVEL        error | warn | info | debug (default: info)
+
+Multiple CCUs, TLS pinning, auth-token rotation and the full variable list:
+https://github.com/claymore666/ccu-mcp#configuration`;
+
+/**
+ * Handle the flags that must work with NO environment at all (issue #112).
+ *
+ * Deliberately runs before createLogger()/loadConfig(): asking an installed
+ * copy "which version are you?" must not require a reachable CCU, and
+ * loadConfig() throws on a missing CCU_HOST. Returns true when the process
+ * should exit without starting a server.
+ */
+function handleInfoFlags(argv: string[]): boolean {
+  if (argv.includes("--version") || argv.includes("-v")) {
+    const { describe, commit, dirty } = loadBuildInfo();
+    // Prefer the git describe stamped at build time; fall back to the bare
+    // version for an npm install, which carries no build-info.json.
+    const stamp = describe ?? commit;
+    // `git describe --dirty` already carries the marker; the commit fallback
+    // does not. Appending unconditionally would print "...-dirty-dirty".
+    const dirtyMark = stamp && dirty && !stamp.endsWith("-dirty") ? "-dirty" : "";
+    process.stdout.write(`${VERSION}${stamp ? ` (${stamp}${dirtyMark})` : ""}\n`);
+    return true;
+  }
+  if (argv.includes("--help") || argv.includes("-h")) {
+    // stdout, not stderr, so `ccu-mcp --help | less` works.
+    process.stdout.write(`${USAGE}\n`);
+    return true;
+  }
+  return false;
+}
 
 async function main(): Promise<void> {
+  if (handleInfoFlags(process.argv.slice(2))) return;
+
   const logger = createLogger();
   const config = loadConfig();
 

--- a/test/e2e/cli-flags.test.ts
+++ b/test/e2e/cli-flags.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Issue #112: --version and --help must work with NO environment at all.
+// main() used to call loadConfig() before looking at argv, so both flags died
+// with "CCU_HOST environment variable is required" — leaving no way to ask an
+// installed copy which version it is without a configured, reachable CCU.
+//
+// Running with a scrubbed env is the whole point of these tests: the bug was
+// precisely that these paths depended on the environment.
+
+const DIST = join(__dirname, "../../dist/index.js");
+const PKG_VERSION = JSON.parse(
+  readFileSync(join(__dirname, "../../package.json"), "utf-8"),
+) as { version: string };
+
+/** Run the built CLI with an empty environment (plus the PATH node needs). */
+function runBare(...args: string[]) {
+  return spawnSync(process.execPath, [DIST, ...args], {
+    env: { PATH: process.env.PATH ?? "" },
+    encoding: "utf-8",
+    timeout: 20_000,
+  });
+}
+
+describe.skipIf(!existsSync(DIST))("CLI info flags (no environment)", () => {
+  it("--version prints the package version and exits 0", () => {
+    const res = runBare("--version");
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim().split(/\s/)[0]).toBe(PKG_VERSION.version);
+    expect(res.stderr).toBe("");
+  });
+
+  it("-v is accepted as the short form", () => {
+    const res = runBare("-v");
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim().split(/\s/)[0]).toBe(PKG_VERSION.version);
+  });
+
+  it("never prints a doubled dirty marker", () => {
+    // `git describe --dirty` already carries the suffix; the commit fallback
+    // does not. Appending unconditionally produced "...-dirty-dirty".
+    expect(runBare("--version").stdout).not.toMatch(/-dirty-dirty/);
+  });
+
+  it("--help prints usage on stdout and exits 0", () => {
+    const res = runBare("--help");
+    expect(res.status).toBe(0);
+    // stdout, not stderr, so `ccu-mcp --help | less` works.
+    expect(res.stderr).toBe("");
+    expect(res.stdout).toContain("Usage:");
+    expect(res.stdout).toContain("--stdio");
+    expect(res.stdout).toContain("CCU_HOST");
+  });
+
+  it("-h is accepted as the short form", () => {
+    const res = runBare("-h");
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("Usage:");
+  });
+
+  it("neither flag trips config loading", () => {
+    // The regression itself. Asserting on the error text, not on "CCU_HOST" —
+    // the help output documents that variable on purpose.
+    for (const flag of ["--version", "--help"]) {
+      const res = runBare(flag);
+      const output = `${res.stdout}${res.stderr}`;
+      expect(output).not.toContain("Fatal error");
+      expect(output).not.toContain("environment variable is required");
+    }
+  });
+
+  it("still fails loudly without a flag and without configuration", () => {
+    // The guard must not have turned a misconfigured start into a silent exit 0.
+    const res = runBare();
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("CCU_HOST");
+  });
+});


### PR DESCRIPTION
Closes #112.

## Problem

`main()` called `loadConfig()` as its second statement, before looking at argv, so both flags died in config loading:

```console
$ node dist/index.js --version
Fatal error: Error: CCU_HOST environment variable is required
    at loadConfig (…/dist/config.js:126:19)
```

That left no way to ask an installed copy which version it is without a configured, reachable CCU — the only route was the `get_system_info` tool, which needs a live MCP session. It hurt most on the documented default install path: `npx ccu-mcp` reuses the copy cached in `~/.npm/_npx` without re-resolving against the registry, so a user can sit on an old version with no local signal. That is exactly the situation v1.8.1 put people in, since its fix reaches consumers only through the raised SDK floor.

## Change

`handleInfoFlags()` runs before `createLogger()`/`loadConfig()`, so neither flag needs any environment:

```console
$ env -i node dist/index.js --version
1.8.1 (v1.8.1-4-g2935fea-dirty)

$ env -i node dist/index.js --help
ccu-mcp — MCP server for a HomeMatic CCU (debmatic, CCU3, OpenCCU/RaspberryMatic)

Usage:
  ccu-mcp [--stdio | --http]
…
```

- Output goes to **stdout**, not stderr, so `ccu-mcp --help | less` works; exit code `0` for both, since they are successful invocations.
- `--version` appends the `git describe` stamped at build time when present. An npm install carries no `build-info.json` and prints the bare version.
- No arg-parsing dependency for two flags.
- `--help` lists the transport flags and the required/common variables, then points at the README for the full table rather than duplicating it.

### One bug caught in review

`git describe --dirty` already carries the marker, the `commit` fallback does not — appending unconditionally printed `1.8.1 (v1.8.1-4-g2935fea-dirty-dirty)`. The marker is now only added when the stamp lacks it, with a test pinning it.

## Tests

`test/e2e/cli-flags.test.ts` spawns the built CLI with a **scrubbed environment**, which is the whole point — the bug was precisely that these paths depended on the environment. Covers both long and short forms, stdout-not-stderr, the doubled-dirty regression, and that neither flag trips config loading.

It also asserts a bare start **still fails loudly**, so the guard cannot have turned a misconfigured launch into a silent exit 0.

## Docs

README gains a *Command-line flags* section including the npx-cache caveat (a bare `npx ccu-mcp` will not pick up a new release), plus a cross-reference from the env table to the profiles section.

`npm test` green (418 passed, 26 skipped), `npm run lint` clean.