### PR TITLE
fix(control): stop reporting failed CCU writes and deletes as success

### DIFF
--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -129,6 +129,17 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
       const active = deps.selection.active;
       const { session, resolver, deviceTypeCache } = active;
       assertWritable(deps.selection, active, args.confirm);
+      // An empty set sends an empty struct; putparamset.tcl iterates nothing and
+      // answers true, so the tool reported a write that touched nothing as a
+      // success (issue #131). Every sibling tool rejects its degenerate input.
+      if (Object.keys(args.set).length === 0) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: "'set' is empty — there is nothing to write.",
+          hint: "Pass the parameters to write, e.g. {TEMPERATURE_WINDOW_OPEN: 5.0}. Use describe_device_type for valid names.",
+        });
+      }
       const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
       // CCU expects set as array of {name, type, value} objects. Types must be
@@ -278,7 +289,19 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         // historical contract) — label matching applies to strings only, so
         // an enum whose labels are numeric strings ("1;2;3") can't silently
         // redefine what a numeric input means.
-        const labels = (sysVar.valueList ?? "").split(";");
+        // "".split(";") is [""], not [] — so an ENUM/LIST variable with no
+        // value list would otherwise present as a one-state enum: index 0
+        // accepted, and a hint reading "Pass an index 0-0 or one of: "
+        // (issue #122). That variable is unwritable by index; say so.
+        if (!sysVar.valueList) {
+          throw new CcuError({
+            error: "CCU_ERROR",
+            code: 0,
+            message: `System variable "${args.name}" is an enum but the CCU reports no value list for it`,
+            hint: "The variable is misconfigured on the CCU — open it in the WebUI and define its value list, or recreate it with create_system_variable.",
+          });
+        }
+        const labels = sysVar.valueList.split(";");
         let index: number;
         if (typeof args.value === "number") {
           index = args.value;
@@ -344,12 +367,37 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
       }
 
       await rateLimiter.acquire();
-      await withRetry(
+      const setResult = await withRetry(
         () => session.call(method, { name: args.name, value: rpcValue }),
         method,
         logger,
         { rateLimiter },
       );
+
+      // setbool.tcl/setfloat.tcl end with:
+      //   if {[hmscript $script args]} { jsonrpc_response $args(value) }
+      //   else                         { jsonrpc_response -1 }
+      // so -1 is the CCU saying "the script engine failed" — the write never
+      // reached the variable. Discarding this result reported a lost write as a
+      // success (issue #118).
+      //
+      // Only the sentinel is treated as failure, deliberately: comparing the
+      // echoed value against what we sent would misfire the moment a firmware
+      // reformats it ("21.5" vs "21.500000"). A false "your write failed" on a
+      // write that landed is worse than the narrow blind spot below.
+      //
+      // Blind spot, and it is safe: setting a float to exactly -1 makes success
+      // and failure indistinguishable. That direction fails open — we report
+      // success for the value the CCU would have stored anyway.
+      if (isCcuScriptFailure(setResult) && String(rpcValue) !== "-1") {
+        throw new CcuError({
+          error: "CCU_ERROR",
+          code: 0,
+          message: `${method} reported failure for "${args.name}" — the value was NOT written`,
+          hint: "The CCU's script engine failed (busy or errored). Verify with list_system_variables and retry.",
+          ccuMethod: method,
+        });
+      }
 
       // setbool.tcl/setfloat.tcl answer success even when dom.GetObject finds
       // no variable (verified in the OCCU TCL) — a delete racing the 30s type
@@ -376,12 +424,18 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         logger.warn("sysvar_write_unverified", { name: args.name, error: (err as Error).message });
         verified = false;
       }
+      // An empty result has TWO causes and getvaluebyname.tcl cannot tell them
+      // apart — it returns `json_toString [hmscript …]`, and hmscript yields ""
+      // both when the variable is gone AND when the script engine itself failed.
+      // Say so rather than asserting a concurrent delete that may not have
+      // happened (issue #118). The setter's own return value is checked above,
+      // so a write that never landed has already been caught by this point.
       if (verified && (typeof verifyResult !== "string" || verifyResult === "")) {
         throw new CcuError({
           error: "NOT_FOUND",
           code: 0,
-          message: `System variable disappeared before the write could land: ${args.name}`,
-          hint: "It was likely deleted concurrently (the CCU's setBool/setFloat report success even without a target). Call list_system_variables to confirm.",
+          message: `Could not confirm the write to "${args.name}": the CCU returned no value for it`,
+          hint: "Either the variable was deleted concurrently, or the CCU's script engine failed during verification. The write itself was acknowledged. Call list_system_variables to see which.",
         });
       }
 
