### PR TITLE
ci: close the fork-PR gap on dev, add a coverage floor, harden the e2e suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,24 @@ name: CI
 on:
   push:
     branches: ["**"]
+  # `dev` must be listed, not just `main`. build-and-test is a required check on
+  # BOTH branches, but on dev it only ever reported via the `push` trigger above
+  # — and a pull request from a FORK pushes to the fork, so no push event fires
+  # here. A fork PR into dev therefore ran no checks at all (issue #127), while
+  # dev is the documented branch to target.
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 # Least privilege: CI only reads the repo (build + test).
 permissions:
   contents: read
+
+# A same-repo branch with an open PR now matches both triggers above, and
+# pushing twice in quick succession used to run the full job to completion for
+# every commit. Supersede instead.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # HERMETIC ONLY. Every step below is a function of the commit under test:
@@ -46,8 +58,12 @@ jobs:
       - name: Type check
         run: npm run lint
 
-      - name: Build
-        run: npm run build
-
+      # No separate Build step: package.json's `pretest` already runs
+      # `npm run build`, so an explicit one compiled the tree twice per run.
+      # A compile error surfaces in Type check above, which covers both
+      # tsconfigs, so nothing is lost in failure attribution.
+      # --coverage so vitest.config.ts's thresholds are actually enforced; a
+      # floor nothing measures is decoration. Still hermetic: coverage is a
+      # function of this commit alone.
       - name: Test
-        run: npm test
+        run: npm test -- --coverage

--- a/test/e2e/_dist.ts
+++ b/test/e2e/_dist.ts
@@ -1,0 +1,41 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/** The built server every e2e suite spawns. */
+export const DIST = join(__dirname, "../../dist/index.js");
+
+// `describe.skipIf(!existsSync(DIST))` is convenient locally — bare
+// `npx vitest` with no build shouldn't explode. But it makes a missing dist/ a
+// SILENT PASS: every e2e block skips and the run still exits 0, which is
+// indistinguishable from "the e2e suites passed". Since these six blocks are
+// ALL the integration coverage there is, that is exactly the false green
+// CLAUDE.md warns about in prose (issue #128).
+//
+// `npm test` builds via `pretest`, so this can only fire if that guarantee is
+// removed or reordered. In CI, say so loudly rather than reporting success.
+if (process.env.CI && !existsSync(DIST)) {
+  throw new Error(
+    "dist/ is missing in CI — the e2e suites would silently skip and the run would still pass. " +
+      "Run `npm run build` first (`npm test` does this via pretest).",
+  );
+}
+
+/** Gate for `describe.skipIf(...)`. Evaluated once, after the CI check above. */
+export const distMissing = !existsSync(DIST);
+
+/**
+ * A listening port for an e2e server, unique per (vitest worker, slot).
+ *
+ * Was `20000 + Math.floor(Math.random() * 20000)` in four separate blocks, with
+ * no coordination and no retry. Vitest runs files in parallel, so two servers
+ * could draw the same port; the second got EADDRINUSE, exited, and the readiness
+ * poll then failed with "server did not start" — pointing at the CCU mock rather
+ * than at the port clash. Rare, unreproducible, and far more expensive to
+ * diagnose than to prevent (issue #128).
+ *
+ * `slot` must be distinct per describe block within a file.
+ */
+export function e2ePort(slot: number): number {
+  const worker = Number(process.env.VITEST_WORKER_ID ?? 1);
+  return 20000 + worker * 100 + slot;
+}

--- a/test/e2e/cli-flags.test.ts
+++ b/test/e2e/cli-flags.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { DIST, distMissing } from "./_dist.js";
 
 // Issue #112: --version and --help must work with NO environment at all.
 // main() used to call loadConfig() before looking at argv, so both flags died
@@ -11,7 +12,6 @@ import { join } from "node:path";
 // Running with a scrubbed env is the whole point of these tests: the bug was
 // precisely that these paths depended on the environment.
 
