### PR TITLE
chore: gitignore the local TESTCHAIN.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 CLAUDE.md
 features.md
 QA-FINDINGS.md
+TESTCHAIN.md
 
 # OS
 .DS_Store


### PR DESCRIPTION
One line in `.gitignore`.

`TESTCHAIN.md` is a local-only note describing the test chain on this
workstation — the `gpu1` host, the OpenCCU dev VM at `127.0.0.1:18080`, the
`debmatic` prod CCU, and which of the four test layers needs what running.

It is machine-specific (local paths, host names, which account prod uses), so
it belongs with the other local docs rather than in the repo. Added next to
`CLAUDE.md`, `features.md` and `QA-FINDINGS.md` in the existing
"Project docs (kept local, not in repo)" block.

No source or behaviour change.