@@ -432,6 +486,36 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
           code: 0,
           message: "An enum system variable requires a non-empty 'values' list.",
           hint: "Pass values, e.g. [\"off\", \"low\", \"high\"].",
+        });
+      }
+      // Arguments that don't apply to the chosen type used to be dropped on the
+      // floor by the switch below — create(type:"bool", min:0, max:40, unit:"°C")
+      // silently made a plain boolean (issue #122). Reject instead, matching the
+      // enum-without-values check directly above.
+      const ignored: string[] = [];
+      if (args.type !== "float") {
+        for (const [k, v] of [["min", args.min], ["max", args.max], ["unit", args.unit]] as const) {
+          if (v !== undefined) ignored.push(k);
+        }
+      }
+      if (args.type !== "enum" && args.values !== undefined) ignored.push("values");
+      if (ignored.length > 0) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: `${ignored.join(", ")} ${ignored.length === 1 ? "does" : "do"} not apply to a "${args.type}" system variable`,
+          hint: "min/max/unit are float-only; values is enum-only. Drop them, or change 'type'.",
+        });
+      }
+      // ValueMin >= ValueMax makes a variable the WebUI cannot set a value in.
+      // hmNumberLiteral checks each bound is representable; nothing checked
+      // them against each other (issue #122).
+      if (args.type === "float" && args.min !== undefined && args.max !== undefined && args.min >= args.max) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: `min (${args.min}) must be less than max (${args.max})`,
+          hint: "Swap them, or omit both for the 0-100 default range.",
         });
       }
       // ";" is the CCU's in-band ValueList separator: a label containing it
@@ -627,12 +711,27 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
       }
 
       await rateLimiter.acquire();
-      await withRetry(
+      const deleteResult = await withRetry(
         () => session.call("SysVar.deleteSysVarByName", { name: args.name }),
         "SysVar.deleteSysVarByName",
         logger,
         { rateLimiter },
       );
+
+      // deletesysvarbyname.tcl is `jsonrpc_response [hmscript $script args]`,
+      // and the script's only output is Write("true"). So anything other than
+      // "true" means hmscript failed and the variable is still there — which
+      // this tool used to report as `deleted: true` (issue #118). Same strict
+      // shape as execute_program's Program.execute check.
+      if (deleteResult !== true && deleteResult !== "true") {
+        throw new CcuError({
+          error: "CCU_ERROR",
+          code: 0,
+          message: `SysVar.deleteSysVarByName reported failure for "${args.name}" — it was NOT deleted`,
+          hint: "The CCU's script engine failed (busy or errored). Confirm with list_system_variables and retry.",
+          ccuMethod: "SysVar.deleteSysVarByName",
+        });
+      }
 
       typeCacheHolder.entry = null; typeCacheHolder.gen++; // removed variable must not linger in the cache
       return toolResult({ name: args.name, deleted: true });
@@ -841,6 +940,16 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
       return toolResult({ id: args.id, name: program.name, executed: true });
     }),
   );
