### PR TITLE
docs: list the configuration errors that abort startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,30 @@ profile (unchanged behavior). At runtime, `list_ccu_targets` shows the targets,
 tools also accept an optional `target` to read from another CCU for a single call
 without switching.
 
+### Configuration errors
+
+Some mistakes stop the server at startup instead of being ignored. Each of these
+would otherwise fail *silently* and much later, so the exit is deliberate:
+
+| Message | Cause and why it's fatal |
+|---|---|
+| `CCU_HOST environment variable is required` | No CCU configured (and no `CCU_PROFILES`). |
+| `CCU_PASSWORD environment variable is required` | Unset **or empty**. Note the asymmetry: a *profile* password may be empty (`CCU_<NAME>_PASSWORD=`, e.g. an OpenCCU dev box), the flat one may not. |
+| `CCU_DEFAULT_PROFILE is set but CCU_PROFILES is not` | A leftover from a profile setup. Ignoring it would point writes at the flat `CCU_HOST` box while the env file suggests a named target. |
+| `CCU_PROFILES is set but lists no profile names` | Empty or comma-only value. |
+| `CCU_PROFILES lists "<name>" more than once` | Duplicate profile name. |
+| `... both map to the same env prefix CCU_<P>_* — rename one` | Distinct names can collide once sanitised: `prod-a` and `prod.a` both read `CCU_PROD_A_*`, so they would silently be the *same* target. |
+| `CCU_DEFAULT_PROFILE="x" is not one of CCU_PROFILES (...)` | Typo in the startup profile. |
+| `profile "<name>" is missing CCU_<P>_HOST` | Every profile needs a host; the password may be empty. |
+| `TLS_FINGERPRINT/CA_CERT/TLS_VERIFY is set but HTTPS is disabled` | The verification code path only exists over HTTPS. Ignoring these would leave you believing the connection is verified while credentials travel in cleartext. Set `CCU_HTTPS=true` (or `CCU_<NAME>_HTTPS=true`) or remove them. |
+| `MCP_TLS_CERT and MCP_TLS_KEY must both be set (or both unset)` | Half a TLS config can't serve HTTPS. |
+| `MCP_TRANSPORT must be "http" or "stdio"` | Case matters. A typo like `STDIO` must not silently select HTTP and leave a stdio-spawning client waiting forever. |
+| `<VAR> must be a positive number` | Any of the numeric settings (ports, timeouts, rate limits, poll interval). |
+| `CCU_CA_CERT could not be read` | Path is wrong or unreadable by the server user. |
+
+`ccu-mcp --version` and `--help` work without any configuration, so they stay
+usable while you sort one of these out.
+
 ## Tools
 
 28 tools organized by what you'd actually want to do:


### PR DESCRIPTION
Closes #113.

## Scope correction first

The original issue claimed the README omits the multi-CCU profile variables entirely. **That was wrong**, and I have rewritten the issue accordingly. README *"Multiple CCU targets (profiles)"* already documents `CCU_PROFILES`, `CCU_DEFAULT_PROFILE`, the `CCU_<NAME>_*` suffix family, the prefix sanitisation rule and both policy flags — `PROTECTED` in more detail than the issue itself did, including the `run_script` / `delete_system_variable` exception. The report came from grepping only the env table and missing the section 30 lines below it.

What survived checking is this PR: `loadConfig()` aborts startup on a range of configuration mistakes, and **none of them is documented anywhere** — not the README, not `.env.example`. Verified by grepping both for the distinguishing phrases ("more than once", "same env prefix", "only apply over HTTPS", "must both be set"): no hits.

## Change

A *Configuration errors* table at the end of the config section. Messages are transcribed from `src/config.ts` so they are searchable verbatim by someone who just hit one.

For several entries the **reasoning** matters more than the message text, and that is what the table carries:

- refusing `TLS_FINGERPRINT` / `CA_CERT` / `TLS_VERIFY` on a plain-HTTP target looks like pedantry until you know it stops you believing the connection is verified while credentials travel in cleartext
- rejecting a stray `CCU_DEFAULT_PROFILE` prevents writes landing on the flat `CCU_HOST` box while the env file suggests a named target
- the sanitised-prefix collision (`prod-a` and `prod.a` both read `CCU_PROD_A_*`) would otherwise make two "different" profiles silently the same target
- a `MCP_TRANSPORT` typo like `STDIO` must not quietly select HTTP and leave a stdio-spawning client waiting forever

Also records an asymmetry that is easy to trip over: a **profile** password may be empty (`CCU_<NAME>_PASSWORD=`, e.g. an OpenCCU dev box), the **flat** `CCU_PASSWORD` may not — `!password` rejects the empty string too.

Closes with a pointer that `--version` / `--help` keep working without configuration (#116), so they stay usable while sorting one of these out.

Docs only — no source or test changes. `npm test` green (411 passed, 26 skipped).