### PR TITLE
refactor(cache): extract the shared paramset-fetch loop, drop two dead params

### DIFF
--- a/src/cache/device-type-cache.ts
+++ b/src/cache/device-type-cache.ts
@@ -185,7 +185,9 @@ export class DeviceTypeCache {
       );
 
       // Get all devices per interface
-      const devicesByType = new Map<string, { interface: string; address: string; channels: string[] }>();
+      // `address` used to be stored here and never read — processType's own
+      // parameter type omitted it (issue #121).
+      const devicesByType = new Map<string, { interface: string; channels: string[] }>();
 
       for (const iface of interfaces) {
         await rateLimiter.acquire();
@@ -207,7 +209,6 @@ export class DeviceTypeCache {
 
           devicesByType.set(device.type, {
             interface: iface.name,
-            address: device.address,
             channels: device.children,
           });
         }
@@ -220,43 +221,9 @@ export class DeviceTypeCache {
       // half while the rate limiter still caps overall CCU load.
       const processType = async (deviceType: string, info: { interface: string; channels: string[] }) => {
         try {
-          const channels: CachedDeviceType["channels"] = {};
-
-          // Get description for each channel
-          for (const channelAddr of info.channels) {
-            const channelIndex = channelAddr.split(":")[1] || "0";
-
-            const paramsets: Record<string, Record<string, CachedParamDescription>> = {};
-
-            for (const paramsetKey of ["VALUES", "MASTER"]) {
-              await rateLimiter.acquire();
-              try {
-                const desc = await session.call("Interface.getParamsetDescription", {
-                  interface: info.interface,
-                  address: channelAddr,
-                  paramsetKey,
-                });
-
-                const params = parseParamDescriptions(desc as RawParamDesc[]);
-
-                if (Object.keys(params).length > 0) {
-                  paramsets[paramsetKey] = params;
-                }
-              } catch {
-                // Some channels don't support all paramset keys — skip
-              }
-            }
-
-            // Determine channel type from the first param or address pattern
-            channels[channelIndex] = {
-              type: channelAddr, // Will be enriched if we add channel type info later
-              paramsets,
-            };
-          }
-
           this.cache.set(deviceType, {
             interface: info.interface,
-            channels,
+            channels: await this.fetchChannels(info.interface, info.channels, session, rateLimiter),
           });
         } catch (err) {
           this.logger.warn("cache_warm_type_failed", { deviceType, error: (err as Error).message });
@@ -289,12 +256,61 @@ export class DeviceTypeCache {
   }
 
   /**
+   * Fetch every channel's VALUES/MASTER paramset descriptions for one device
+   * type. Shared by the background warm and the live query fallback — they had
+   * near-identical copies of this loop that had already drifted apart in error
+   * handling (issue #121).
+   *
+   * A channel that doesn't support a paramset key is normal and skipped; the
+   * result guard is `expectArray`, so a malformed CCU/proxy answer (`result:
+   * null`) is a diagnosable CCU_ERROR rather than a TypeError swallowed as
+   * "this channel has no such paramset".
+   */
+  private async fetchChannels(
+    interfaceName: string,
+    channels: string[],
+    session: SessionManager,
+    rateLimiter: RateLimiter,
+  ): Promise<CachedDeviceType["channels"]> {
+    const out: CachedDeviceType["channels"] = {};
+
+    for (const channelAddr of channels) {
+      const channelIndex = channelAddr.split(":")[1] || "0";
+      const paramsets: Record<string, Record<string, CachedParamDescription>> = {};
+
+      for (const paramsetKey of ["VALUES", "MASTER"]) {
+        await rateLimiter.acquire();
+        try {
+          const desc = await session.call("Interface.getParamsetDescription", {
+            interface: interfaceName,
+            address: channelAddr,
+            paramsetKey,
+          });
+          const params = parseParamDescriptions(
+            expectArray<RawParamDesc>(desc, "Interface.getParamsetDescription"),
+          );
+          if (Object.keys(params).length > 0) {
+            paramsets[paramsetKey] = params;
+          }
+        } catch {
+          // Channel doesn't support this paramset key — expected, skip.
+        }
+      }
+
+      // `type` carries the channel address for now; enriched if we ever add
+      // real channel-type info.
+      out[channelIndex] = { type: channelAddr, paramsets };
+    }
+
+    return out;
+  }
+
+  /**
    * Add a single type to cache (live query fallback).
    * Single-flight per device type: concurrent calls share one live query.
    */
   async queryAndCache(
     deviceType: string,
-    deviceAddress: string,
     interfaceName: string,
     channels: string[],
     session: SessionManager,
@@ -318,31 +334,10 @@ export class DeviceTypeCache {
     session: SessionManager,
     rateLimiter: RateLimiter,
   ): Promise<CachedDeviceType | undefined> {
-    const cached: CachedDeviceType = { interface: interfaceName, channels: {} };
-
-    for (const channelAddr of channels) {
-      const channelIndex = channelAddr.split(":")[1] || "0";
-      const paramsets: Record<string, Record<string, CachedParamDescription>> = {};
-
-      for (const paramsetKey of ["VALUES", "MASTER"]) {
-        await rateLimiter.acquire();
-        try {
-          const desc = await session.call("Interface.getParamsetDescription", {
-            interface: interfaceName,
-            address: channelAddr,
-            paramsetKey,
-          });
-
-          const params = parseParamDescriptions(desc as RawParamDesc[]);
-
-          if (Object.keys(params).length > 0) {
-            paramsets[paramsetKey] = params;
-          }
-        } catch { /* skip */ }
-      }
-
-      cached.channels[channelIndex] = { type: channelAddr, paramsets };
-    }
+    const cached: CachedDeviceType = {
+      interface: interfaceName,
+      channels: await this.fetchChannels(interfaceName, channels, session, rateLimiter),
+    };
 
     this.cache.set(deviceType, cached);
     // Don't block on disk save

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -313,7 +313,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
         if (device) {
           try {
             cached = await deviceTypeCache.queryAndCache(
-              args.deviceType, device.address, device.interface,
+              args.deviceType, device.interface,
               device.channels.map((ch) => ch.address),
               session, rateLimiter,
             );

--- a/test/unit/device-type-cache.test.ts
+++ b/test/unit/device-type-cache.test.ts
@@ -143,8 +143,8 @@ describe("DeviceTypeCache", () => {
     const rateLimiter = { acquire: async () => {} } as any;
 
     const [a, b] = await Promise.all([
-      cache.queryAndCache("HmIP-X", "ADDR", "HmIP-RF", ["ADDR:1"], session, rateLimiter),
-      cache.queryAndCache("HmIP-X", "ADDR", "HmIP-RF", ["ADDR:1"], session, rateLimiter),
+      cache.queryAndCache("HmIP-X", "HmIP-RF", ["ADDR:1"], session, rateLimiter),
+      cache.queryAndCache("HmIP-X", "HmIP-RF", ["ADDR:1"], session, rateLimiter),
     ]);
 
     // 1 channel × 2 paramset keys = 2 CCU calls if coalesced, 4 if duplicated
@@ -225,7 +225,7 @@ describe("warm edge cases (coverage round)", () => {
     } as any;
     const rateLimiter = { acquire: async () => {} } as any;
 
-    const cached = await cache.queryAndCache("HmIP-X", "A1", "HmIP-RF", ["A1:1"], session, rateLimiter);
+    const cached = await cache.queryAndCache("HmIP-X", "HmIP-RF", ["A1:1"], session, rateLimiter);
     const param = cached!.channels["1"]!.paramsets["VALUES"]!["LEVEL"]!;
     expect(param).toMatchObject({ type: "FLOAT", operations: 7, min: 0, max: 1.01, unit: "%", valueList: ["a", "b"] });
     await new Promise((r) => setTimeout(r, 25)); // let background save finish


### PR DESCRIPTION
Closes #121.

## The duplication

`warm()` → `processType` and `doQueryAndCache()` both walked a device type's channels, fetched `VALUES` and `MASTER` paramset descriptions, kept the non-empty ones, and stored `{type, paramsets}`. Same loop, written twice.

They had already drifted:

| | `warm()` | `doQueryAndCache()` |
|---|---|---|
| per-type error handling | `try/catch` + `cache_warm_type_failed` | none |
| fully-failed type | skipped, warm continues | cached with empty channels |

Both now call one `private fetchChannels()`.

## A swallowed error the extraction fixes

Both copies did `parseParamDescriptions(desc as RawParamDesc[])` — a bare cast. When the CCU (or a proxy) answers `result: null`, `for (const p of descArray)` throws a `TypeError` **inside the `catch` that means "this channel doesn't support that paramset key"**. So a systematically broken CCU produced a silently empty schema cache with no diagnostic at all.

Now routed through `expectArray()`, which `warm()` already used for `Interface.listInterfaces` and `Interface.listDevices` twelve lines above. A malformed answer is a diagnosable `CCU_ERROR`; a genuinely unsupported paramset key is still skipped, as before.

## Dead code

- `queryAndCache(deviceType, **deviceAddress**, interfaceName, …)` — accepted, never used, never forwarded to `doQueryAndCache`, whose signature already omitted it.
- `devicesByType`'s `address` field — stored on every entry, never read; `processType`'s own parameter type didn't include it.

`tsconfig.json` sets `strict: true` but not `noUnusedParameters`, so neither was flagged. Worth considering separately.

## Note

`npm run lint`'s second pass (`tsc -p tsconfig.test.json`) caught the three test call sites of the changed signature. `npm test` alone would not have — the exact reason CLAUDE.md insists on running lint before pushing.

425 tests pass, unchanged in count: this is a refactor, and the existing `device-type-cache` and `device-type-cache-warm` suites already cover both paths through the extracted code.