+}
+
+/**
+ * True when a CCU response carries the `-1` sentinel that SysVar.setBool /
+ * SysVar.setFloat return when their ReGa script failed to run (verified in the
+ * OCCU sources: `setbool.tcl`, `setfloat.tcl`). Accepts both the numeric and
+ * the string form — the CCU's JSON layer is not consistent about which.
+ */
+function isCcuScriptFailure(result: unknown): boolean {
+  return result === -1 || result === "-1";
 }
 
 /**

--- a/test/unit/tools-control.test.ts
+++ b/test/unit/tools-control.test.ts
@@ -268,6 +268,51 @@ describe("set_system_variable handler", () => {
     expect(result.note).toMatch(/could not be verified/);
     cleanupDeps(deps);
   });
+
+  it("reports CCU_ERROR when setBool answers the -1 script-failure sentinel (#118)", async () => {
+    // setbool.tcl: `if {[hmscript ...]} { response $value } else { response -1 }`.
+    // The old code discarded this, and getValueByName still returned the OLD
+    // value — so a lost write read as a success.
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [{ name: "Anwesenheit", type: "LOGIC" }];
+      if (method === "SysVar.setBool") return -1;
+      if (method === "SysVar.getValueByName") return "false"; // stale value still present
+      return true;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "set_system_variable", { name: "Anwesenheit", value: true });
+    expect(result.isError).toBe(true);
+    const err = JSON.parse(result.content[0].text);
+    expect(err.error).toBe("CCU_ERROR");
+    expect(err.message).toMatch(/NOT written/);
+    cleanupDeps(deps);
+  });
+
+  it("accepts a legitimate -1 on a numeric variable (the sentinel is ambiguous there, and fails open)", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [{ name: "Delta", type: "NUMBER" }];
+      if (method === "SysVar.setFloat") return -1; // indistinguishable from success here
+      if (method === "SysVar.getValueByName") return "-1";
+      return true;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const result = parseToolResult(await callTool(server, "set_system_variable", { name: "Delta", value: -1 })) as any;
+    expect(result.value).toBe(-1);
+    expect(result.method).toBe("SysVar.setFloat");
+    cleanupDeps(deps);
+  });
+
+  it("rejects an enum variable the CCU reports with no value list (#122)", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) =>
+      method === "SysVar.getAll" ? [{ name: "Modus", type: "LIST" }] : true);
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "set_system_variable", { name: "Modus", value: 0 });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("CCU_ERROR");
+    // never attempts the write
+    expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "SysVar.setFloat")).toBe(false);
+    cleanupDeps(deps);
+  });
 });
 
 describe("create_system_variable handler", () => {
@@ -337,6 +382,31 @@ describe("create_system_variable handler", () => {
     cleanupDeps(deps);
   });
 
+  it("rejects min >= max on a float variable (#122)", async () => {
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "create_system_variable", { name: "T", type: "float", min: 100, max: 0 });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).message).toMatch(/must be less than max/);
+    expect(sessionCall).not.toHaveBeenCalled();
+    cleanupDeps(deps);
+  });
+
+  it("rejects arguments that don't apply to the chosen type instead of dropping them (#122)", async () => {
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+    // min/max/unit are float-only — silently ignored before, so this created a plain bool
+    const bad: any = await callTool(server, "create_system_variable", { name: "B", type: "bool", min: 0, max: 40, unit: "°C" });
+    expect(bad.isError).toBe(true);
+    expect(JSON.parse(bad.content[0].text).message).toMatch(/do not apply to a "bool"/);
+    // values is enum-only
+    const bad2: any = await callTool(server, "create_system_variable", { name: "F", type: "float", values: ["a", "b"] });
+    expect(bad2.isError).toBe(true);
+    expect(JSON.parse(bad2.content[0].text).message).toMatch(/values does not apply/);
+    expect(sessionCall).not.toHaveBeenCalled();
+    cleanupDeps(deps);
+  });
+
   it("rejects min/max magnitudes that stringify to exponent notation", async () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => (method === "SysVar.getAll" ? [] : null));
     const { server, deps } = createTestServer({ sessionCall });
@@ -386,13 +456,29 @@ describe("create_system_variable handler", () => {
 
 describe("delete_system_variable handler", () => {
   it("deletes an existing variable via deleteSysVarByName", async () => {
+    // deletesysvarbyname.tcl echoes hmscript's output, whose only Write is "true".
     const sessionCall = vi.fn().mockImplementation(async (method: string) =>
-      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : null);
+      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : "true");
     const { server, deps } = createTestServer({ sessionCall });
 
     const result = parseToolResult(await callTool(server, "delete_system_variable", { name: "Urlaub" })) as any;
     expect(result).toEqual({ name: "Urlaub", deleted: true });
     expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "SysVar.deleteSysVarByName")).toBe(true);
+    cleanupDeps(deps);
+  });
+
+  it("reports CCU_ERROR when the delete script failed, instead of deleted:true (#118)", async () => {
+    // hmscript returns "" on any script error; the old code ignored the result
+    // and reported a successful delete for a variable that is still there.
+    const sessionCall = vi.fn().mockImplementation(async (method: string) =>
+      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : "");
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result: any = await callTool(server, "delete_system_variable", { name: "Urlaub" });
+    expect(result.isError).toBe(true);
+    const err = JSON.parse(result.content[0].text);
+    expect(err.error).toBe("CCU_ERROR");
+    expect(err.message).toMatch(/NOT deleted/);
     cleanupDeps(deps);
   });
 
@@ -578,6 +664,16 @@ describe("remaining error paths (coverage round)", () => {
 
     const call = sessionCall.mock.calls.find((c: unknown[]) => c[0] === "Interface.putParamset");
     expect((call![1] as any).set).toEqual([{ name: "SET_POINT_TEMPERATURE", type: "double", value: "21.5" }]);
+    cleanupDeps(deps);
+  });
+
+  it("put_paramset rejects an empty set instead of reporting a no-op write as success (#131)", async () => {
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "put_paramset", { address: "AAA:1", paramsetKey: "VALUES", set: {}, interface: "HmIP-RF" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "Interface.putParamset")).toBe(false);
     cleanupDeps(deps);
   });
 

--- a/test/unit/tools-targets.test.ts
+++ b/test/unit/tools-targets.test.ts
@@ -152,8 +152,9 @@ describe("per-call confirm for high-impact tools (issue #72)", () => {
   });
 
   it("delete_system_variable refuses without confirm even after the session is unlocked", async () => {
+    // "true" is what deletesysvarbyname.tcl really answers; the tool checks it (#118).
     const sessionCall = vi.fn().mockImplementation(async (method: string) =>
-      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : null);
+      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : "true");
     const t = createTestServer({ protected: true, sessionCall });
     deps = t.deps;
     await unlockSession(t.server);


### PR DESCRIPTION
Closes #118, closes #122, closes #131.

## The core bug (#118)

Three CCU methods report failure in their **return value**. All three were awaited and thrown away, so a write or delete that never happened was reported to the client as a success.

Verified in the OCCU sources:

| Method | On failure | Was |
|---|---|---|
| `SysVar.setBool` / `setFloat` | `jsonrpc_response -1` | discarded |
| `SysVar.deleteSysVarByName` | echoes `hmscript`'s `""` | discarded → `{deleted: true}` |

`set_system_variable`'s existing `getValueByName` follow-up did not cover this: it only proves the variable still **exists**, never that the new value landed. A `-1` leaves the old value in place, `getValueByName` returns that old non-empty value, and the tool answers success.

### Why only the `-1` sentinel, not an echo comparison

On success these methods echo `$args(value)`. Comparing it against what we sent would be stricter — and would misfire the moment a firmware reformats the value (`21.5` vs `21.500000`), reporting a failure for a write that landed. That is worse than the one blind spot it would close.

The blind spot: setting a float to exactly `-1` makes success and failure indistinguishable. That direction **fails open** — we report success for the value the CCU would have stored anyway. Both cases have tests.

### Third case

`getvaluebyname.tcl` returns `json_toString [hmscript …]`, and `hmscript` yields `""` both when the variable is gone **and** when the script engine failed. The old error asserted a concurrent deletion as fact. It now states both possibilities.

## Validation gaps found alongside (#122, #131)

- `create_system_variable` rejects `min >= max`. `hmNumberLiteral` checked each bound was representable; nothing compared them, so `{min: 100, max: 0}` created a variable the WebUI cannot set a value in.
- `create_system_variable` rejects arguments that don't apply to the chosen type. `{type: "bool", min: 0, max: 40, unit: "°C"}` silently made a plain boolean — the `switch` simply never read those fields. Now consistent with the enum-without-`values` check that was already there.
- `set_system_variable` rejects an ENUM whose CCU value list is empty. `"".split(";")` is `[""]`, not `[]`, so `labels.length === 1` and index `0` passed the bound check, with a hint reading `Pass an index 0-0 or one of: `.
- `put_paramset` rejects an empty `set` (#131). It used to send an empty struct, which `putparamset.tcl` answers `true` to, and report a write that touched nothing as a success.

## Tests

418 → 425. New coverage for the `-1` sentinel, the legitimate `-1` fail-open, a failed delete, the value-list-less enum, `min >= max`, type-irrelevant arguments, and the empty `set`.

Two existing mocks returned `null` for `deleteSysVarByName` and now return `"true"` — the contract the CCU actually has. That change is the point of the fix, not a workaround for it.