### PR TITLE
fix(http): don't write a JSON body into an already-streaming response

### DIFF
--- a/src/http/error-response.ts
+++ b/src/http/error-response.ts
@@ -1,0 +1,25 @@
+import type { ServerResponse } from "node:http";
+
+/**
+ * Terminate a response after an unexpected handler failure.
+ *
+ * Split out of the HTTP handler's catch-all so it can be unit-tested:
+ * `src/index.ts` calls `main()` at module scope, so a test cannot import it
+ * without starting a server.
+ *
+ * The `headersSent` branch is the point. A GET opens the long-lived SSE
+ * notification stream, which commits its headers the moment it opens; any
+ * later rejection lands in the catch with a response already in flight.
+ * Writing a JSON body there appended it INTO the event stream, where it is
+ * neither a valid `data:` frame nor an event boundary — clients saw a parse
+ * error rather than a clean close (issue #123). End the stream instead and
+ * let the client reconnect.
+ */
+export function endWithInternalError(res: ServerResponse): void {
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+  res.writeHead(500, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Internal error" }));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { TargetRegistry, TargetSelection } from "./ccu/target-registry.js";
 import { ResourcePoller } from "./resources/poller.js";
 import { resolveAuthTokens, startAutoRotation } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
+import { endWithInternalError } from "./http/error-response.js";
 import { createMcpServer, serverSubscriptions, type ServerDeps } from "./server.js";
 import { extractBearerToken, normalizeClientIp, VERSION, loadBuildInfo } from "./utils.js";
 
@@ -412,10 +413,7 @@ async function main(): Promise<void> {
       } catch (err) {
         // One bad request must not take down the process (unhandled rejection)
         logger.error("http_handler_error", { error: (err as Error).message });
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-        }
-        res.end(JSON.stringify({ error: "Internal error" }));
+        endWithInternalError(res);
       }
     };
 

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -144,8 +144,11 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             })),
           }));
 
-      log({ deviceCount: devices.length });
-      return structuredResult({ devices: Array.isArray(output) ? output : [] }, output);
+      // Count what is RETURNED, not what was fetched: the unfiltered path drops
+      // the 50-channel virtual receivers below, so the old pre-filter count was
+      // 1-2 higher than the list the caller got (issue #124).
+      log({ deviceCount: output.length });
+      return structuredResult({ devices: output }, output);
     }),
   );
 }
@@ -243,7 +246,7 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
         programs = programs.filter((p) => p.name.toLowerCase().includes(needle));
       }
 
-      return structuredResult({ programs: Array.isArray(programs) ? programs : [] }, programs);
+      return structuredResult({ programs }, programs);
     }),
   );
 }
@@ -272,7 +275,7 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
         sysvars = sysvars.filter((v) => v.name.toLowerCase().includes(needle));
       }
 
-      return structuredResult({ systemVariables: Array.isArray(sysvars) ? sysvars : [] }, sysvars);
+      return structuredResult({ systemVariables: sysvars }, sysvars);
     }),
   );
 }

--- a/test/unit/http-error-response.test.ts
+++ b/test/unit/http-error-response.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ServerResponse } from "node:http";
+import { endWithInternalError } from "../../src/http/error-response.js";
+
+/** Minimal ServerResponse stand-in recording what the handler did to it. */
+function fakeRes(headersSent: boolean) {
+  const res = {
+    headersSent,
+    writeHead: vi.fn(),
+    end: vi.fn(),
+  };
+  return res as unknown as ServerResponse & typeof res;
+}
+
+describe("endWithInternalError", () => {
+  it("sends a 500 JSON body when nothing has been written yet", () => {
+    const res = fakeRes(false);
+    endWithInternalError(res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(500, { "Content-Type": "application/json" });
+    expect(res.end).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(res.end.mock.calls[0]![0] as string)).toEqual({ error: "Internal error" });
+  });
+
+  // Issue #123: the old code guarded writeHead on headersSent but not end(), so
+  // a failure on an already-open SSE stream appended {"error":"Internal error"}
+  // into the event stream — not a valid `data:` frame, not an event boundary.
+  it("closes an already-committed response without writing a body into it", () => {
+    const res = fakeRes(true);
+    endWithInternalError(res);
+
+    expect(res.writeHead).not.toHaveBeenCalled();
+    expect(res.end).toHaveBeenCalledTimes(1);
+    // the decisive assertion: end() called with NO payload
+    expect(res.end.mock.calls[0]).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #123. Completes #124 (its `config.ts` half landed in #133).

## #123 — SSE stream corruption

The catch-all guarded `writeHead` on `headersSent`, but not `end`:

```ts
if (!res.headersSent) {
  res.writeHead(500, { "Content-Type": "application/json" });
}
res.end(JSON.stringify({ error: "Internal error" }));   // ← runs either way
```

A GET opens the long-lived SSE notification stream, which commits its headers the moment it opens. Any later rejection from `transport.handleRequest` — or from the poller writing into a dead socket — lands here with a response in flight, and the JSON gets appended **into the event stream**. It is neither a valid `data:` frame nor an event boundary, so the client sees a parse error rather than a clean close.

Now the stream is simply ended and the client can reconnect.

### On testability

Extracted as `endWithInternalError()` in `src/http/error-response.ts`. `src/index.ts` calls `main()` at module scope, so no unit test can import the handler without starting a server — which is also why `index.ts` reads as 0% coverage. Moving the branch out makes it directly assertable, and the decisive assertion is that `end()` is called with **no payload** on a committed response.

## #124 — `discovery.ts` remainder

- `list_devices` logged `deviceCount` before the `HIDDEN_TYPES` filter, so `tool_call … deviceCount:` was 1–2 higher than the list the caller received. It now logs what it returns.
- Three `Array.isArray(x) ? x : []` fallbacks were unreachable: `expectArray()` already throws for anything that is not an array, and `list_devices`' `output` is a ternary between an array and a `.map()`. Removed — they implied a doubt that does not exist.

The `Array.isArray` in `list_links` **stays**: `Interface.getLinks` can legitimately answer a non-array for an interface that doesn't expose links, and that path is a `continue`, not an error.

425 → 431 tests.