### PR TITLE
docs(server.json): document the 10 missing stdio env vars, and guard against drift

### DIFF
--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -48,6 +48,19 @@ if (pkg.mcpName !== server.name) {
 rows.push([`${PKG} mcpName`, pkg.mcpName]);
 rows.push([`${SERVER} name`, server.name]);
 
+// 4. The npm package the registry tells people to install must BE this package.
+// Unchecked until now: this repo renamed its npm package once already
+// (debmatic-mcp -> ccu-mcp, v1.5.0), and had `identifier` been missed in that
+// rename every gate in the release runbook would still have gone green while
+// the registry pointed users at the deprecated package.
+packages.forEach((p, i) => {
+  if (p.registryType === "npm" && p.identifier !== pkg.name) {
+    problems.push(`${SERVER} packages[${i}].identifier "${p.identifier}" != ${PKG} name "${pkg.name}"`);
+  }
+  rows.push([`${SERVER} packages[${i}].identifier`, p.identifier]);
+});
+rows.push([`${PKG} name`, pkg.name]);
+
 const width = Math.max(...rows.map(([label]) => label.length));
 for (const [label, value] of rows) {
   console.log(`  ${label.padEnd(width)}  ${value}`);

--- a/scripts/sync-server-version.mjs
+++ b/scripts/sync-server-version.mjs
@@ -16,8 +16,9 @@ const PKG = process.env.PKG_FILE ?? "package.json";
 const SERVER = process.env.SERVER_FILE ?? "server.json";
 
 const pkg = JSON.parse(readFileSync(PKG, "utf8"));
-const raw = readFileSync(SERVER, "utf8");
-const server = JSON.parse(raw);
+// (the raw text is not needed beyond parsing — JSON.stringify(…, 2) below is
+// what preserves the 2-space indentation and trailing newline)
+const server = JSON.parse(readFileSync(SERVER, "utf8"));
 
 const version = pkg.version;
 if (!version) {

--- a/server.json
+++ b/server.json
@@ -79,6 +79,64 @@
           "name": "CCU_DEFAULT_PROFILE",
           "description": "Which profile from CCU_PROFILES is active at startup (default: the first listed)",
           "format": "string"
+        },
+        {
+          "name": "CCU_TLS_VERIFY",
+          "description": "Verify the CCU's TLS certificate against the system trust store. Only meaningful with CCU_HTTPS=true. Default false, because a CCU ships a self-signed certificate — prefer CCU_TLS_FINGERPRINT or CCU_CA_CERT to verify one of those",
+          "default": "false",
+          "format": "boolean"
+        },
+        {
+          "name": "CCU_TLS_FINGERPRINT",
+          "description": "Pin the CCU's self-signed leaf certificate by its SHA-256 fingerprint (hex, colons optional). The strongest option for an appliance: the connection is rejected unless the presented certificate matches. Takes precedence over CCU_CA_CERT",
+          "format": "string"
+        },
+        {
+          "name": "CCU_CA_CERT",
+          "description": "Path to a PEM file holding the CCU's CA or self-signed certificate. The connection is then validated against it with standard chain verification",
+          "format": "string"
+        },
+        {
+          "name": "CCU_TIMEOUT",
+          "description": "Timeout for a CCU JSON-RPC call, in MILLISECONDS",
+          "default": "10000",
+          "format": "number"
+        },
+        {
+          "name": "CCU_SCRIPT_TIMEOUT",
+          "description": "Timeout for HomeMatic Script execution (ReGa), in MILLISECONDS — scripts are slower than plain API calls",
+          "default": "30000",
+          "format": "number"
+        },
+        {
+          "name": "CACHE_TTL",
+          "description": "Lifetime of the on-disk device-type schema cache, in SECONDS",
+          "default": "86400",
+          "format": "number"
+        },
+        {
+          "name": "CCU_RATE_LIMIT_BURST",
+          "description": "Token-bucket burst size for CCU requests — how many may be issued back to back",
+          "default": "20",
+          "format": "number"
+        },
+        {
+          "name": "CCU_RATE_LIMIT_RATE",
+          "description": "Sustained CCU request rate, in requests per second",
+          "default": "10",
+          "format": "number"
+        },
+        {
+          "name": "RESOURCE_POLL_INTERVAL",
+          "description": "How often MCP resources are polled for change notifications, in SECONDS",
+          "default": "60",
+          "format": "number"
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "error | warn | info | debug. Logs are structured JSON on stderr",
+          "default": "info",
+          "format": "string"
         }
       ]
     }

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -46,6 +46,43 @@ function envKeysInExample(): Set<string> {
   return keys;
 }
 
