### PR TITLE
chore(release): v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
-## v1.9.0 — unreleased
+## v1.9.0 — 2026-07-31
 
 A correctness release. A sustained review pass over the whole source tree found
 two classes of problem worth a version of their own: places where a *failed*
@@ -102,6 +102,11 @@ all of them.
   published in the meantime as `src/tclrpc/tclrpc.cpp` in `OpenCCU/OpenCCU-Base`:
   the `bool` branch converts with `Tcl_GetBoolean` and propagates its error,
   which is exactly the observed behaviour.
+
+- The `help` tool's per-tool text now states the error contracts this release
+  added, so the in-band documentation matches the code: `put_paramset` on an
+  empty `set`, the `CCU_ERROR` raised when a system-variable write or delete
+  fails, and the widened `INVALID_INPUT` cases in `create_system_variable`.
 
 ### Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.8.1",
+  "version": "1.9.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -133,12 +133,14 @@ Idempotent: yes`,
 Args: address (string), paramsetKey ("VALUES"|"MASTER"), set (object with key:value pairs, e.g. {"TEMPERATURE_WINDOW_OPEN": 5.0}), interface? (auto), confirm? (true to authorize on a protected target)
 The set object uses simple key:value format — types are auto-resolved from the device type cache. Values are converted to strings internally.
 Returns: {address, paramsetKey, written}
+INVALID_INPUT if 'set' is empty — there is nothing to write.
 Idempotent: yes`,
 
   set_system_variable: `Set a system variable (type auto-detected).
 Args: name (string), value (string|number|boolean), confirm? (true to authorize on a protected target)
 Enum (LIST) variables accept a 0-based index or one of the enum's labels.
 Returns: {name, value, method}
+CCU_ERROR if the CCU reports the write failed — the value was NOT written.
 Idempotent: yes`,
 
   create_system_variable: `Create a new system variable.
@@ -146,12 +148,13 @@ Args: name (string), type ("bool"|"float"|"enum"|"string"), description? (string
   unit?/min?/max? (float only), values? (string[], required for enum; labels must not contain ";"),
   confirm? (true to authorize on a protected target)
 Returns: {name, type, created: true}
-INVALID_INPUT if the name already exists (or enum without values). Use set_system_variable to write it.`,
+INVALID_INPUT if the name already exists, an enum has no values, min >= max, or an
+argument doesn't apply to the chosen type. Use set_system_variable to write it.`,
 
   delete_system_variable: `Delete a system variable by name.
 Args: name (string, exact match), confirm (REQUIRED true on every call against a protected target — never rides on the session unlock)
 Returns: {name, deleted: true}
-NOT_FOUND if the name doesn't exist.`,
+NOT_FOUND if the name doesn't exist; CCU_ERROR if the CCU reports the delete failed.`,
 
   assign_channel: `Assign a channel to a room and/or function group.
 Args: channel (address), room? (name), function? (name) — at least one of room/function; confirm? (true to authorize on a protected target)


### PR DESCRIPTION
Version bump and release-notes date for v1.9.0, plus the one gap the
documentation review found.

- `npm version minor` — `package.json`, `server.json` root `version` and
  `packages[0].version` all at 1.9.0; `npm run check:versions` passes.
- `CHANGELOG.md` v1.9.0 section dated 2026-07-31.
- `src/tools/meta.ts` — the `help` tool's per-tool text still described the
  pre-1.9.0 error contracts. #131, #132 and #122 added error paths that the
  in-band docs didn't mention: `put_paramset` on an empty `set`, the
  `CCU_ERROR` on a failed system-variable write or delete, and the widened
  `INVALID_INPUT` cases in `create_system_variable`.

Pre-flight, all green: `npm run lint`, `npm test` (434 passed, 26 skipped —
the `CCU_HOST`-gated live suite), `npm publish --dry-run` (120 files,
`dist/` only), `mcp-publisher validate`.