### PR TITLE
docs(changelog): confirm the tclrpc boolean finding against published source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,9 +96,12 @@ all of them.
   change. The concern was that `put_paramset` sends `String(value)` where
   `set_value` sends values raw, which looked like it could turn `false` into a
   truthy `"false"`. Settled by loading the CCU's compiled XML-RPC extension
-  (`tclrpc.so`) in a lab VM and capturing what it actually emits: it follows
-  `Tcl_GetBooleanFromObj`, so `"false"` encodes to `<boolean>0</boolean>` and
-  anything that isn't a boolean is *rejected* rather than coerced.
+  (`tclrpc.so`) in a lab VM and capturing what it actually emits: `"false"`
+  encodes to `<boolean>0</boolean>`, and anything that isn't a boolean is
+  *rejected* rather than coerced. Since confirmed against the extension's source,
+  published in the meantime as `src/tclrpc/tclrpc.cpp` in `OpenCCU/OpenCCU-Base`:
+  the `bool` branch converts with `Tcl_GetBoolean` and propagates its error,
+  which is exactly the observed behaviour.
 
 ### Dependencies
 


### PR DESCRIPTION
The v1.9.0 changelog notes that #125 was settled by capturing `tclrpc.so`'s output, since the extension ships compiled-only.

That source has since been published as `src/tclrpc/tclrpc.cpp` in [OpenCCU/OpenCCU-Base](https://github.com/OpenCCU/OpenCCU-Base), and it confirms the captured behaviour exactly — the `bool` branch converts with `Tcl_GetBoolean` and propagates a conversion failure rather than coercing:

```cpp
}else if(strstr(type, "bool")==type){//bool
    int b;
    retval=Tcl_GetBoolean(interp, value, &b);
    if(retval==TCL_OK)(bool&)v=(b!=0);
```

Also corrects the function name — `Tcl_GetBoolean`, not `Tcl_GetBooleanFromObj`. Same semantics, wrong symbol.

Docs only. Lint and tests pass.