+// server.json is the MCP REGISTRY manifest — what someone installing from the
+// registry reads. It drifted to 10 of 30 variables because nothing checked it
+// (issue #126). It is not a straight mirror of the code: the manifest declares
+// the STDIO package, so the HTTP-transport variables genuinely do not apply.
+// List those exemptions explicitly, so the exemption is a decision on the
+// record rather than an omission.
+const SERVER_JSON = join(__dirname, "../../server.json");
+const HTTP_ONLY_VARS = new Set([
+  "MCP_TRANSPORT", "MCP_PORT", "MCP_HOST",
+  "MCP_AUTH_TOKEN", "MCP_AUTH_TOKEN_PREVIOUS", "MCP_AUTH_TOKEN_TTL_DAYS", "MCP_AUTH_TOKEN_GRACE_HOURS",
+  "MCP_TLS_CERT", "MCP_TLS_KEY", "MCP_ALLOW_PLAINTEXT",
+  "MCP_ALLOWED_ORIGINS", "MCP_ALLOWED_HOSTS",
+]);
+
+describe("server.json (MCP registry manifest)", () => {
+  const manifest = () => JSON.parse(readFileSync(SERVER_JSON, "utf-8"));
+
+  it("documents every env var that applies to the stdio package", () => {
+    const declared = new Set<string>(
+      (manifest().packages[0].environmentVariables ?? []).map((v: { name: string }) => v.name),
+    );
+    const missing = [...envKeysReferencedInCode()]
+      .filter((k) => !HTTP_ONLY_VARS.has(k) && !declared.has(k))
+      .sort();
+    expect(missing, `env vars read in code but missing from server.json: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("does not declare env vars the code never reads", () => {
+    const code = envKeysReferencedInCode();
+    const stale = ((manifest().packages[0].environmentVariables ?? []) as Array<{ name: string }>)
+      .map((v) => v.name)
+      .filter((n) => !code.has(n))
+      .sort();
+    expect(stale, `env vars in server.json not read anywhere in code: ${stale.join(", ")}`).toEqual([]);
+  });
+});
+
 describe(".env.example", () => {
   it("documents every env var the code reads", () => {
     const code = envKeysReferencedInCode();


### PR DESCRIPTION
Closes #126.

## The gap

`server.json` is the MCP **registry** manifest — what someone installing from the registry reads. It declared 10 of the 30 variables `config.ts` reads.

The manifest declares `transport: stdio` with `packageArguments: ["--stdio"]`, so the 12 HTTP-transport variables genuinely don't apply to that package and stay out. The remaining 10 do apply, and are now documented.

The important ones are the CCU TLS trio. `CCU_HTTPS` **was** documented; `CCU_TLS_VERIFY`, `CCU_TLS_FINGERPRINT` and `CCU_CA_CERT` were not — so the manifest told a user how to turn on HTTPS but not how to *verify* the certificate, and the default with none of them set is an unverified connection that `src/ccu/client.ts` itself warns about (`ccu_tls_unverified`). Also added `CCU_TIMEOUT`, `CCU_SCRIPT_TIMEOUT`, `CACHE_TTL`, both rate-limit knobs, `RESOURCE_POLL_INTERVAL` and `LOG_LEVEL` — with units stated, since #119 just showed how easily those are misread.

## Stopping it drifting again

`test/unit/env-example-sync.test.ts` already guarded `.env.example` in both directions. It now does the same for `server.json`, reusing the same scanner.

The HTTP-only exemptions are an **explicit list** in the test, not a silent filter, so leaving a variable out is a decision on the record.

I mutation-checked the guard rather than trusting it: removing `CCU_TLS_FINGERPRINT` from the manifest fails the test with the variable named. It is not passing vacuously.

## Release-gate gap in the same area

`scripts/check-version-sync.mjs` runs as a `build-and-test` step *and* on `prepublishOnly`, and its header advertises checking "the package identity". It compared versions and `mcpName` ↔ `server.name`, but never `package.json name` ↔ `packages[0].identifier` — the field telling the registry which npm package to install.

This repo renamed its npm package once already (`debmatic-mcp` → `ccu-mcp`, v1.5.0). Had `identifier` been missed in that rename, every gate in the runbook would have stayed green while the registry pointed users at the now-deprecated package. Now checked, and shown in the gate's output table.

Also dropped the unused `raw` binding in `sync-server-version.mjs`.