-const DIST = join(__dirname, "../../dist/index.js");
 const PKG_VERSION = JSON.parse(
   readFileSync(join(__dirname, "../../package.json"), "utf-8"),
 ) as { version: string };
@@ -25,7 +25,7 @@ function runBare(...args: string[]) {
   });
 }
 
-describe.skipIf(!existsSync(DIST))("CLI info flags (no environment)", () => {
+describe.skipIf(distMissing)("CLI info flags (no environment)", () => {
   it("--version prints the package version and exits 0", () => {
     const res = runBare("--version");
     expect(res.status).toBe(0);

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -2,17 +2,17 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createServer, request, type Server, type IncomingHttpHeaders } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { AddressInfo } from "node:net";
+import { DIST, distMissing, e2ePort } from "./_dist.js";
 
 // End-to-end test of the HTTP transport against the BUILT server (dist/) with a
 // mocked CCU. Regression test for issue #17: a reused stateless transport broke
 // every request after the first; the server must support multiple requests per
 // session and multiple concurrent sessions.
 
-const DIST = join(__dirname, "../../dist/index.js");
 const AUTH_TOKEN = "e2e-test-token";
 
 /**
@@ -90,14 +90,14 @@ async function parseSse(res: Response): Promise<any> {
 // Degraded startup: the server must come up and speak MCP even when the CCU
 // is unreachable (required for CCU outages and for Glama's containerized
 // build checks, which start the server with placeholder credentials).
-describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () => {
+describe.skipIf(distMissing)("degraded startup e2e (CCU unreachable)", () => {
   let child: ChildProcess;
   let mcpPort: number;
   let cacheDir: string;
 
   beforeAll(async () => {
     cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-degraded-"));
-    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+    mcpPort = e2ePort(0);
 
     child = spawn("node", [DIST], {
       env: {
@@ -176,16 +176,17 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
   });
 });
 
-describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU)", () => {
+describe.skipIf(distMissing)("HTTP transport e2e (built server, mocked CCU)", () => {
   let ccu: { server: Server; port: number };
   let child: ChildProcess;
   let mcpPort: number;
   let cacheDir: string;
+  let stderrLines: string[];
 
   beforeAll(async () => {
     ccu = await startCcuMock();
     cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-"));
-    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+    mcpPort = e2ePort(1);
 
     child = spawn("node", [DIST], {
       env: {
@@ -203,9 +204,18 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
         MCP_ALLOWED_ORIGINS: ALLOWED_ORIGIN,
         CACHE_DIR: cacheDir,
         RESOURCE_POLL_INTERVAL: "3600",
-        LOG_LEVEL: "error",
+        // warn, not error: auth_failed is a warn-level line, and the fail2ban
+        // filter test below asserts against the real thing (issue #129).
+        LOG_LEVEL: "warn",
       },
       stdio: ["ignore", "ignore", "pipe"],
+    });
+    // Drain stderr — both to keep the assertion below honest and so the pipe
+    // buffer can't fill and stall the child.
+    stderrLines = [];
+    child.stderr!.setEncoding("utf-8");
+    child.stderr!.on("data", (chunk: string) => {
+      for (const line of chunk.split("\n")) if (line.trim()) stderrLines.push(line);
     });
 
     // Wait for the port to accept connections
@@ -227,6 +237,39 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
     ccu?.server.close();
     rmSync(cacheDir, { recursive: true, force: true });
   });
+
+  // Issue #129: the fail2ban unit test asserts against a hand-mirrored copy of
+  // this log line, not the line src/index.ts actually writes — so adding a
+  // field ahead of `client` would break every deployed jail while that test
+  // stayed green. Close the loop against the real process here.
+  it("emits an auth_failed line the committed fail2ban filter matches", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer wrong-token" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    expect(res.status).toBe(401);
+
+    // give the child a moment to flush the line
+    const deadline = Date.now() + 5_000;
+    let line: string | undefined;
+    while (Date.now() < deadline) {
+      line = stderrLines.find((l) => l.includes('"msg":"auth_failed"'));
+      if (line) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(line, `no auth_failed line in stderr: ${stderrLines.join(" | ")}`).toBeTruthy();
+
+    // the SHIPPED filter regex, read from the file operators install
+    const conf = readFileSync(join(__dirname, "../../fail2ban/filter.d/ccu-mcp.conf"), "utf-8");
+    const pattern = conf.match(/^failregex\s*=\s*(.+)$/m)?.[1];
+    expect(pattern, "filter must define a failregex").toBeTruthy();
+    const re = new RegExp(pattern!.replace("<HOST>", "([0-9a-fA-F:.]+)"));
+
+    const m = line!.match(re);
+    expect(m, `shipped fail2ban filter did not match the real line: ${line}`).not.toBeNull();
+    expect(m![1]).toMatch(/^(127\.0\.0\.1|::1)$/); // <HOST> captures the peer IP
+  }, 15_000);
 
   it("serves the health endpoint without auth (liveness only)", async () => {
     const res = await fetch(`http://127.0.0.1:${mcpPort}/health`);
@@ -451,7 +494,7 @@ const INIT_BODY = {
   params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "secure", version: "1" } },
 };
 
-describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebinding on)", () => {
+describe.skipIf(distMissing)("secure HTTP defaults e2e (no CORS, DNS-rebinding on)", () => {
   let ccu: { server: Server; port: number };
   let child: ChildProcess;
   let mcpPort: number;
@@ -460,7 +503,7 @@ describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebin
   beforeAll(async () => {
     ccu = await startCcuMock();
     cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-secure-"));
-    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+    mcpPort = e2ePort(2);
 
     child = spawn("node", [DIST], {
       env: {
@@ -571,7 +614,7 @@ function httpsJson(
   });
 }
 
-describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native TLS, mocked CCU)", () => {
+describe.skipIf(distMissing || !HAVE_OPENSSL)("HTTPS transport e2e (native TLS, mocked CCU)", () => {
   let ccu: { server: Server; port: number };
   let child: ChildProcess;
   let mcpPort: number;
@@ -581,7 +624,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   beforeAll(async () => {
     ccu = await startCcuMock();
     cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-tls-"));
-    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+    mcpPort = e2ePort(3);
 
     // Mint a throwaway self-signed cert. The SAN must include IP:127.0.0.1 —
     // Node (>=17) no longer falls back to the subject CN for identity checks,

--- a/test/e2e/stdio-transport.test.ts
+++ b/test/e2e/stdio-transport.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createServer, type Server } from "node:http";
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { AddressInfo } from "node:net";
+import { DIST, distMissing } from "./_dist.js";
 
 // End-to-end test of the STDIO transport against the BUILT server (dist/) with
 // a mocked CCU. stdio is the documented default install path
@@ -17,7 +18,6 @@ import { AddressInfo } from "node:net";
 // exit via event-loop drain with no Session.logout — leaking a CCU session
 // toward "too many sessions" — and no cache save.
 
-const DIST = join(__dirname, "../../dist/index.js");
 
 /** process.env with every server config var scrubbed (see http-transport e2e). */
 function cleanEnv(): Record<string, string | undefined> {
@@ -108,7 +108,7 @@ class StdioClient {
   }
 }
 
-describe.skipIf(!existsSync(DIST))("stdio transport e2e (built server, mocked CCU)", () => {
+describe.skipIf(distMissing)("stdio transport e2e (built server, mocked CCU)", () => {
   let ccu: CcuMock;
   let child: ChildProcess;
   let client: StdioClient;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,21 @@ export default defineConfig({
     coverage: {
       // Count every source file, including ones no test imports
       include: ["src/**/*.ts"],
+      // Floor, set just under the numbers at the time of writing so ordinary
+      // work doesn't trip it but a real slide does. Hermetic — a pure function
+      // of the commit under test, so it stays inside the `build-and-test`
+      // contract described in ci.yml.
+      //
+      // GLOBAL only, deliberately: src/index.ts reads as 0% because the e2e
+      // suites spawn it as a subprocess and v8 coverage cannot attribute those.
+      // A per-file threshold would fail on it permanently, for a measurement
+      // artifact rather than a real gap.
+      thresholds: {
+        statements: 85,
+        branches: 79,
+        functions: 87,
+        lines: 85,
+      },
     },
   },
 });


### PR DESCRIPTION
Closes #127, closes #128, closes #129.

## #127 — a fork PR into `dev` ran no checks at all

`build-and-test` is a required check on **both** `main` and `dev`, but `ci.yml` listed only `main` under `pull_request`. On `dev` it reported purely via `push: ["**"]` — and a pull request from a **fork** pushes to the fork, so no `push` event fires in this repo.

`dev` is the branch CLAUDE.md tells contributors to target, and this repo does take outside contributions (the CORS implementation came from @marcinn2, credited in `src/index.ts`). Fixed by adding `dev` to the `pull_request` branches.

Two consequences handled in the same file:

- Same-repo branches with an open PR now match **both** triggers, so a `concurrency` group cancels superseded runs.
- The explicit `Build` step is gone. `package.json`'s `pretest` already runs `npm run build`, so every run compiled the tree twice; a compile error still surfaces in `Type check`, which covers both tsconfigs.

## Coverage floor

`vitest.config.ts` gains thresholds set just under the current numbers (85.78 / 79.82 / 88.22 / 86.26), and the CI Test step runs `--coverage` so they are actually enforced — a floor nothing measures is decoration.

**Global thresholds only, deliberately.** `src/index.ts` reads as 0% because the e2e suites spawn it as a subprocess and v8 coverage cannot attribute those. A per-file threshold would fail on it permanently, for a measurement artifact rather than a real gap. Still hermetic: coverage is a function of the commit alone, so this stays inside the `build-and-test` contract.

## #128 — e2e suites could pass by not running

All six e2e blocks were `describe.skipIf(!existsSync(DIST))`. `skipIf` reports *skipped*, so a missing `dist/` meant every integration test vanished and the run still exited 0 — indistinguishable from "e2e passed", and those six blocks are all the integration coverage there is.

Now a hard failure under `CI`, still a skip locally where bare `npx vitest` shouldn't explode.

I hit this myself while writing the PR: after a mutation experiment rebuilt `dist/`, a bare `npx vitest run --coverage` failed against the stale build. Exactly the trap.

The four `20000 + Math.random() * 20000` ports are now deterministic per (vitest worker, slot). Nothing coordinated the draws and there was no retry, so a collision gave the second server `EADDRINUSE` and surfaced 15 seconds later as `server did not start` — pointing at the CCU mock rather than the port clash.

## #129 — the fail2ban guard didn't guard

`test/unit/fail2ban-filter.test.ts` claims to lock the log line in `src/index.ts` against the shipped filter regex. It doesn't: it asserts against a hand-maintained copy in its own helper. Adding a field ahead of `client` — say a `reason` distinguishing an expired token from a wrong one — silently breaks every deployed jail while the test stays green.

Added an e2e assertion that provokes a real 401 against the spawned server, captures its stderr, and matches the line against the `failregex` read from `fail2ban/filter.d/ccu-mcp.conf`. That block needed `LOG_LEVEL: warn` (auth_failed is warn-level) and a stderr drain.

**Mutation-verified rather than assumed.** Inserting `reason: "drift"` ahead of `client` fails it with the real line quoted:

```
shipped fail2ban filter did not match the real line:
{"ts":"…","level":"warn","msg":"auth_failed","reason":"drift","client":"127.0.0.1","hadToken":true}
```

The unit test stays — it is fast and covers the strict/loose variant distinction — it just no longer carries the whole claim alone.

431 → 432 tests.