### PR TITLE
fix(config): reject malformed numeric and boolean env vars instead of misreading them

### DIFF
--- a/src/ccu/types.ts
+++ b/src/ccu/types.ts
@@ -169,6 +169,14 @@ export interface CcuProfile {
   protected: boolean;
   /** When true, write tools are refused outright (even with confirm). */
   readonly: boolean;
+  /**
+   * True only for the back-compat profile synthesised from the FLAT `CCU_*`
+   * variables when `CCU_PROFILES` is unset. Not the same as `name === "default"`:
+   * `CCU_PROFILES=default,dev` is legal and produces a profile genuinely named
+   * "default" that reads `CCU_DEFAULT_*`. Error messages must name the variable
+   * the profile actually reads, so they key off this instead of the name.
+   */
+  isFlat?: boolean;
   /** Connection details for this target. */
   ccu: CcuConfig;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,16 @@ export interface AppConfig {
   resourcePollInterval: number;
 }
 
+/**
+ * The env-var prefix a profile name maps to: `prod-a` → `PROD_A`, read as
+ * `CCU_PROD_A_*`. Single definition — this was written out three times, once as
+ * the actual prefix, once in the duplicate-detection loop, and once inside an
+ * error message that had to agree with both (issue #124).
+ */
+function envPrefix(name: string): string {
+  return name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+}
+
 export function loadConfig(): AppConfig {
   // CLI flags override env vars for transport. Validate the env value: a typo
   // ("STDIO", "Stdio") must fail loudly, not silently select HTTP and leave a
@@ -98,12 +108,38 @@ export function loadConfig(): AppConfig {
   if (args.includes("--stdio")) transport = "stdio";
   if (args.includes("--http")) transport = "http";
 
+  // Strict: the whole value must be a plain positive integer. parseInt() used to
+  // do this and stopped at the first non-digit, so "30s" silently became 30 —
+  // a 30 MILLISECOND CCU_TIMEOUT, whose every failure then looked like a slow
+  // CCU rather than a config typo (issue #119). The units are documented only
+  // in comments, so a "30s" is a natural thing to write.
+  // Rejecting via regex rather than Number() also excludes forms Number()
+  // accepts but nobody means here: hex ("0x10"), exponent ("1e4"), decimals.
   const parseIntEnv = (name: string, fallback: string): number => {
-    const val = parseInt(process.env[name] || fallback, 10);
-    if (isNaN(val) || val <= 0) {
-      throw new Error(`${name} must be a positive number, got: "${process.env[name]}"`);
+    // Unset or explicitly empty ("VAR=" in a compose file) means "use the
+    // default", as before. Whitespace-only does NOT — it is a typo, and the old
+    // parseInt(" ") → NaN rejected it. Trim only after that distinction.
+    const raw = process.env[name];
+    const source = raw === undefined || raw === "" ? fallback : raw.trim();
+    if (!/^\d+$/.test(source) || !Number.isSafeInteger(Number(source)) || Number(source) <= 0) {
+      throw new Error(`${name} must be a positive integer, got: "${process.env[name]}"`);
     }
-    return val;
+    return Number(source);
+  };
+
+  // Booleans were compared as `process.env[name] === "true"` against the RAW value,
+  // so a trailing space or CR made the setting silently false (issue #120).
+  // For CCU_<P>_PROTECTED / _READONLY that failed OPEN — the production write
+  // gate quietly disabled. Docker passes `environment:` values verbatim, and
+  // docker-compose.yml documents exactly those variables, so this was reachable.
+  // Garbage is rejected rather than read as false, matching MCP_TRANSPORT:
+  // `CCU_PROD_PROTECTED=yes` must not mean "unprotected".
+  const parseBoolEnv = (name: string): boolean => {
+    const raw = process.env[name]?.trim().toLowerCase();
+    if (raw === undefined || raw === "") return false;
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    throw new Error(`${name} must be "true" or "false", got: "${process.env[name]}"`);
   };
 
   // Optional positive duration in `unitMs` units; fractional values allowed
@@ -173,20 +209,20 @@ export function loadConfig(): AppConfig {
   // literal scan doesn't see them — intentional; they're documented as comments
   // in .env.example. Password may be empty (OpenCCU dev boxes default to it).
   const buildProfile = (name: string): CcuProfile => {
-    const p = name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+    const p = envPrefix(name);
     const get = (suffix: string): string | undefined => process.env[`CCU_${p}_${suffix}`]?.trim() || undefined;
     const host = get("HOST");
     if (!host) throw new Error(`profile "${name}" is missing CCU_${p}_HOST`);
-    const https = process.env[`CCU_${p}_HTTPS`] === "true";
+    const https = parseBoolEnv(`CCU_${p}_HTTPS`);
     return {
       name,
-      protected: process.env[`CCU_${p}_PROTECTED`] === "true",
-      readonly: process.env[`CCU_${p}_READONLY`] === "true",
+      protected: parseBoolEnv(`CCU_${p}_PROTECTED`),
+      readonly: parseBoolEnv(`CCU_${p}_READONLY`),
       ccu: {
         host,
         port: parseIntEnv(`CCU_${p}_PORT`, https ? "443" : "80"),
         https,
-        tlsVerify: process.env[`CCU_${p}_TLS_VERIFY`] === "true",
+        tlsVerify: parseBoolEnv(`CCU_${p}_TLS_VERIFY`),
         tlsFingerprint: get("TLS_FINGERPRINT"),
         caCert: readCaCert(`CCU_${p}_CA_CERT`, get("CA_CERT")),
         user: get("USER") || "Admin",
@@ -216,15 +252,17 @@ export function loadConfig(): AppConfig {
     if (!host) throw new Error("CCU_HOST environment variable is required");
     const password = process.env.CCU_PASSWORD;
     if (!password) throw new Error("CCU_PASSWORD environment variable is required");
+    const flatHttps = parseBoolEnv("CCU_HTTPS");
     profiles = [{
       name: "default",
       protected: false,
       readonly: false,
+      isFlat: true,
       ccu: {
         host,
-        port: parseIntEnv("CCU_PORT", process.env.CCU_HTTPS === "true" ? "443" : "80"),
-        https: process.env.CCU_HTTPS === "true",
-        tlsVerify: process.env.CCU_TLS_VERIFY === "true",
+        port: parseIntEnv("CCU_PORT", flatHttps ? "443" : "80"),
+        https: flatHttps,
+        tlsVerify: parseBoolEnv("CCU_TLS_VERIFY"),
         tlsFingerprint: process.env.CCU_TLS_FINGERPRINT?.trim() || undefined,
         caCert: readCaCert("CCU_CA_CERT", process.env.CCU_CA_CERT?.trim() || undefined),
         user: process.env.CCU_USER || "Admin",
@@ -246,7 +284,7 @@ export function loadConfig(): AppConfig {
       const key = n.toLowerCase();
       if (seen.has(key)) throw new Error(`CCU_PROFILES lists "${n}" more than once`);
       seen.add(key);
-      const prefix = n.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+      const prefix = envPrefix(n);
       const clash = seenPrefix.get(prefix);
       if (clash) {
         throw new Error(
@@ -272,9 +310,15 @@ export function loadConfig(): AppConfig {
   // Fail fast instead of silently ignoring the settings.
   for (const p of profiles) {
     if (!p.ccu.https && (p.ccu.tlsFingerprint || p.ccu.caCert || p.ccu.tlsVerify)) {
+      // `isFlat`, not `name === "default"`: CCU_PROFILES=default,dev is legal
+      // and yields a profile genuinely NAMED "default" that reads
+      // CCU_DEFAULT_HTTPS. Keying off the name told that operator to set
+      // CCU_HTTPS, which the profile path never reads — following the hint
+      // would not clear the error (issue #124).
+      const httpsVar = p.isFlat ? "CCU_HTTPS" : `CCU_${envPrefix(p.name)}_HTTPS`;
       throw new Error(
         `CCU profile "${p.name}": TLS_FINGERPRINT/CA_CERT/TLS_VERIFY is set but HTTPS is disabled — ` +
-        `these settings only apply over HTTPS. Set ${p.name === "default" ? "CCU_HTTPS" : `CCU_${p.name.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_HTTPS`}=true or remove them.`,
+        `these settings only apply over HTTPS. Set ${httpsVar}=true or remove them.`,
       );
     }
   }
@@ -300,7 +344,7 @@ export function loadConfig(): AppConfig {
       host: process.env.MCP_HOST?.trim() || undefined,
       tlsCertPath,
       tlsKeyPath,
-      allowPlaintext: process.env.MCP_ALLOW_PLAINTEXT === "true",
+      allowPlaintext: parseBoolEnv("MCP_ALLOW_PLAINTEXT"),
     },
     cache: {
       dir: process.env.CACHE_DIR || "/data",

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -159,14 +159,66 @@ describe("loadConfig", () => {
     process.env.CCU_PASSWORD = "pw";
 
     process.env.CCU_TIMEOUT = "0";
-    expect(() => loadConfig()).toThrow(/CCU_TIMEOUT must be a positive number/);
+    expect(() => loadConfig()).toThrow(/CCU_TIMEOUT must be a positive integer/);
 
     process.env.CCU_TIMEOUT = "-5000";
-    expect(() => loadConfig()).toThrow(/CCU_TIMEOUT must be a positive number/);
+    expect(() => loadConfig()).toThrow(/CCU_TIMEOUT must be a positive integer/);
     delete process.env.CCU_TIMEOUT;
 
     process.env.RESOURCE_POLL_INTERVAL = "-60";
-    expect(() => loadConfig()).toThrow(/RESOURCE_POLL_INTERVAL must be a positive number/);
+    expect(() => loadConfig()).toThrow(/RESOURCE_POLL_INTERVAL must be a positive integer/);
+  });
+
+  // Issue #119: parseInt() stopped at the first non-digit, so a unit suffix was
+  // silently truncated — "30s" became a 30 MILLISECOND timeout, and every call
+  // then failed looking like a slow CCU rather than a config typo.
+  it("rejects numeric env vars with a trailing unit or non-decimal notation", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+
+    for (const bad of ["30s", "10000ms", "1e4", "0x10", "3000/tcp", "21.5", " "]) {
+      process.env.CCU_TIMEOUT = bad;
+      expect(() => loadConfig(), `should reject CCU_TIMEOUT=${JSON.stringify(bad)}`)
+        .toThrow(/CCU_TIMEOUT must be a positive integer/);
+    }
+    // surrounding whitespace on an otherwise valid value is still fine
+    process.env.CCU_TIMEOUT = " 30000 ";
+    expect(loadConfig().ccu.timeout).toBe(30000);
+    delete process.env.CCU_TIMEOUT;
+  });
+
+  // Issue #120: the raw comparison `=== "true"` made a trailing space read as
+  // false. For PROTECTED/READONLY that failed OPEN — the production write gate
+  // silently disabled. Docker passes `environment:` values verbatim.
+  it("trims boolean env vars so a trailing space cannot disable a safety gate", () => {
+    process.env.CCU_PROFILES = "prod";
+    process.env.CCU_PROD_HOST = "ccu";
+    process.env.CCU_PROD_PASSWORD = "pw";
+    process.env.CCU_PROD_PROTECTED = "true ";
+    process.env.CCU_PROD_READONLY = " TRUE";
+
+    const prod = loadConfig().profiles[0]!;
+    expect(prod.protected).toBe(true);
+    expect(prod.readonly).toBe(true);
+  });
+
+  it("rejects a non-boolean value instead of reading it as false", () => {
+    process.env.CCU_PROFILES = "prod";
+    process.env.CCU_PROD_HOST = "ccu";
+    process.env.CCU_PROD_PASSWORD = "pw";
+    process.env.CCU_PROD_PROTECTED = "yes";
+    expect(() => loadConfig()).toThrow(/CCU_PROD_PROTECTED must be "true" or "false"/);
+  });
+
+  // Issue #124: `name === "default"` conflated the flat back-compat profile with
+  // a profile literally NAMED "default", which reads CCU_DEFAULT_*. The hint
+  // named a variable that profile never reads.
+  it("names the variable the profile actually reads in the TLS-on-plain-HTTP error", () => {
+    process.env.CCU_PROFILES = "default";
+    process.env.CCU_DEFAULT_HOST = "ccu";
+    process.env.CCU_DEFAULT_PASSWORD = "pw";
+    process.env.CCU_DEFAULT_TLS_VERIFY = "true"; // TLS setting without HTTPS
+    expect(() => loadConfig()).toThrow(/Set CCU_DEFAULT_HTTPS=true/);
   });
 
   // Issue #28 / #37: HTTP transport hardening

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -27,8 +27,10 @@ function envKeysReferencedInCode(): Set<string> {
     for (const m of text.matchAll(/process\.env(?:\.([A-Z][A-Z0-9_]*)|\["([A-Z][A-Z0-9_]*)"\])/g)) {
       keys.add(m[1] ?? m[2]);
     }
-    // parseIntEnv("FOO", ...) / parseDurationEnv("FOO", ...) — indirect reads
-    for (const m of text.matchAll(/parse(?:Int|Duration)Env\("([A-Z][A-Z0-9_]*)"/g)) {
+    // parseIntEnv("FOO", …) / parseDurationEnv("FOO", …) / parseBoolEnv("FOO")
+    // — indirect reads. Keep this alternation in step with the helpers in
+    // config.ts, or a var read only through a new helper looks undocumented.
+    for (const m of text.matchAll(/parse(?:Int|Duration|Bool)Env\("([A-Z][A-Z0-9_]*)"/g)) {
       keys.add(m[1]);
     }
   }


### PR DESCRIPTION
Closes #119, closes #120. Partially addresses #124 (the `config.ts` half).

## Numeric values (#119)

`parseIntEnv` used `parseInt`, which stops at the first non-digit and returns what it got:

| value | was | intent |
|---|---|---|
| `30s` | `30` | 30 seconds |
| `24h` | `24` | 24 hours |
| `1e4` | `1` | 10000 |

`CCU_TIMEOUT=30s` therefore configured a **30 millisecond** timeout. Every call then failed with `TIMEOUT — CCU may be slow or overloaded`, pointing at the CCU rather than at the config. Units live only in comments and `docker-compose.yml`, so a unit suffix is a natural thing to write.

Now validated as a plain positive integer — the same contract `parseDurationEnv` twelve lines below already had, comment and all. The regex form also rejects `0x10`, `1e4` and decimals, which `Number()` alone would accept.

`VAR=` (explicitly empty) still means "use the default", as before. `VAR=" "` is a typo and throws, as it did under `parseInt(" ") → NaN`.

## Booleans (#120) — this one failed open

Every boolean was `process.env.X === "true"` against the **raw** value, so `"true "` ≠ `"true"`:

- `CCU_PROD_PROTECTED=true ` → not protected → `set_value`, `run_script`, `delete_system_variable` all execute against production without `confirm: true`.
- `CCU_DEV_READONLY=true ` → read-only guard gone.

Nothing logged a warning, and `get_connection_info` reported `protected: false` — accurate, but with no hint the config meant otherwise. Docker passes `environment:` values verbatim, and `docker-compose.yml` documents `CCU_PROD_PROTECTED` specifically, so this was reachable. (Node's `--env-file` does trim, so the `.mcp.json` path was unaffected.)

Values are now trimmed and case-folded. A non-boolean is **rejected** rather than read as false — `CCU_PROD_PROTECTED=yes` must not silently mean "unprotected". That mirrors `MCP_TRANSPORT`, which has failed loudly on a typo since #37.

Note this is a deliberate behaviour change: a config that previously "worked" with `CCU_HTTPS=1` will now fail at startup. It never did what it looked like it did.

## From #124

- The env-prefix expression (`name.toUpperCase().replace(/[^A-Z0-9]/g, "_")`) was written out three times — twice as the actual prefix, once inside an error message that had to agree with both. Now one `envPrefix()` helper.
- The TLS-on-plain-HTTP hint used `name === "default"` to mean "this is the flat back-compat profile". But `CCU_PROFILES=default,dev` is legal and produces a profile genuinely **named** `default` that reads `CCU_DEFAULT_*`. That operator was told to set `CCU_HTTPS`, which the profile path never reads — following the hint would not clear the error. Now keyed off an explicit `isFlat` flag on the profile.

## Tests

418 → 422, covering every rejected numeric form, the trailing-space safety gate, non-boolean rejection, and the corrected hint.

One test-infrastructure change worth flagging: `env-example-sync`'s scanner had to learn `parseBoolEnv`, since three variables moved from `process.env.X` to the helper and would otherwise have looked undocumented. It caught that immediately — including, amusingly, a `process.env.X` I had written inside an explanatory comment.