### PR TITLE
Release v1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,24 @@ name: CI
 on:
   push:
     branches: ["**"]
+  # `dev` must be listed, not just `main`. build-and-test is a required check on
+  # BOTH branches, but on dev it only ever reported via the `push` trigger above
+  # — and a pull request from a FORK pushes to the fork, so no push event fires
+  # here. A fork PR into dev therefore ran no checks at all (issue #127), while
+  # dev is the documented branch to target.
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 # Least privilege: CI only reads the repo (build + test).
 permissions:
   contents: read
+
+# A same-repo branch with an open PR now matches both triggers above, and
+# pushing twice in quick succession used to run the full job to completion for
+# every commit. Supersede instead.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # HERMETIC ONLY. Every step below is a function of the commit under test:
@@ -46,8 +58,12 @@ jobs:
       - name: Type check
         run: npm run lint
 
-      - name: Build
-        run: npm run build
-
+      # No separate Build step: package.json's `pretest` already runs
+      # `npm run build`, so an explicit one compiled the tree twice per run.
+      # A compile error surfaces in Type check above, which covers both
+      # tsconfigs, so nothing is lost in failure attribution.
+      # --coverage so vitest.config.ts's thresholds are actually enforced; a
+      # floor nothing measures is decoration. Still hermetic: coverage is a
+      # function of this commit alone.
       - name: Test
-        run: npm test
+        run: npm test -- --coverage

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 CLAUDE.md
 features.md
 QA-FINDINGS.md
+TESTCHAIN.md
 
 # OS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ coverage/
 
 # Local review reports
 code-review-report.md
+
+# Drafts of upstream (OCCU/OpenCCU) issue reports — written here, filed there
+occu-issue-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,9 +96,12 @@ all of them.
   change. The concern was that `put_paramset` sends `String(value)` where
   `set_value` sends values raw, which looked like it could turn `false` into a
   truthy `"false"`. Settled by loading the CCU's compiled XML-RPC extension
-  (`tclrpc.so`) in a lab VM and capturing what it actually emits: it follows
-  `Tcl_GetBooleanFromObj`, so `"false"` encodes to `<boolean>0</boolean>` and
-  anything that isn't a boolean is *rejected* rather than coerced.
+  (`tclrpc.so`) in a lab VM and capturing what it actually emits: `"false"`
+  encodes to `<boolean>0</boolean>`, and anything that isn't a boolean is
+  *rejected* rather than coerced. Since confirmed against the extension's source,
+  published in the meantime as `src/tclrpc/tclrpc.cpp` in `OpenCCU/OpenCCU-Base`:
+  the `bool` branch converts with `Tcl_GetBoolean` and propagates its error,
+  which is exactly the observed behaviour.
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
-## v1.9.0 — unreleased
+## v1.9.0 — 2026-07-31
 
 A correctness release. A sustained review pass over the whole source tree found
 two classes of problem worth a version of their own: places where a *failed*
@@ -102,6 +102,11 @@ all of them.
   published in the meantime as `src/tclrpc/tclrpc.cpp` in `OpenCCU/OpenCCU-Base`:
   the `bool` branch converts with `Tcl_GetBoolean` and propagates its error,
   which is exactly the observed behaviour.
+
+- The `help` tool's per-tool text now states the error contracts this release
+  added, so the in-band documentation matches the code: `put_paramset` on an
+  empty `set`, the `CCU_ERROR` raised when a system-variable write or delete
+  fails, and the widened `INVALID_INPUT` cases in `create_system_variable`.
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,107 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
+## v1.9.0 — unreleased
+
+A correctness release. A sustained review pass over the whole source tree found
+two classes of problem worth a version of their own: places where a *failed*
+CCU write was reported to the client as success, and places where a malformed
+environment variable was silently reinterpreted as something else rather than
+rejected. Both fail in the same direction — quietly, and in the direction that
+looks like everything worked.
+
+### Behavior changes (read before upgrading)
+
+- **Malformed numeric settings now abort startup instead of being partially
+  parsed.** The old code used `parseInt`, which stops at the first non-digit and
+  keeps what it has: `CCU_TIMEOUT=30s` became a **30 millisecond** timeout, so
+  every call failed and the value that caused it looked entirely reasonable in
+  the env file. `30.5` truncated to 30, and `1e4` became 1. All of these are now
+  rejected by name. Affects ports, timeouts, `CACHE_TTL`, the rate limits and
+  `RESOURCE_POLL_INTERVAL`.
+- **Boolean settings are trimmed, and anything that isn't a boolean aborts
+  startup.** They were previously compared with `=== "true"` against the raw
+  value, so `CCU_PROD_PROTECTED=true ` — one trailing space, invisible in an env
+  file — evaluated to *false* and silently switched the write-confirmation gate
+  off on the protected target. That trailing space now works as intended. The
+  other half of the change: `yes`, `1` and `on` used to mean false and now abort
+  instead, for the same reason — a value that reads as "on" must never quietly
+  disable a protection. Affects `CCU_HTTPS`, `CCU_TLS_VERIFY`,
+  `CCU_<NAME>_PROTECTED`, `CCU_<NAME>_READONLY` and `MCP_ALLOW_PLAINTEXT`.
+
+If either of these stops your server starting, the message names the variable
+and shows the value it rejected. The README's *Configuration errors* table lists
+all of them.
+
+### Fixed
+
+- **`set_system_variable` and `delete_system_variable` no longer report success
+  when the CCU says the write failed.** `SysVar.setBool` and `SysVar.setFloat`
+  answer `-1` when the ReGa script engine fails, and `SysVar.deleteSysVarByName`
+  answers a boolean — both were being discarded, so a variable that was never
+  written or never deleted came back as a clean success. They now raise
+  `CCU_ERROR` stating explicitly that the value was **not** written. (One
+  deliberate limit: a float legitimately set to exactly `-1` is
+  indistinguishable from the failure sentinel and is reported as success — the
+  value the CCU would have stored either way.)
+- **The HTTP error path no longer writes a JSON body into an already-streaming
+  response.** An error raised after an SSE stream had started appended a JSON
+  object to the event stream, corrupting it for the connected client. It now
+  ends the response cleanly when headers are already sent.
+- **System-variable creation validates its arguments** instead of accepting
+  input the CCU will reject or silently distort: an `enum` with an empty
+  `valueList`, a `float` with `min >= max`, and arguments that are meaningless
+  for the chosen type (which were being silently ignored, so a typo'd type left
+  you with a variable configured nothing like what you asked for).
+- **`put_paramset` rejects an empty `set` object** rather than reporting a
+  successful write of nothing.
+- The `getValueByName` empty-string error now names both of its causes instead
+  of only one; a TLS configuration hint pointed at the wrong variable name for
+  profile-based setups; and the device-discovery log line counted devices before
+  filtering, so it over-reported.
+
+### Added
+
+- **`--version` and `--help` work without a configured CCU.** Both previously
+  needed a complete environment, which made them useless for the case you most
+  want them in — checking what you have installed while fixing a config.
+- **The README documents every configuration error that aborts startup**, with
+  the cause and the reason the exit is deliberate rather than tolerant.
+- **`server.json` documents 20 environment variables, up from 10.** The missing
+  half included every TLS verification setting — `CCU_TLS_VERIFY`,
+  `CCU_TLS_FINGERPRINT`, `CCU_CA_CERT` — so a registry-driven install had no way
+  to discover that certificate verification was configurable at all. A test now
+  fails when a new stdio-relevant variable is added without a manifest entry.
+
+### Internal
+
+- `DeviceTypeCache`'s paramset-fetch loop was duplicated between `warm()` and
+  `doQueryAndCache()` and the copies had already drifted; it is now one shared
+  method. A swallowed non-array response from `getParamsetDescription` now
+  surfaces as an error, and two dead parameters are gone.
+- CI: `pull_request` runs on `dev`, closing a gap where a fork PR into `dev` ran
+  **no checks at all**; a concurrency group so superseded runs are cancelled; a
+  redundant duplicate build removed; and a coverage floor (85% statements/lines,
+  79% branches, 87% functions) so the ratchet can't slip backwards.
+- The e2e suites no longer skip themselves silently. Every block was guarded on
+  `dist/` existing, so running the tests without a build reported a green run
+  that had executed none of them; in CI a missing `dist/` is now a hard failure.
+  Fixed e2e port slots replace random allocation, which could collide.
+- The fail2ban filter test asserted against a hand-mirrored copy of the log line
+  rather than the one `src/index.ts` emits, so the two could drift apart without
+  failing. It now runs the real server output through the real filter.
+- **`put_paramset`'s value stringification was investigated and is correct** — no
+  change. The concern was that `put_paramset` sends `String(value)` where
+  `set_value` sends values raw, which looked like it could turn `false` into a
+  truthy `"false"`. Settled by loading the CCU's compiled XML-RPC extension
+  (`tclrpc.so`) in a lab VM and capturing what it actually emits: it follows
+  `Tcl_GetBooleanFromObj`, so `"false"` encodes to `<boolean>0</boolean>` and
+  anything that isn't a boolean is *rejected* rather than coerced.
+
+### Dependencies
+
+- @types/node 26.1.1 → 26.1.2.
+
 ## v1.8.1 — 2026-07-28
 
 Security patch release. Clears all six open dependency advisories — two of them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ changes; no behavior changes.
   2.0.12, `hono` 4.12.25 → 4.12.32, `fast-uri` 3.1.2 → 3.1.4, `postcss` 8.5.16 →
   8.5.24, `body-parser` 2.2.2 → 2.3.0, plus `type-is`, `nanoid`, and a nested
   `content-type` carried along by the re-resolution.
+- `undici` 8.8.0 → 8.9.0 (#104) — a routine Dependabot bump, no advisory.
 
 ## v1.8.0 — 2026-07-05
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,31 @@ All configuration is via environment variables:
 | `CCU_RATE_LIMIT_RATE` | `10` | Sustained CCU requests per second |
 | `RESOURCE_POLL_INTERVAL` | `60` | Seconds between polls for MCP resource change notifications |
 
+To drive **several CCUs** from one server, these flat `CCU_*` vars are replaced
+by named profiles — see [Multiple CCU targets](#multiple-ccu-targets-profiles)
+below.
+
+### Command-line flags
+
+```sh
+ccu-mcp --stdio        # serve over stdin/stdout (overrides MCP_TRANSPORT)
+ccu-mcp --http         # serve over HTTP (default)
+ccu-mcp --version      # print the installed version and exit
+ccu-mcp --help         # print usage and exit
+```
+
+`--version` and `--help` need no configuration — use them to check what an
+installed copy actually is, e.g. after updating:
+
+```console
+$ npx ccu-mcp@latest --version
+1.8.1
+```
+
+Note that a bare `npx ccu-mcp` reuses the copy cached in `~/.npm/_npx` without
+re-resolving against the registry; pin `@latest` (or clear that cache) when you
+want the newest release.
+
 ### How to supply these (inline, `.env`, or export)
 
 The required `CCU_HOST` / `CCU_PASSWORD` (and everything else) are **environment

--- a/README.md
+++ b/README.md
@@ -328,7 +328,9 @@ would otherwise fail *silently* and much later, so the exit is deliberate:
 | `TLS_FINGERPRINT/CA_CERT/TLS_VERIFY is set but HTTPS is disabled` | The verification code path only exists over HTTPS. Ignoring these would leave you believing the connection is verified while credentials travel in cleartext. Set `CCU_HTTPS=true` (or `CCU_<NAME>_HTTPS=true`) or remove them. |
 | `MCP_TLS_CERT and MCP_TLS_KEY must both be set (or both unset)` | Half a TLS config can't serve HTTPS. |
 | `MCP_TRANSPORT must be "http" or "stdio"` | Case matters. A typo like `STDIO` must not silently select HTTP and leave a stdio-spawning client waiting forever. |
-| `<VAR> must be a positive number` | Any of the numeric settings (ports, timeouts, rate limits, poll interval). |
+| `<VAR> must be a positive integer` | Ports, timeouts, `CACHE_TTL`, rate limits, `RESOURCE_POLL_INTERVAL`. The *whole* value has to be digits — `CCU_TIMEOUT=30s` is rejected rather than read as 30 ms, and `30.5` or `1e4` are rejected rather than truncated. |
+| `<VAR> must be a positive number` | The two duration settings, `MCP_AUTH_TOKEN_TTL_DAYS` and `MCP_AUTH_TOKEN_GRACE_HOURS`, where a fractional value is meaningful. |
+| `<VAR> must be "true" or "false"` | Any boolean setting (`CCU_HTTPS`, `CCU_TLS_VERIFY`, `CCU_<NAME>_PROTECTED`, `CCU_<NAME>_READONLY`, `MCP_ALLOW_PLAINTEXT`). Surrounding whitespace and capitalisation are fine; `yes`, `1` and `on` are not, because treating them as *false* would quietly switch a protection off. |
 | `CCU_CA_CERT could not be read` | Path is wrong or unreadable by the server user. |
 
 `ccu-mcp --version` and `--help` work without any configuration, so they stay

--- a/README.md
+++ b/README.md
@@ -310,6 +310,30 @@ profile (unchanged behavior). At runtime, `list_ccu_targets` shows the targets,
 tools also accept an optional `target` to read from another CCU for a single call
 without switching.
 
+### Configuration errors
+
+Some mistakes stop the server at startup instead of being ignored. Each of these
+would otherwise fail *silently* and much later, so the exit is deliberate:
+
+| Message | Cause and why it's fatal |
+|---|---|
+| `CCU_HOST environment variable is required` | No CCU configured (and no `CCU_PROFILES`). |
+| `CCU_PASSWORD environment variable is required` | Unset **or empty**. Note the asymmetry: a *profile* password may be empty (`CCU_<NAME>_PASSWORD=`, e.g. an OpenCCU dev box), the flat one may not. |
+| `CCU_DEFAULT_PROFILE is set but CCU_PROFILES is not` | A leftover from a profile setup. Ignoring it would point writes at the flat `CCU_HOST` box while the env file suggests a named target. |
+| `CCU_PROFILES is set but lists no profile names` | Empty or comma-only value. |
+| `CCU_PROFILES lists "<name>" more than once` | Duplicate profile name. |
+| `... both map to the same env prefix CCU_<P>_* — rename one` | Distinct names can collide once sanitised: `prod-a` and `prod.a` both read `CCU_PROD_A_*`, so they would silently be the *same* target. |
+| `CCU_DEFAULT_PROFILE="x" is not one of CCU_PROFILES (...)` | Typo in the startup profile. |
+| `profile "<name>" is missing CCU_<P>_HOST` | Every profile needs a host; the password may be empty. |
+| `TLS_FINGERPRINT/CA_CERT/TLS_VERIFY is set but HTTPS is disabled` | The verification code path only exists over HTTPS. Ignoring these would leave you believing the connection is verified while credentials travel in cleartext. Set `CCU_HTTPS=true` (or `CCU_<NAME>_HTTPS=true`) or remove them. |
+| `MCP_TLS_CERT and MCP_TLS_KEY must both be set (or both unset)` | Half a TLS config can't serve HTTPS. |
+| `MCP_TRANSPORT must be "http" or "stdio"` | Case matters. A typo like `STDIO` must not silently select HTTP and leave a stdio-spawning client waiting forever. |
+| `<VAR> must be a positive number` | Any of the numeric settings (ports, timeouts, rate limits, poll interval). |
+| `CCU_CA_CERT could not be read` | Path is wrong or unreadable by the server user. |
+
+`ccu-mcp --version` and `--help` work without any configuration, so they stay
+usable while you sort one of these out.
+
 ## Tools
 
 28 tools organized by what you'd actually want to do:

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -172,6 +172,18 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    auto-closes them and lets the milestone close. `main` is protected, so
    this PR is the only way in; merge it when the checks are green.
 
+   **The workflow runs on this PR may sit at `action_required`** — GitHub
+   holds the `pull_request` runs on the merge ref pending approval, and the
+   PR stays `BLOCKED` with the required checks simply never reporting. It
+   looks like a broken gate; it is just an unapproved run. Approve both:
+   ```sh
+   gh run list --limit 6 --json databaseId,workflowName,conclusion \
+     --jq '.[] | select(.conclusion=="action_required") | .databaseId'
+   # then, per id:
+   gh api -X POST repos/claymore666/ccu-mcp/actions/runs/<id>/approve
+   ```
+   They re-queue immediately and report normally.
+
    Required checks here: `build-and-test`, `release-title`, and
    **`release-audit`** — the last asserts no high/critical advisories in
    production dependencies (`npm audit --omit=dev`). It is the one gate that

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,9 +555,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -48,6 +48,19 @@ if (pkg.mcpName !== server.name) {
 rows.push([`${PKG} mcpName`, pkg.mcpName]);
 rows.push([`${SERVER} name`, server.name]);
 
+// 4. The npm package the registry tells people to install must BE this package.
+// Unchecked until now: this repo renamed its npm package once already
+// (debmatic-mcp -> ccu-mcp, v1.5.0), and had `identifier` been missed in that
+// rename every gate in the release runbook would still have gone green while
+// the registry pointed users at the deprecated package.
+packages.forEach((p, i) => {
+  if (p.registryType === "npm" && p.identifier !== pkg.name) {
+    problems.push(`${SERVER} packages[${i}].identifier "${p.identifier}" != ${PKG} name "${pkg.name}"`);
+  }
+  rows.push([`${SERVER} packages[${i}].identifier`, p.identifier]);
+});
+rows.push([`${PKG} name`, pkg.name]);
+
 const width = Math.max(...rows.map(([label]) => label.length));
 for (const [label, value] of rows) {
   console.log(`  ${label.padEnd(width)}  ${value}`);

--- a/scripts/sync-server-version.mjs
+++ b/scripts/sync-server-version.mjs
@@ -16,8 +16,9 @@ const PKG = process.env.PKG_FILE ?? "package.json";
 const SERVER = process.env.SERVER_FILE ?? "server.json";
 
 const pkg = JSON.parse(readFileSync(PKG, "utf8"));
-const raw = readFileSync(SERVER, "utf8");
-const server = JSON.parse(raw);
+// (the raw text is not needed beyond parsing — JSON.stringify(…, 2) below is
+// what preserves the 2-space indentation and trailing newline)
+const server = JSON.parse(readFileSync(SERVER, "utf8"));
 
 const version = pkg.version;
 if (!version) {

--- a/server.json
+++ b/server.json
@@ -79,6 +79,64 @@
           "name": "CCU_DEFAULT_PROFILE",
           "description": "Which profile from CCU_PROFILES is active at startup (default: the first listed)",
           "format": "string"
+        },
+        {
+          "name": "CCU_TLS_VERIFY",
+          "description": "Verify the CCU's TLS certificate against the system trust store. Only meaningful with CCU_HTTPS=true. Default false, because a CCU ships a self-signed certificate — prefer CCU_TLS_FINGERPRINT or CCU_CA_CERT to verify one of those",
+          "default": "false",
+          "format": "boolean"
+        },
+        {
+          "name": "CCU_TLS_FINGERPRINT",
+          "description": "Pin the CCU's self-signed leaf certificate by its SHA-256 fingerprint (hex, colons optional). The strongest option for an appliance: the connection is rejected unless the presented certificate matches. Takes precedence over CCU_CA_CERT",
+          "format": "string"
+        },
+        {
+          "name": "CCU_CA_CERT",
+          "description": "Path to a PEM file holding the CCU's CA or self-signed certificate. The connection is then validated against it with standard chain verification",
+          "format": "string"
+        },
+        {
+          "name": "CCU_TIMEOUT",
+          "description": "Timeout for a CCU JSON-RPC call, in MILLISECONDS",
+          "default": "10000",
+          "format": "number"
+        },
+        {
+          "name": "CCU_SCRIPT_TIMEOUT",
+          "description": "Timeout for HomeMatic Script execution (ReGa), in MILLISECONDS — scripts are slower than plain API calls",
+          "default": "30000",
+          "format": "number"
+        },
+        {
+          "name": "CACHE_TTL",
+          "description": "Lifetime of the on-disk device-type schema cache, in SECONDS",
+          "default": "86400",
+          "format": "number"
+        },
+        {
+          "name": "CCU_RATE_LIMIT_BURST",
+          "description": "Token-bucket burst size for CCU requests — how many may be issued back to back",
+          "default": "20",
+          "format": "number"
+        },
+        {
+          "name": "CCU_RATE_LIMIT_RATE",
+          "description": "Sustained CCU request rate, in requests per second",
+          "default": "10",
+          "format": "number"
+        },
+        {
+          "name": "RESOURCE_POLL_INTERVAL",
+          "description": "How often MCP resources are polled for change notifications, in SECONDS",
+          "default": "60",
+          "format": "number"
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "error | warn | info | debug. Logs are structured JSON on stderr",
+          "default": "info",
+          "format": "string"
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.8.1",
+  "version": "1.9.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/cache/device-type-cache.ts
+++ b/src/cache/device-type-cache.ts
@@ -185,7 +185,9 @@ export class DeviceTypeCache {
       );
 
       // Get all devices per interface
-      const devicesByType = new Map<string, { interface: string; address: string; channels: string[] }>();
+      // `address` used to be stored here and never read — processType's own
+      // parameter type omitted it (issue #121).
+      const devicesByType = new Map<string, { interface: string; channels: string[] }>();
 
       for (const iface of interfaces) {
         await rateLimiter.acquire();
@@ -207,7 +209,6 @@ export class DeviceTypeCache {
 
           devicesByType.set(device.type, {
             interface: iface.name,
-            address: device.address,
             channels: device.children,
           });
         }
@@ -220,43 +221,9 @@ export class DeviceTypeCache {
       // half while the rate limiter still caps overall CCU load.
       const processType = async (deviceType: string, info: { interface: string; channels: string[] }) => {
         try {
-          const channels: CachedDeviceType["channels"] = {};
-
-          // Get description for each channel
-          for (const channelAddr of info.channels) {
-            const channelIndex = channelAddr.split(":")[1] || "0";
-
-            const paramsets: Record<string, Record<string, CachedParamDescription>> = {};
-
-            for (const paramsetKey of ["VALUES", "MASTER"]) {
-              await rateLimiter.acquire();
-              try {
-                const desc = await session.call("Interface.getParamsetDescription", {
-                  interface: info.interface,
-                  address: channelAddr,
-                  paramsetKey,
-                });
-
-                const params = parseParamDescriptions(desc as RawParamDesc[]);
-
-                if (Object.keys(params).length > 0) {
-                  paramsets[paramsetKey] = params;
-                }
-              } catch {
-                // Some channels don't support all paramset keys — skip
-              }
-            }
-
-            // Determine channel type from the first param or address pattern
-            channels[channelIndex] = {
-              type: channelAddr, // Will be enriched if we add channel type info later
-              paramsets,
-            };
-          }
-
           this.cache.set(deviceType, {
             interface: info.interface,
-            channels,
+            channels: await this.fetchChannels(info.interface, info.channels, session, rateLimiter),
           });
         } catch (err) {
           this.logger.warn("cache_warm_type_failed", { deviceType, error: (err as Error).message });
@@ -289,12 +256,61 @@ export class DeviceTypeCache {
   }
 
   /**
+   * Fetch every channel's VALUES/MASTER paramset descriptions for one device
+   * type. Shared by the background warm and the live query fallback — they had
+   * near-identical copies of this loop that had already drifted apart in error
+   * handling (issue #121).
+   *
+   * A channel that doesn't support a paramset key is normal and skipped; the
+   * result guard is `expectArray`, so a malformed CCU/proxy answer (`result:
+   * null`) is a diagnosable CCU_ERROR rather than a TypeError swallowed as
+   * "this channel has no such paramset".
+   */
+  private async fetchChannels(
+    interfaceName: string,
+    channels: string[],
+    session: SessionManager,
+    rateLimiter: RateLimiter,
+  ): Promise<CachedDeviceType["channels"]> {
+    const out: CachedDeviceType["channels"] = {};
+
+    for (const channelAddr of channels) {
+      const channelIndex = channelAddr.split(":")[1] || "0";
+      const paramsets: Record<string, Record<string, CachedParamDescription>> = {};
+
+      for (const paramsetKey of ["VALUES", "MASTER"]) {
+        await rateLimiter.acquire();
+        try {
+          const desc = await session.call("Interface.getParamsetDescription", {
+            interface: interfaceName,
+            address: channelAddr,
+            paramsetKey,
+          });
+          const params = parseParamDescriptions(
+            expectArray<RawParamDesc>(desc, "Interface.getParamsetDescription"),
+          );
+          if (Object.keys(params).length > 0) {
+            paramsets[paramsetKey] = params;
+          }
+        } catch {
+          // Channel doesn't support this paramset key — expected, skip.
+        }
+      }
+
+      // `type` carries the channel address for now; enriched if we ever add
+      // real channel-type info.
+      out[channelIndex] = { type: channelAddr, paramsets };
+    }
+
+    return out;
+  }
+
+  /**
    * Add a single type to cache (live query fallback).
    * Single-flight per device type: concurrent calls share one live query.
    */
   async queryAndCache(
     deviceType: string,
-    deviceAddress: string,
     interfaceName: string,
     channels: string[],
     session: SessionManager,
@@ -318,31 +334,10 @@ export class DeviceTypeCache {
     session: SessionManager,
     rateLimiter: RateLimiter,
   ): Promise<CachedDeviceType | undefined> {
-    const cached: CachedDeviceType = { interface: interfaceName, channels: {} };
-
-    for (const channelAddr of channels) {
-      const channelIndex = channelAddr.split(":")[1] || "0";
-      const paramsets: Record<string, Record<string, CachedParamDescription>> = {};
-
-      for (const paramsetKey of ["VALUES", "MASTER"]) {
-        await rateLimiter.acquire();
-        try {
-          const desc = await session.call("Interface.getParamsetDescription", {
-            interface: interfaceName,
-            address: channelAddr,
-            paramsetKey,
-          });
-
-          const params = parseParamDescriptions(desc as RawParamDesc[]);
-
-          if (Object.keys(params).length > 0) {
-            paramsets[paramsetKey] = params;
-          }
-        } catch { /* skip */ }
-      }
-
-      cached.channels[channelIndex] = { type: channelAddr, paramsets };
-    }
+    const cached: CachedDeviceType = {
+      interface: interfaceName,
+      channels: await this.fetchChannels(interfaceName, channels, session, rateLimiter),
+    };
 
     this.cache.set(deviceType, cached);
     // Don't block on disk save

--- a/src/ccu/types.ts
+++ b/src/ccu/types.ts
@@ -169,6 +169,14 @@ export interface CcuProfile {
   protected: boolean;
   /** When true, write tools are refused outright (even with confirm). */
   readonly: boolean;
+  /**
+   * True only for the back-compat profile synthesised from the FLAT `CCU_*`
+   * variables when `CCU_PROFILES` is unset. Not the same as `name === "default"`:
+   * `CCU_PROFILES=default,dev` is legal and produces a profile genuinely named
+   * "default" that reads `CCU_DEFAULT_*`. Error messages must name the variable
+   * the profile actually reads, so they key off this instead of the name.
+   */
+  isFlat?: boolean;
   /** Connection details for this target. */
   ccu: CcuConfig;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,16 @@ export interface AppConfig {
   resourcePollInterval: number;
 }
 
+/**
+ * The env-var prefix a profile name maps to: `prod-a` → `PROD_A`, read as
+ * `CCU_PROD_A_*`. Single definition — this was written out three times, once as
+ * the actual prefix, once in the duplicate-detection loop, and once inside an
+ * error message that had to agree with both (issue #124).
+ */
+function envPrefix(name: string): string {
+  return name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+}
+
 export function loadConfig(): AppConfig {
   // CLI flags override env vars for transport. Validate the env value: a typo
   // ("STDIO", "Stdio") must fail loudly, not silently select HTTP and leave a
@@ -98,12 +108,38 @@ export function loadConfig(): AppConfig {
   if (args.includes("--stdio")) transport = "stdio";
   if (args.includes("--http")) transport = "http";
 
+  // Strict: the whole value must be a plain positive integer. parseInt() used to
+  // do this and stopped at the first non-digit, so "30s" silently became 30 —
+  // a 30 MILLISECOND CCU_TIMEOUT, whose every failure then looked like a slow
+  // CCU rather than a config typo (issue #119). The units are documented only
+  // in comments, so a "30s" is a natural thing to write.
+  // Rejecting via regex rather than Number() also excludes forms Number()
+  // accepts but nobody means here: hex ("0x10"), exponent ("1e4"), decimals.
   const parseIntEnv = (name: string, fallback: string): number => {
-    const val = parseInt(process.env[name] || fallback, 10);
-    if (isNaN(val) || val <= 0) {
-      throw new Error(`${name} must be a positive number, got: "${process.env[name]}"`);
+    // Unset or explicitly empty ("VAR=" in a compose file) means "use the
+    // default", as before. Whitespace-only does NOT — it is a typo, and the old
+    // parseInt(" ") → NaN rejected it. Trim only after that distinction.
+    const raw = process.env[name];
+    const source = raw === undefined || raw === "" ? fallback : raw.trim();
+    if (!/^\d+$/.test(source) || !Number.isSafeInteger(Number(source)) || Number(source) <= 0) {
+      throw new Error(`${name} must be a positive integer, got: "${process.env[name]}"`);
     }
-    return val;
+    return Number(source);
+  };
+
+  // Booleans were compared as `process.env[name] === "true"` against the RAW value,
+  // so a trailing space or CR made the setting silently false (issue #120).
+  // For CCU_<P>_PROTECTED / _READONLY that failed OPEN — the production write
+  // gate quietly disabled. Docker passes `environment:` values verbatim, and
+  // docker-compose.yml documents exactly those variables, so this was reachable.
+  // Garbage is rejected rather than read as false, matching MCP_TRANSPORT:
+  // `CCU_PROD_PROTECTED=yes` must not mean "unprotected".
+  const parseBoolEnv = (name: string): boolean => {
+    const raw = process.env[name]?.trim().toLowerCase();
+    if (raw === undefined || raw === "") return false;
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    throw new Error(`${name} must be "true" or "false", got: "${process.env[name]}"`);
   };
 
   // Optional positive duration in `unitMs` units; fractional values allowed
@@ -173,20 +209,20 @@ export function loadConfig(): AppConfig {
   // literal scan doesn't see them — intentional; they're documented as comments
   // in .env.example. Password may be empty (OpenCCU dev boxes default to it).
   const buildProfile = (name: string): CcuProfile => {
-    const p = name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+    const p = envPrefix(name);
     const get = (suffix: string): string | undefined => process.env[`CCU_${p}_${suffix}`]?.trim() || undefined;
     const host = get("HOST");
     if (!host) throw new Error(`profile "${name}" is missing CCU_${p}_HOST`);
-    const https = process.env[`CCU_${p}_HTTPS`] === "true";
+    const https = parseBoolEnv(`CCU_${p}_HTTPS`);
     return {
       name,
-      protected: process.env[`CCU_${p}_PROTECTED`] === "true",
-      readonly: process.env[`CCU_${p}_READONLY`] === "true",
+      protected: parseBoolEnv(`CCU_${p}_PROTECTED`),
+      readonly: parseBoolEnv(`CCU_${p}_READONLY`),
       ccu: {
         host,
         port: parseIntEnv(`CCU_${p}_PORT`, https ? "443" : "80"),
         https,
-        tlsVerify: process.env[`CCU_${p}_TLS_VERIFY`] === "true",
+        tlsVerify: parseBoolEnv(`CCU_${p}_TLS_VERIFY`),
         tlsFingerprint: get("TLS_FINGERPRINT"),
         caCert: readCaCert(`CCU_${p}_CA_CERT`, get("CA_CERT")),
         user: get("USER") || "Admin",
@@ -216,15 +252,17 @@ export function loadConfig(): AppConfig {
     if (!host) throw new Error("CCU_HOST environment variable is required");
     const password = process.env.CCU_PASSWORD;
     if (!password) throw new Error("CCU_PASSWORD environment variable is required");
+    const flatHttps = parseBoolEnv("CCU_HTTPS");
     profiles = [{
       name: "default",
       protected: false,
       readonly: false,
+      isFlat: true,
       ccu: {
         host,
-        port: parseIntEnv("CCU_PORT", process.env.CCU_HTTPS === "true" ? "443" : "80"),
-        https: process.env.CCU_HTTPS === "true",
-        tlsVerify: process.env.CCU_TLS_VERIFY === "true",
+        port: parseIntEnv("CCU_PORT", flatHttps ? "443" : "80"),
+        https: flatHttps,
+        tlsVerify: parseBoolEnv("CCU_TLS_VERIFY"),
         tlsFingerprint: process.env.CCU_TLS_FINGERPRINT?.trim() || undefined,
         caCert: readCaCert("CCU_CA_CERT", process.env.CCU_CA_CERT?.trim() || undefined),
         user: process.env.CCU_USER || "Admin",
@@ -246,7 +284,7 @@ export function loadConfig(): AppConfig {
       const key = n.toLowerCase();
       if (seen.has(key)) throw new Error(`CCU_PROFILES lists "${n}" more than once`);
       seen.add(key);
-      const prefix = n.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+      const prefix = envPrefix(n);
       const clash = seenPrefix.get(prefix);
       if (clash) {
         throw new Error(
@@ -272,9 +310,15 @@ export function loadConfig(): AppConfig {
   // Fail fast instead of silently ignoring the settings.
   for (const p of profiles) {
     if (!p.ccu.https && (p.ccu.tlsFingerprint || p.ccu.caCert || p.ccu.tlsVerify)) {
+      // `isFlat`, not `name === "default"`: CCU_PROFILES=default,dev is legal
+      // and yields a profile genuinely NAMED "default" that reads
+      // CCU_DEFAULT_HTTPS. Keying off the name told that operator to set
+      // CCU_HTTPS, which the profile path never reads — following the hint
+      // would not clear the error (issue #124).
+      const httpsVar = p.isFlat ? "CCU_HTTPS" : `CCU_${envPrefix(p.name)}_HTTPS`;
       throw new Error(
         `CCU profile "${p.name}": TLS_FINGERPRINT/CA_CERT/TLS_VERIFY is set but HTTPS is disabled — ` +
-        `these settings only apply over HTTPS. Set ${p.name === "default" ? "CCU_HTTPS" : `CCU_${p.name.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_HTTPS`}=true or remove them.`,
+        `these settings only apply over HTTPS. Set ${httpsVar}=true or remove them.`,
       );
     }
   }
@@ -300,7 +344,7 @@ export function loadConfig(): AppConfig {
       host: process.env.MCP_HOST?.trim() || undefined,
       tlsCertPath,
       tlsKeyPath,
-      allowPlaintext: process.env.MCP_ALLOW_PLAINTEXT === "true",
+      allowPlaintext: parseBoolEnv("MCP_ALLOW_PLAINTEXT"),
     },
     cache: {
       dir: process.env.CACHE_DIR || "/data",

--- a/src/http/error-response.ts
+++ b/src/http/error-response.ts
@@ -1,0 +1,25 @@
+import type { ServerResponse } from "node:http";
+
+/**
+ * Terminate a response after an unexpected handler failure.
+ *
+ * Split out of the HTTP handler's catch-all so it can be unit-tested:
+ * `src/index.ts` calls `main()` at module scope, so a test cannot import it
+ * without starting a server.
+ *
+ * The `headersSent` branch is the point. A GET opens the long-lived SSE
+ * notification stream, which commits its headers the moment it opens; any
+ * later rejection lands in the catch with a response already in flight.
+ * Writing a JSON body there appended it INTO the event stream, where it is
+ * neither a valid `data:` frame nor an event boundary — clients saw a parse
+ * error rather than a clean close (issue #123). End the stream instead and
+ * let the client reconnect.
+ */
+export function endWithInternalError(res: ServerResponse): void {
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+  res.writeHead(500, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Internal error" }));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { TargetRegistry, TargetSelection } from "./ccu/target-registry.js";
 import { ResourcePoller } from "./resources/poller.js";
 import { resolveAuthTokens, startAutoRotation } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
+import { endWithInternalError } from "./http/error-response.js";
 import { createMcpServer, serverSubscriptions, type ServerDeps } from "./server.js";
 import { extractBearerToken, normalizeClientIp, VERSION, loadBuildInfo } from "./utils.js";
 
@@ -412,10 +413,7 @@ async function main(): Promise<void> {
       } catch (err) {
         // One bad request must not take down the process (unhandled rejection)
         logger.error("http_handler_error", { error: (err as Error).message });
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-        }
-        res.end(JSON.stringify({ error: "Internal error" }));
+        endWithInternalError(res);
       }
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,68 @@ import { ResourcePoller } from "./resources/poller.js";
 import { resolveAuthTokens, startAutoRotation } from "./auth/token.js";
 import { handleHealthRequest } from "./health/handler.js";
 import { createMcpServer, serverSubscriptions, type ServerDeps } from "./server.js";
-import { extractBearerToken, normalizeClientIp } from "./utils.js";
+import { extractBearerToken, normalizeClientIp, VERSION, loadBuildInfo } from "./utils.js";
+
+const USAGE = `ccu-mcp — MCP server for a HomeMatic CCU (debmatic, CCU3, OpenCCU/RaspberryMatic)
+
+Usage:
+  ccu-mcp [--stdio | --http]
+  ccu-mcp --version
+  ccu-mcp --help
+
+Options:
+  --stdio          Serve MCP over stdin/stdout (overrides MCP_TRANSPORT)
+  --http           Serve MCP over HTTP (default)
+  -v, --version    Print the version and exit
+  -h, --help       Print this help and exit
+
+Required environment:
+  CCU_HOST         Hostname or IP of the CCU
+  CCU_PASSWORD     Password for CCU_USER
+
+Common environment:
+  CCU_USER         CCU username (default: Admin)
+  CCU_PORT         API port (default: 80, or 443 with CCU_HTTPS=true)
+  CCU_HTTPS        Connect over HTTPS (default: false)
+  MCP_TRANSPORT    "http" or "stdio" (default: http)
+  MCP_PORT         HTTP listener port (default: 3000)
+  CACHE_DIR        Cache, session and generated token (default: /data)
+  LOG_LEVEL        error | warn | info | debug (default: info)
+
+Multiple CCUs, TLS pinning, auth-token rotation and the full variable list:
+https://github.com/claymore666/ccu-mcp#configuration`;
+
+/**
+ * Handle the flags that must work with NO environment at all (issue #112).
+ *
+ * Deliberately runs before createLogger()/loadConfig(): asking an installed
+ * copy "which version are you?" must not require a reachable CCU, and
+ * loadConfig() throws on a missing CCU_HOST. Returns true when the process
+ * should exit without starting a server.
+ */
+function handleInfoFlags(argv: string[]): boolean {
+  if (argv.includes("--version") || argv.includes("-v")) {
+    const { describe, commit, dirty } = loadBuildInfo();
+    // Prefer the git describe stamped at build time; fall back to the bare
+    // version for an npm install, which carries no build-info.json.
+    const stamp = describe ?? commit;
+    // `git describe --dirty` already carries the marker; the commit fallback
+    // does not. Appending unconditionally would print "...-dirty-dirty".
+    const dirtyMark = stamp && dirty && !stamp.endsWith("-dirty") ? "-dirty" : "";
+    process.stdout.write(`${VERSION}${stamp ? ` (${stamp}${dirtyMark})` : ""}\n`);
+    return true;
+  }
+  if (argv.includes("--help") || argv.includes("-h")) {
+    // stdout, not stderr, so `ccu-mcp --help | less` works.
+    process.stdout.write(`${USAGE}\n`);
+    return true;
+  }
+  return false;
+}
 
 async function main(): Promise<void> {
+  if (handleInfoFlags(process.argv.slice(2))) return;
+
   const logger = createLogger();
   const config = loadConfig();
 

--- a/src/tools/control.ts
+++ b/src/tools/control.ts
@@ -129,6 +129,17 @@ function registerPutParamset(server: McpServer, deps: ServerDeps): void {
       const active = deps.selection.active;
       const { session, resolver, deviceTypeCache } = active;
       assertWritable(deps.selection, active, args.confirm);
+      // An empty set sends an empty struct; putparamset.tcl iterates nothing and
+      // answers true, so the tool reported a write that touched nothing as a
+      // success (issue #131). Every sibling tool rejects its degenerate input.
+      if (Object.keys(args.set).length === 0) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: "'set' is empty — there is nothing to write.",
+          hint: "Pass the parameters to write, e.g. {TEMPERATURE_WINDOW_OPEN: 5.0}. Use describe_device_type for valid names.",
+        });
+      }
       const iface = args.interface ?? await resolver.resolveInterface(args.address, session, rateLimiter, logger);
 
       // CCU expects set as array of {name, type, value} objects. Types must be
@@ -278,7 +289,19 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         // historical contract) — label matching applies to strings only, so
         // an enum whose labels are numeric strings ("1;2;3") can't silently
         // redefine what a numeric input means.
-        const labels = (sysVar.valueList ?? "").split(";");
+        // "".split(";") is [""], not [] — so an ENUM/LIST variable with no
+        // value list would otherwise present as a one-state enum: index 0
+        // accepted, and a hint reading "Pass an index 0-0 or one of: "
+        // (issue #122). That variable is unwritable by index; say so.
+        if (!sysVar.valueList) {
+          throw new CcuError({
+            error: "CCU_ERROR",
+            code: 0,
+            message: `System variable "${args.name}" is an enum but the CCU reports no value list for it`,
+            hint: "The variable is misconfigured on the CCU — open it in the WebUI and define its value list, or recreate it with create_system_variable.",
+          });
+        }
+        const labels = sysVar.valueList.split(";");
         let index: number;
         if (typeof args.value === "number") {
           index = args.value;
@@ -344,12 +367,37 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
       }
 
       await rateLimiter.acquire();
-      await withRetry(
+      const setResult = await withRetry(
         () => session.call(method, { name: args.name, value: rpcValue }),
         method,
         logger,
         { rateLimiter },
       );
+
+      // setbool.tcl/setfloat.tcl end with:
+      //   if {[hmscript $script args]} { jsonrpc_response $args(value) }
+      //   else                         { jsonrpc_response -1 }
+      // so -1 is the CCU saying "the script engine failed" — the write never
+      // reached the variable. Discarding this result reported a lost write as a
+      // success (issue #118).
+      //
+      // Only the sentinel is treated as failure, deliberately: comparing the
+      // echoed value against what we sent would misfire the moment a firmware
+      // reformats it ("21.5" vs "21.500000"). A false "your write failed" on a
+      // write that landed is worse than the narrow blind spot below.
+      //
+      // Blind spot, and it is safe: setting a float to exactly -1 makes success
+      // and failure indistinguishable. That direction fails open — we report
+      // success for the value the CCU would have stored anyway.
+      if (isCcuScriptFailure(setResult) && String(rpcValue) !== "-1") {
+        throw new CcuError({
+          error: "CCU_ERROR",
+          code: 0,
+          message: `${method} reported failure for "${args.name}" — the value was NOT written`,
+          hint: "The CCU's script engine failed (busy or errored). Verify with list_system_variables and retry.",
+          ccuMethod: method,
+        });
+      }
 
       // setbool.tcl/setfloat.tcl answer success even when dom.GetObject finds
       // no variable (verified in the OCCU TCL) — a delete racing the 30s type
@@ -376,12 +424,18 @@ function registerSetSystemVariable(server: McpServer, deps: ServerDeps): void {
         logger.warn("sysvar_write_unverified", { name: args.name, error: (err as Error).message });
         verified = false;
       }
+      // An empty result has TWO causes and getvaluebyname.tcl cannot tell them
+      // apart — it returns `json_toString [hmscript …]`, and hmscript yields ""
+      // both when the variable is gone AND when the script engine itself failed.
+      // Say so rather than asserting a concurrent delete that may not have
+      // happened (issue #118). The setter's own return value is checked above,
+      // so a write that never landed has already been caught by this point.
       if (verified && (typeof verifyResult !== "string" || verifyResult === "")) {
         throw new CcuError({
           error: "NOT_FOUND",
           code: 0,
-          message: `System variable disappeared before the write could land: ${args.name}`,
-          hint: "It was likely deleted concurrently (the CCU's setBool/setFloat report success even without a target). Call list_system_variables to confirm.",
+          message: `Could not confirm the write to "${args.name}": the CCU returned no value for it`,
+          hint: "Either the variable was deleted concurrently, or the CCU's script engine failed during verification. The write itself was acknowledged. Call list_system_variables to see which.",
         });
       }
 
@@ -432,6 +486,36 @@ function registerCreateSystemVariable(server: McpServer, deps: ServerDeps): void
           code: 0,
           message: "An enum system variable requires a non-empty 'values' list.",
           hint: "Pass values, e.g. [\"off\", \"low\", \"high\"].",
+        });
+      }
+      // Arguments that don't apply to the chosen type used to be dropped on the
+      // floor by the switch below — create(type:"bool", min:0, max:40, unit:"°C")
+      // silently made a plain boolean (issue #122). Reject instead, matching the
+      // enum-without-values check directly above.
+      const ignored: string[] = [];
+      if (args.type !== "float") {
+        for (const [k, v] of [["min", args.min], ["max", args.max], ["unit", args.unit]] as const) {
+          if (v !== undefined) ignored.push(k);
+        }
+      }
+      if (args.type !== "enum" && args.values !== undefined) ignored.push("values");
+      if (ignored.length > 0) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: `${ignored.join(", ")} ${ignored.length === 1 ? "does" : "do"} not apply to a "${args.type}" system variable`,
+          hint: "min/max/unit are float-only; values is enum-only. Drop them, or change 'type'.",
+        });
+      }
+      // ValueMin >= ValueMax makes a variable the WebUI cannot set a value in.
+      // hmNumberLiteral checks each bound is representable; nothing checked
+      // them against each other (issue #122).
+      if (args.type === "float" && args.min !== undefined && args.max !== undefined && args.min >= args.max) {
+        throw new CcuError({
+          error: "INVALID_INPUT",
+          code: 0,
+          message: `min (${args.min}) must be less than max (${args.max})`,
+          hint: "Swap them, or omit both for the 0-100 default range.",
         });
       }
       // ";" is the CCU's in-band ValueList separator: a label containing it
@@ -627,12 +711,27 @@ function registerDeleteSystemVariable(server: McpServer, deps: ServerDeps): void
       }
 
       await rateLimiter.acquire();
-      await withRetry(
+      const deleteResult = await withRetry(
         () => session.call("SysVar.deleteSysVarByName", { name: args.name }),
         "SysVar.deleteSysVarByName",
         logger,
         { rateLimiter },
       );
+
+      // deletesysvarbyname.tcl is `jsonrpc_response [hmscript $script args]`,
+      // and the script's only output is Write("true"). So anything other than
+      // "true" means hmscript failed and the variable is still there — which
+      // this tool used to report as `deleted: true` (issue #118). Same strict
+      // shape as execute_program's Program.execute check.
+      if (deleteResult !== true && deleteResult !== "true") {
+        throw new CcuError({
+          error: "CCU_ERROR",
+          code: 0,
+          message: `SysVar.deleteSysVarByName reported failure for "${args.name}" — it was NOT deleted`,
+          hint: "The CCU's script engine failed (busy or errored). Confirm with list_system_variables and retry.",
+          ccuMethod: "SysVar.deleteSysVarByName",
+        });
+      }
 
       typeCacheHolder.entry = null; typeCacheHolder.gen++; // removed variable must not linger in the cache
       return toolResult({ name: args.name, deleted: true });
@@ -841,6 +940,16 @@ function registerExecuteProgram(server: McpServer, deps: ServerDeps): void {
       return toolResult({ id: args.id, name: program.name, executed: true });
     }),
   );
+}
+
+/**
+ * True when a CCU response carries the `-1` sentinel that SysVar.setBool /
+ * SysVar.setFloat return when their ReGa script failed to run (verified in the
+ * OCCU sources: `setbool.tcl`, `setfloat.tcl`). Accepts both the numeric and
+ * the string form — the CCU's JSON layer is not consistent about which.
+ */
+function isCcuScriptFailure(result: unknown): boolean {
+  return result === -1 || result === "-1";
 }
 
 /**

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -313,7 +313,7 @@ function registerDescribeDeviceType(server: McpServer, deps: ServerDeps): void {
         if (device) {
           try {
             cached = await deviceTypeCache.queryAndCache(
-              args.deviceType, device.address, device.interface,
+              args.deviceType, device.interface,
               device.channels.map((ch) => ch.address),
               session, rateLimiter,
             );

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -144,8 +144,11 @@ function registerListDevices(server: McpServer, deps: ServerDeps): void {
             })),
           }));
 
-      log({ deviceCount: devices.length });
-      return structuredResult({ devices: Array.isArray(output) ? output : [] }, output);
+      // Count what is RETURNED, not what was fetched: the unfiltered path drops
+      // the 50-channel virtual receivers below, so the old pre-filter count was
+      // 1-2 higher than the list the caller got (issue #124).
+      log({ deviceCount: output.length });
+      return structuredResult({ devices: output }, output);
     }),
   );
 }
@@ -243,7 +246,7 @@ function registerListPrograms(server: McpServer, deps: ServerDeps): void {
         programs = programs.filter((p) => p.name.toLowerCase().includes(needle));
       }
 
-      return structuredResult({ programs: Array.isArray(programs) ? programs : [] }, programs);
+      return structuredResult({ programs }, programs);
     }),
   );
 }
@@ -272,7 +275,7 @@ function registerListSystemVariables(server: McpServer, deps: ServerDeps): void 
         sysvars = sysvars.filter((v) => v.name.toLowerCase().includes(needle));
       }
 
-      return structuredResult({ systemVariables: Array.isArray(sysvars) ? sysvars : [] }, sysvars);
+      return structuredResult({ systemVariables: sysvars }, sysvars);
     }),
   );
 }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -133,12 +133,14 @@ Idempotent: yes`,
 Args: address (string), paramsetKey ("VALUES"|"MASTER"), set (object with key:value pairs, e.g. {"TEMPERATURE_WINDOW_OPEN": 5.0}), interface? (auto), confirm? (true to authorize on a protected target)
 The set object uses simple key:value format — types are auto-resolved from the device type cache. Values are converted to strings internally.
 Returns: {address, paramsetKey, written}
+INVALID_INPUT if 'set' is empty — there is nothing to write.
 Idempotent: yes`,
 
   set_system_variable: `Set a system variable (type auto-detected).
 Args: name (string), value (string|number|boolean), confirm? (true to authorize on a protected target)
 Enum (LIST) variables accept a 0-based index or one of the enum's labels.
 Returns: {name, value, method}
+CCU_ERROR if the CCU reports the write failed — the value was NOT written.
 Idempotent: yes`,
 
   create_system_variable: `Create a new system variable.
@@ -146,12 +148,13 @@ Args: name (string), type ("bool"|"float"|"enum"|"string"), description? (string
   unit?/min?/max? (float only), values? (string[], required for enum; labels must not contain ";"),
   confirm? (true to authorize on a protected target)
 Returns: {name, type, created: true}
-INVALID_INPUT if the name already exists (or enum without values). Use set_system_variable to write it.`,
+INVALID_INPUT if the name already exists, an enum has no values, min >= max, or an
+argument doesn't apply to the chosen type. Use set_system_variable to write it.`,
 
   delete_system_variable: `Delete a system variable by name.
 Args: name (string, exact match), confirm (REQUIRED true on every call against a protected target — never rides on the session unlock)
 Returns: {name, deleted: true}
-NOT_FOUND if the name doesn't exist.`,
+NOT_FOUND if the name doesn't exist; CCU_ERROR if the CCU reports the delete failed.`,
 
   assign_channel: `Assign a channel to a room and/or function group.
 Args: channel (address), room? (name), function? (name) — at least one of room/function; confirm? (true to authorize on a protected target)

--- a/test/e2e/_dist.ts
+++ b/test/e2e/_dist.ts
@@ -1,0 +1,41 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/** The built server every e2e suite spawns. */
+export const DIST = join(__dirname, "../../dist/index.js");
+
+// `describe.skipIf(!existsSync(DIST))` is convenient locally — bare
+// `npx vitest` with no build shouldn't explode. But it makes a missing dist/ a
+// SILENT PASS: every e2e block skips and the run still exits 0, which is
+// indistinguishable from "the e2e suites passed". Since these six blocks are
+// ALL the integration coverage there is, that is exactly the false green
+// CLAUDE.md warns about in prose (issue #128).
+//
+// `npm test` builds via `pretest`, so this can only fire if that guarantee is
+// removed or reordered. In CI, say so loudly rather than reporting success.
+if (process.env.CI && !existsSync(DIST)) {
+  throw new Error(
+    "dist/ is missing in CI — the e2e suites would silently skip and the run would still pass. " +
+      "Run `npm run build` first (`npm test` does this via pretest).",
+  );
+}
+
+/** Gate for `describe.skipIf(...)`. Evaluated once, after the CI check above. */
+export const distMissing = !existsSync(DIST);
+
+/**
+ * A listening port for an e2e server, unique per (vitest worker, slot).
+ *
+ * Was `20000 + Math.floor(Math.random() * 20000)` in four separate blocks, with
+ * no coordination and no retry. Vitest runs files in parallel, so two servers
+ * could draw the same port; the second got EADDRINUSE, exited, and the readiness
+ * poll then failed with "server did not start" — pointing at the CCU mock rather
+ * than at the port clash. Rare, unreproducible, and far more expensive to
+ * diagnose than to prevent (issue #128).
+ *
+ * `slot` must be distinct per describe block within a file.
+ */
+export function e2ePort(slot: number): number {
+  const worker = Number(process.env.VITEST_WORKER_ID ?? 1);
+  return 20000 + worker * 100 + slot;
+}

--- a/test/e2e/cli-flags.test.ts
+++ b/test/e2e/cli-flags.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Issue #112: --version and --help must work with NO environment at all.
+// main() used to call loadConfig() before looking at argv, so both flags died
+// with "CCU_HOST environment variable is required" — leaving no way to ask an
+// installed copy which version it is without a configured, reachable CCU.
+//
+// Running with a scrubbed env is the whole point of these tests: the bug was
+// precisely that these paths depended on the environment.
+
+const DIST = join(__dirname, "../../dist/index.js");
+const PKG_VERSION = JSON.parse(
+  readFileSync(join(__dirname, "../../package.json"), "utf-8"),
+) as { version: string };
+
+/** Run the built CLI with an empty environment (plus the PATH node needs). */
+function runBare(...args: string[]) {
+  return spawnSync(process.execPath, [DIST, ...args], {
+    env: { PATH: process.env.PATH ?? "" },
+    encoding: "utf-8",
+    timeout: 20_000,
+  });
+}
+
+describe.skipIf(!existsSync(DIST))("CLI info flags (no environment)", () => {
+  it("--version prints the package version and exits 0", () => {
+    const res = runBare("--version");
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim().split(/\s/)[0]).toBe(PKG_VERSION.version);
+    expect(res.stderr).toBe("");
+  });
+
+  it("-v is accepted as the short form", () => {
+    const res = runBare("-v");
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim().split(/\s/)[0]).toBe(PKG_VERSION.version);
+  });
+
+  it("never prints a doubled dirty marker", () => {
+    // `git describe --dirty` already carries the suffix; the commit fallback
+    // does not. Appending unconditionally produced "...-dirty-dirty".
+    expect(runBare("--version").stdout).not.toMatch(/-dirty-dirty/);
+  });
+
+  it("--help prints usage on stdout and exits 0", () => {
+    const res = runBare("--help");
+    expect(res.status).toBe(0);
+    // stdout, not stderr, so `ccu-mcp --help | less` works.
+    expect(res.stderr).toBe("");
+    expect(res.stdout).toContain("Usage:");
+    expect(res.stdout).toContain("--stdio");
+    expect(res.stdout).toContain("CCU_HOST");
+  });
+
+  it("-h is accepted as the short form", () => {
+    const res = runBare("-h");
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("Usage:");
+  });
+
+  it("neither flag trips config loading", () => {
+    // The regression itself. Asserting on the error text, not on "CCU_HOST" —
+    // the help output documents that variable on purpose.
+    for (const flag of ["--version", "--help"]) {
+      const res = runBare(flag);
+      const output = `${res.stdout}${res.stderr}`;
+      expect(output).not.toContain("Fatal error");
+      expect(output).not.toContain("environment variable is required");
+    }
+  });
+
+  it("still fails loudly without a flag and without configuration", () => {
+    // The guard must not have turned a misconfigured start into a silent exit 0.
+    const res = runBare();
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("CCU_HOST");
+  });
+});

--- a/test/e2e/cli-flags.test.ts
+++ b/test/e2e/cli-flags.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { DIST, distMissing } from "./_dist.js";
 
 // Issue #112: --version and --help must work with NO environment at all.
 // main() used to call loadConfig() before looking at argv, so both flags died
@@ -11,7 +12,6 @@ import { join } from "node:path";
 // Running with a scrubbed env is the whole point of these tests: the bug was
 // precisely that these paths depended on the environment.
 
-const DIST = join(__dirname, "../../dist/index.js");
 const PKG_VERSION = JSON.parse(
   readFileSync(join(__dirname, "../../package.json"), "utf-8"),
 ) as { version: string };
@@ -25,7 +25,7 @@ function runBare(...args: string[]) {
   });
 }
 
-describe.skipIf(!existsSync(DIST))("CLI info flags (no environment)", () => {
+describe.skipIf(distMissing)("CLI info flags (no environment)", () => {
   it("--version prints the package version and exits 0", () => {
     const res = runBare("--version");
     expect(res.status).toBe(0);

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -2,17 +2,17 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createServer, request, type Server, type IncomingHttpHeaders } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { AddressInfo } from "node:net";
+import { DIST, distMissing, e2ePort } from "./_dist.js";
 
 // End-to-end test of the HTTP transport against the BUILT server (dist/) with a
 // mocked CCU. Regression test for issue #17: a reused stateless transport broke
 // every request after the first; the server must support multiple requests per
 // session and multiple concurrent sessions.
 
-const DIST = join(__dirname, "../../dist/index.js");
 const AUTH_TOKEN = "e2e-test-token";
 
 /**
@@ -90,14 +90,14 @@ async function parseSse(res: Response): Promise<any> {
 // Degraded startup: the server must come up and speak MCP even when the CCU
 // is unreachable (required for CCU outages and for Glama's containerized
 // build checks, which start the server with placeholder credentials).
-describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () => {
+describe.skipIf(distMissing)("degraded startup e2e (CCU unreachable)", () => {
   let child: ChildProcess;
   let mcpPort: number;
   let cacheDir: string;
 
   beforeAll(async () => {
     cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-degraded-"));
-    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+    mcpPort = e2ePort(0);
 
     child = spawn("node", [DIST], {
       env: {
@@ -176,16 +176,17 @@ describe.skipIf(!existsSync(DIST))("degraded startup e2e (CCU unreachable)", () 
   });
 });
 
-describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU)", () => {
+describe.skipIf(distMissing)("HTTP transport e2e (built server, mocked CCU)", () => {
   let ccu: { server: Server; port: number };
   let child: ChildProcess;
   let mcpPort: number;
   let cacheDir: string;
+  let stderrLines: string[];
 
   beforeAll(async () => {
     ccu = await startCcuMock();
     cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-"));
-    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+    mcpPort = e2ePort(1);
 
     child = spawn("node", [DIST], {
       env: {
@@ -203,9 +204,18 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
         MCP_ALLOWED_ORIGINS: ALLOWED_ORIGIN,
         CACHE_DIR: cacheDir,
         RESOURCE_POLL_INTERVAL: "3600",
-        LOG_LEVEL: "error",
+        // warn, not error: auth_failed is a warn-level line, and the fail2ban
+        // filter test below asserts against the real thing (issue #129).
+        LOG_LEVEL: "warn",
       },
       stdio: ["ignore", "ignore", "pipe"],
+    });
+    // Drain stderr — both to keep the assertion below honest and so the pipe
+    // buffer can't fill and stall the child.
+    stderrLines = [];
+    child.stderr!.setEncoding("utf-8");
+    child.stderr!.on("data", (chunk: string) => {
+      for (const line of chunk.split("\n")) if (line.trim()) stderrLines.push(line);
     });
 
     // Wait for the port to accept connections
@@ -227,6 +237,39 @@ describe.skipIf(!existsSync(DIST))("HTTP transport e2e (built server, mocked CCU
     ccu?.server.close();
     rmSync(cacheDir, { recursive: true, force: true });
   });
+
+  // Issue #129: the fail2ban unit test asserts against a hand-mirrored copy of
+  // this log line, not the line src/index.ts actually writes — so adding a
+  // field ahead of `client` would break every deployed jail while that test
+  // stayed green. Close the loop against the real process here.
+  it("emits an auth_failed line the committed fail2ban filter matches", async () => {
+    const res = await fetch(`http://127.0.0.1:${mcpPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer wrong-token" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    expect(res.status).toBe(401);
+
+    // give the child a moment to flush the line
+    const deadline = Date.now() + 5_000;
+    let line: string | undefined;
+    while (Date.now() < deadline) {
+      line = stderrLines.find((l) => l.includes('"msg":"auth_failed"'));
+      if (line) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(line, `no auth_failed line in stderr: ${stderrLines.join(" | ")}`).toBeTruthy();
+
+    // the SHIPPED filter regex, read from the file operators install
+    const conf = readFileSync(join(__dirname, "../../fail2ban/filter.d/ccu-mcp.conf"), "utf-8");
+    const pattern = conf.match(/^failregex\s*=\s*(.+)$/m)?.[1];
+    expect(pattern, "filter must define a failregex").toBeTruthy();
+    const re = new RegExp(pattern!.replace("<HOST>", "([0-9a-fA-F:.]+)"));
+
+    const m = line!.match(re);
+    expect(m, `shipped fail2ban filter did not match the real line: ${line}`).not.toBeNull();
+    expect(m![1]).toMatch(/^(127\.0\.0\.1|::1)$/); // <HOST> captures the peer IP
+  }, 15_000);
 
   it("serves the health endpoint without auth (liveness only)", async () => {
     const res = await fetch(`http://127.0.0.1:${mcpPort}/health`);
@@ -451,7 +494,7 @@ const INIT_BODY = {
   params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "secure", version: "1" } },
 };
 
-describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebinding on)", () => {
+describe.skipIf(distMissing)("secure HTTP defaults e2e (no CORS, DNS-rebinding on)", () => {
   let ccu: { server: Server; port: number };
   let child: ChildProcess;
   let mcpPort: number;
@@ -460,7 +503,7 @@ describe.skipIf(!existsSync(DIST))("secure HTTP defaults e2e (no CORS, DNS-rebin
   beforeAll(async () => {
     ccu = await startCcuMock();
     cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-secure-"));
-    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+    mcpPort = e2ePort(2);
 
     child = spawn("node", [DIST], {
       env: {
@@ -571,7 +614,7 @@ function httpsJson(
   });
 }
 
-describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native TLS, mocked CCU)", () => {
+describe.skipIf(distMissing || !HAVE_OPENSSL)("HTTPS transport e2e (native TLS, mocked CCU)", () => {
   let ccu: { server: Server; port: number };
   let child: ChildProcess;
   let mcpPort: number;
@@ -581,7 +624,7 @@ describe.skipIf(!existsSync(DIST) || !HAVE_OPENSSL)("HTTPS transport e2e (native
   beforeAll(async () => {
     ccu = await startCcuMock();
     cacheDir = mkdtempSync(join(tmpdir(), "debmatic-e2e-tls-"));
-    mcpPort = 20000 + Math.floor(Math.random() * 20000);
+    mcpPort = e2ePort(3);
 
     // Mint a throwaway self-signed cert. The SAN must include IP:127.0.0.1 —
     // Node (>=17) no longer falls back to the subject CN for identity checks,

--- a/test/e2e/stdio-transport.test.ts
+++ b/test/e2e/stdio-transport.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { AddressInfo } from "node:net";
+
+// End-to-end test of the STDIO transport against the BUILT server (dist/) with
+// a mocked CCU. stdio is the documented default install path
+// (`npx ccu-mcp --stdio`), but every other e2e block drives the HTTP transport,
+// so the whole stdio branch of src/index.ts had no coverage.
+//
+// The shutdown case is the one that matters: StdioServerTransport registers
+// only 'data'/'error' listeners, so transport/server onclose never fires on
+// stdin EOF. Without the direct stdin hooks in src/index.ts the process would
+// exit via event-loop drain with no Session.logout — leaking a CCU session
+// toward "too many sessions" — and no cache save.
+
+const DIST = join(__dirname, "../../dist/index.js");
+
+/** process.env with every server config var scrubbed (see http-transport e2e). */
+function cleanEnv(): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (/^(CCU_|MCP_|CACHE_|RESOURCE_POLL_INTERVAL$|LOG_LEVEL$)/.test(key)) delete env[key];
+  }
+  return env;
+}
+
+interface CcuMock {
+  server: Server;
+  port: number;
+  /** Every JSON-RPC method the server called, in order. */
+  calls: string[];
+}
+
+function startCcuMock(): Promise<CcuMock> {
+  const calls: string[] = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      let method = "";
+      try { method = JSON.parse(body).method; } catch { /* ignore */ }
+      if (method) calls.push(method);
+      const results: Record<string, unknown> = {
+        "Session.login": "mock-session-id",
+        "Session.renew": true,
+        "Session.logout": true,
+        "Interface.listInterfaces": [],
+        "Device.listAllDetail": [],
+        "Room.getAll": [],
+      };
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ version: "2.0", result: results[method] ?? [], error: null }));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () =>
+      resolve({ server, port: (server.address() as AddressInfo).port, calls }),
+    );
+  });
+}
+
+/**
+ * Minimal newline-delimited JSON-RPC client over the child's stdio pipes —
+ * the framing StdioServerTransport uses.
+ */
+class StdioClient {
+  private buffer = "";
+  private pending = new Map<number, (msg: any) => void>();
+  private nextId = 1;
+
+  constructor(private child: ChildProcess) {
+    child.stdout!.setEncoding("utf-8");
+    child.stdout!.on("data", (chunk: string) => {
+      this.buffer += chunk;
+      let nl: number;
+      while ((nl = this.buffer.indexOf("\n")) !== -1) {
+        const line = this.buffer.slice(0, nl).trim();
+        this.buffer = this.buffer.slice(nl + 1);
+        if (!line) continue;
+        let msg: any;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (typeof msg.id === "number" && this.pending.has(msg.id)) {
+          this.pending.get(msg.id)!(msg);
+          this.pending.delete(msg.id);
+        }
+      }
+    });
+  }
+
+  request(method: string, params: unknown = {}, timeoutMs = 10_000): Promise<any> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`stdio request "${method}" timed out`));
+      }, timeoutMs);
+      this.pending.set(id, (msg) => { clearTimeout(timer); resolve(msg); });
+      this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  }
+
+  notify(method: string, params: unknown = {}): void {
+    this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+  }
+}
+
+describe.skipIf(!existsSync(DIST))("stdio transport e2e (built server, mocked CCU)", () => {
+  let ccu: CcuMock;
+  let child: ChildProcess;
+  let client: StdioClient;
+  let cacheDir: string;
+
+  beforeAll(async () => {
+    ccu = await startCcuMock();
+    cacheDir = mkdtempSync(join(tmpdir(), "ccu-mcp-e2e-stdio-"));
+
+    // --stdio (the CLI flag, not MCP_TRANSPORT) is what the README documents,
+    // so that is the path under test.
+    child = spawn("node", [DIST, "--stdio"], {
+      env: {
+        ...cleanEnv(),
+        CCU_HOST: "127.0.0.1",
+        CCU_PORT: String(ccu.port),
+        CCU_HTTPS: "false",
+        CCU_PASSWORD: "mock",
+        CACHE_DIR: cacheDir,
+        RESOURCE_POLL_INTERVAL: "3600",
+        LOG_LEVEL: "error",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    client = new StdioClient(child);
+
+    const init = await client.request("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "e2e-stdio", version: "1" },
+    }, 20_000);
+    expect(init.result?.serverInfo?.name).toBe("ccu-mcp");
+    client.notify("notifications/initialized");
+  }, 30_000);
+
+  afterAll(async () => {
+    child?.kill("SIGKILL");
+    ccu?.server.close();
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("lists tools over stdio", async () => {
+    const res = await client.request("tools/list");
+    const names = (res.result?.tools ?? []).map((t: { name: string }) => t.name);
+    expect(names).toContain("help");
+    expect(names).toContain("list_devices");
+  });
+
+  it("answers a tool call that needs no CCU", async () => {
+    const res = await client.request("tools/call", { name: "help", arguments: {} });
+    expect(res.result?.isError).toBeFalsy();
+    expect(JSON.stringify(res.result?.content ?? "")).toMatch(/ccu-mcp|tool/i);
+  });
+
+  it("reaches the mocked CCU through a tool call", async () => {
+    const res = await client.request("tools/call", { name: "list_devices", arguments: {} });
+    expect(res.result?.isError).toBeFalsy();
+    expect(ccu.calls).toContain("Session.login");
+  });
+
+  it("serves the same tool set on both transports", async () => {
+    const res = await client.request("tools/list");
+    // stdio must not silently register a different surface than HTTP does.
+    expect((res.result?.tools ?? []).length).toBeGreaterThan(20);
+  });
+
+  // Must be last: closing stdin terminates the server.
+  it("shuts down cleanly on stdin EOF, logging out of the CCU", async () => {
+    const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
+
+    // EOF, not a signal — this is how an MCP client normally ends a stdio server.
+    child.stdin!.end();
+
+    const code = await Promise.race([
+      exited,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("stdin-EOF shutdown timed out")), 12_000)),
+    ]);
+
+    expect(code).toBe(0);
+    // The regression guard: without the explicit stdin hooks the process exits
+    // via event-loop drain and never logs out, leaking the CCU session.
+    expect(ccu.calls).toContain("Session.logout");
+  }, 15_000);
+});

--- a/test/e2e/stdio-transport.test.ts
+++ b/test/e2e/stdio-transport.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createServer, type Server } from "node:http";
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { AddressInfo } from "node:net";
+import { DIST, distMissing } from "./_dist.js";
 
 // End-to-end test of the STDIO transport against the BUILT server (dist/) with
 // a mocked CCU. stdio is the documented default install path
@@ -17,7 +18,6 @@ import { AddressInfo } from "node:net";
 // exit via event-loop drain with no Session.logout — leaking a CCU session
 // toward "too many sessions" — and no cache save.
 
-const DIST = join(__dirname, "../../dist/index.js");
 
 /** process.env with every server config var scrubbed (see http-transport e2e). */
 function cleanEnv(): Record<string, string | undefined> {
@@ -108,7 +108,7 @@ class StdioClient {
   }
 }
 
-describe.skipIf(!existsSync(DIST))("stdio transport e2e (built server, mocked CCU)", () => {
+describe.skipIf(distMissing)("stdio transport e2e (built server, mocked CCU)", () => {
   let ccu: CcuMock;
   let child: ChildProcess;
   let client: StdioClient;

--- a/test/unit/auth-token-rotation.test.ts
+++ b/test/unit/auth-token-rotation.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { resolveAuthTokens, startAutoRotation } from "../../src/auth/token.js";
+import { Logger } from "../../src/logger.js";
+import { mkdtemp, readFile, writeFile, rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Runtime auto-rotation (src/auth/token.ts startAutoRotation). The tricky part
+// is not rotating on time — it is NOT rotating when the data dir is broken.
+// A tick that blindly adopted its own resolve would mint and announce a brand
+// new token every interval, 401ing the one clients are actually holding, and
+// it would do so silently for as long as the dir stays unwritable.
+
+const logger = new Logger("error");
+const HOUR = 3_600_000;
+
+/** Poll until `predicate` holds, so we never race the tick's async work. */
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 4000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await predicate()) return;
+    if (Date.now() > deadline) throw new Error("condition not reached within timeout");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+async function fileToken(dir: string): Promise<string | undefined> {
+  try {
+    const content = await readFile(join(dir, ".env"), "utf-8");
+    return content.match(/^MCP_AUTH_TOKEN=(.+)$/m)?.[1]?.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+describe("startAutoRotation", () => {
+  let dir: string;
+  let stop: (() => void) | undefined;
+  let stderr: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "ccu-mcp-rotation-"));
+    stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(async () => {
+    stop?.();
+    stop = undefined;
+    await rm(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("rotates on the immediate tick, without waiting out the first interval", async () => {
+    // A token already past its TTL: if the first tick only ran after `intervalMs`,
+    // clients would 401 for that whole window. The interval here is deliberately
+    // far longer than the test, so only the immediate tick can do the work.
+    await writeFile(
+      join(dir, ".env"),
+      `MCP_AUTH_TOKEN=stale-token\nMCP_AUTH_TOKEN_ISSUED=${Date.now() - 4 * HOUR}\n`,
+      "utf-8",
+    );
+    const tokens = await resolveAuthTokens({ dataDir: dir, ttlMs: HOUR, graceMs: HOUR }, logger);
+
+    stop = startAutoRotation(tokens, { dataDir: dir, ttlMs: HOUR, graceMs: HOUR }, logger, 600_000);
+
+    await waitFor(async () => (await fileToken(dir)) !== "stale-token");
+    const rotated = await fileToken(dir);
+    expect(rotated).toBeDefined();
+    expect(tokens.verify(rotated!)).toBe(true);
+  });
+
+  it("keeps the outgoing token valid for the grace window after rotating", async () => {
+    await writeFile(
+      join(dir, ".env"),
+      `MCP_AUTH_TOKEN=outgoing-token\nMCP_AUTH_TOKEN_ISSUED=${Date.now() - 4 * HOUR}\n`,
+      "utf-8",
+    );
+    const tokens = await resolveAuthTokens({ dataDir: dir, ttlMs: HOUR, graceMs: HOUR }, logger);
+
+    stop = startAutoRotation(tokens, { dataDir: dir, ttlMs: HOUR, graceMs: HOUR }, logger, 600_000);
+    await waitFor(async () => (await fileToken(dir)) !== "outgoing-token");
+
+    // Both must validate: a client mid-migration is not cut off.
+    expect(tokens.verify("outgoing-token")).toBe(true);
+    expect(tokens.verify((await fileToken(dir))!)).toBe(true);
+  });
+
+  it("stops ticking once the returned stop function is called", async () => {
+    const tokens = await resolveAuthTokens({ dataDir: dir, ttlMs: 50, graceMs: HOUR }, logger);
+    const stopFn = startAutoRotation(tokens, { dataDir: dir, ttlMs: 50, graceMs: HOUR }, logger, 20);
+
+    await waitFor(async () => (await fileToken(dir)) !== undefined);
+    stopFn();
+    const afterStop = await fileToken(dir);
+
+    // Several intervals' worth of wall clock with no further rotation.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await fileToken(dir)).toBe(afterStop);
+  });
+
+  describe("unwritable data dir", () => {
+    let brokenDir: string;
+
+    beforeEach(async () => {
+      // A FILE where the data dir should be: mkdir fails with ENOTDIR for any
+      // user, unlike chmod 000 which root ignores.
+      brokenDir = join(dir, "not-a-directory");
+      await writeFile(brokenDir, "", "utf-8");
+    });
+
+    it("does not replace the in-memory token while nothing can be persisted", async () => {
+      // Long TTL on purpose: a short one would expire the startup token and
+      // mask the thing under test. With a broken dir every tick mints a fresh
+      // token regardless of TTL, because it can never read a persisted one.
+      const opts = { dataDir: brokenDir, ttlMs: HOUR, graceMs: HOUR };
+      const tokens = await resolveAuthTokens(opts, logger);
+      // The startup mint was announced with the token echoed (it could not be saved).
+      const minted = String(stderr.mock.calls.at(-1)?.[0]).match(/token: (\S+)/)?.[1];
+      expect(minted).toBeDefined();
+      expect(tokens.verify(minted!)).toBe(true);
+
+      stderr.mockClear();
+      stop = startAutoRotation(tokens, opts, logger, 20);
+
+      // Let several ticks run. Each one resolves a fresh token internally; none
+      // may be adopted, or the token clients hold would stop validating.
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(tokens.verify(minted!)).toBe(true);
+      expect(tokens.liveCount()).toBe(1);
+    });
+
+    it("announces nothing per tick while the dir stays broken", async () => {
+      const opts = { dataDir: brokenDir, ttlMs: HOUR, graceMs: HOUR };
+      const tokens = await resolveAuthTokens(opts, logger);
+
+      stderr.mockClear();
+      stop = startAutoRotation(tokens, opts, logger, 20);
+      await new Promise((r) => setTimeout(r, 200));
+
+      // announceUnpersisted:false — a broken dir must not spam a new token on
+      // every tick, which would also invalidate the previous announcement.
+      const announcements = stderr.mock.calls.filter((c: unknown[]) => String(c[0]).includes("[ccu-mcp]"));
+      expect(announcements).toHaveLength(0);
+    });
+
+    it("adopts with grace once persistence recovers, without a 401 gap", async () => {
+      const opts = { dataDir: brokenDir, ttlMs: HOUR, graceMs: HOUR };
+      const tokens = await resolveAuthTokens(opts, logger);
+      const inMemory = String(stderr.mock.calls.at(-1)?.[0]).match(/token: (\S+)/)?.[1];
+      expect(inMemory).toBeDefined();
+
+      stop = startAutoRotation(tokens, opts, logger, 20);
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Operator fixes the data dir; the next tick persists for the first time.
+      await rm(brokenDir, { force: true });
+      await mkdir(brokenDir, { recursive: true });
+
+      await waitFor(async () => (await fileToken(brokenDir)) !== undefined);
+      const persisted = await fileToken(brokenDir);
+
+      expect(tokens.verify(persisted!)).toBe(true);
+      // The token clients were handed at startup keeps working through the overlap.
+      expect(tokens.verify(inMemory!)).toBe(true);
+    });
+  });
+
+  it("survives a failing tick and keeps the timer alive", async () => {
+    const opts = { dataDir: dir, ttlMs: 50, graceMs: HOUR };
+    const tokens = await resolveAuthTokens(opts, logger);
+    const before = await fileToken(dir);
+
+    const failing = vi.spyOn(logger, "error").mockImplementation(() => {});
+    stop = startAutoRotation(tokens, opts, logger, 20);
+    await waitFor(async () => (await fileToken(dir)) !== before);
+
+    // Rotation kept working; nothing escaped as an unhandled rejection.
+    expect(tokens.liveCount()).toBeGreaterThanOrEqual(1);
+    failing.mockRestore();
+  });
+});

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -159,14 +159,66 @@ describe("loadConfig", () => {
     process.env.CCU_PASSWORD = "pw";
 
     process.env.CCU_TIMEOUT = "0";
-    expect(() => loadConfig()).toThrow(/CCU_TIMEOUT must be a positive number/);
+    expect(() => loadConfig()).toThrow(/CCU_TIMEOUT must be a positive integer/);
 
     process.env.CCU_TIMEOUT = "-5000";
-    expect(() => loadConfig()).toThrow(/CCU_TIMEOUT must be a positive number/);
+    expect(() => loadConfig()).toThrow(/CCU_TIMEOUT must be a positive integer/);
     delete process.env.CCU_TIMEOUT;
 
     process.env.RESOURCE_POLL_INTERVAL = "-60";
-    expect(() => loadConfig()).toThrow(/RESOURCE_POLL_INTERVAL must be a positive number/);
+    expect(() => loadConfig()).toThrow(/RESOURCE_POLL_INTERVAL must be a positive integer/);
+  });
+
+  // Issue #119: parseInt() stopped at the first non-digit, so a unit suffix was
+  // silently truncated — "30s" became a 30 MILLISECOND timeout, and every call
+  // then failed looking like a slow CCU rather than a config typo.
+  it("rejects numeric env vars with a trailing unit or non-decimal notation", () => {
+    process.env.CCU_HOST = "test";
+    process.env.CCU_PASSWORD = "pw";
+
+    for (const bad of ["30s", "10000ms", "1e4", "0x10", "3000/tcp", "21.5", " "]) {
+      process.env.CCU_TIMEOUT = bad;
+      expect(() => loadConfig(), `should reject CCU_TIMEOUT=${JSON.stringify(bad)}`)
+        .toThrow(/CCU_TIMEOUT must be a positive integer/);
+    }
+    // surrounding whitespace on an otherwise valid value is still fine
+    process.env.CCU_TIMEOUT = " 30000 ";
+    expect(loadConfig().ccu.timeout).toBe(30000);
+    delete process.env.CCU_TIMEOUT;
+  });
+
+  // Issue #120: the raw comparison `=== "true"` made a trailing space read as
+  // false. For PROTECTED/READONLY that failed OPEN — the production write gate
+  // silently disabled. Docker passes `environment:` values verbatim.
+  it("trims boolean env vars so a trailing space cannot disable a safety gate", () => {
+    process.env.CCU_PROFILES = "prod";
+    process.env.CCU_PROD_HOST = "ccu";
+    process.env.CCU_PROD_PASSWORD = "pw";
+    process.env.CCU_PROD_PROTECTED = "true ";
+    process.env.CCU_PROD_READONLY = " TRUE";
+
+    const prod = loadConfig().profiles[0]!;
+    expect(prod.protected).toBe(true);
+    expect(prod.readonly).toBe(true);
+  });
+
+  it("rejects a non-boolean value instead of reading it as false", () => {
+    process.env.CCU_PROFILES = "prod";
+    process.env.CCU_PROD_HOST = "ccu";
+    process.env.CCU_PROD_PASSWORD = "pw";
+    process.env.CCU_PROD_PROTECTED = "yes";
+    expect(() => loadConfig()).toThrow(/CCU_PROD_PROTECTED must be "true" or "false"/);
+  });
+
+  // Issue #124: `name === "default"` conflated the flat back-compat profile with
+  // a profile literally NAMED "default", which reads CCU_DEFAULT_*. The hint
+  // named a variable that profile never reads.
+  it("names the variable the profile actually reads in the TLS-on-plain-HTTP error", () => {
+    process.env.CCU_PROFILES = "default";
+    process.env.CCU_DEFAULT_HOST = "ccu";
+    process.env.CCU_DEFAULT_PASSWORD = "pw";
+    process.env.CCU_DEFAULT_TLS_VERIFY = "true"; // TLS setting without HTTPS
+    expect(() => loadConfig()).toThrow(/Set CCU_DEFAULT_HTTPS=true/);
   });
 
   // Issue #28 / #37: HTTP transport hardening

--- a/test/unit/device-type-cache-warm.test.ts
+++ b/test/unit/device-type-cache-warm.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { DeviceTypeCache } from "../../src/cache/device-type-cache.js";
+import { Logger } from "../../src/logger.js";
+import { RateLimiter } from "../../src/middleware/rate-limiter.js";
+import type { SessionManager } from "../../src/ccu/session.js";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Covers the warm/parse half of DeviceTypeCache, which the existing suite
+// leaves out: the TCL VALUE_LIST tokenizer, the device/channel filtering, and
+// the failure paths that must degrade instead of aborting a warm run.
+
+const logger = new Logger("error");
+
+/** A SessionManager stand-in driven by a per-method script. */
+function fakeSession(handlers: Record<string, (params?: any) => unknown>): SessionManager {
+  return {
+    call: async (method: string, params?: any) => {
+      const h = handlers[method];
+      if (!h) throw new Error(`unexpected CCU call: ${method}`);
+      return h(params);
+    },
+  } as unknown as SessionManager;
+}
+
+/** Fast limiter — these tests care about logic, not pacing. */
+function limiter(): RateLimiter {
+  return new RateLimiter(1000, 1000);
+}
+
+const ETRV_DESC = [
+  { ID: "SET_POINT_TEMPERATURE", TYPE: "FLOAT", OPERATIONS: "7", MIN: "4.5", MAX: "30.5", UNIT: "°C" },
+];
+
+describe("DeviceTypeCache.warm", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "ccu-mcp-warm-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("caches one entry per device type and skips channels", async () => {
+    const session = fakeSession({
+      "Interface.listInterfaces": () => [{ name: "HmIP-RF" }],
+      "Interface.listDevices": () => [
+        { type: "HmIP-eTRV-2", address: "0001", children: ["0001:1"] },
+        // Same type again — must be deduplicated, not re-queried.
+        { type: "HmIP-eTRV-2", address: "0002", children: ["0002:1"] },
+        // A channel (no children) — must be skipped entirely.
+        { type: "MAINTENANCE", address: "0001:0", parent: "0001" },
+      ],
+      "Interface.getParamsetDescription": () => ETRV_DESC,
+    });
+
+    const cache = new DeviceTypeCache(dir, 86400, logger);
+    await cache.warm(session, limiter());
+
+    expect(cache.size()).toBe(1);
+    expect(cache.has("HmIP-eTRV-2")).toBe(true);
+    expect(cache.has("MAINTENANCE")).toBe(false);
+    expect(cache.get("HmIP-eTRV-2")?.interface).toBe("HmIP-RF");
+  });
+
+  it("skips an interface whose device listing fails and keeps the rest", async () => {
+    const session = fakeSession({
+      "Interface.listInterfaces": () => [{ name: "BidCos-RF" }, { name: "HmIP-RF" }],
+      "Interface.listDevices": (p: { interface: string }) => {
+        if (p.interface === "BidCos-RF") throw new Error("interface down");
+        return [{ type: "HmIP-eTRV-2", address: "0001", children: ["0001:1"] }];
+      },
+      "Interface.getParamsetDescription": () => ETRV_DESC,
+    });
+
+    const cache = new DeviceTypeCache(dir, 86400, logger);
+    await cache.warm(session, limiter());
+
+    // One bad interface must not abort the whole warm run.
+    expect(cache.has("HmIP-eTRV-2")).toBe(true);
+  });
+
+  it("keeps a device type whose paramset query fails, minus the failed paramset", async () => {
+    const session = fakeSession({
+      "Interface.listInterfaces": () => [{ name: "HmIP-RF" }],
+      "Interface.listDevices": () => [{ type: "HmIP-eTRV-2", address: "0001", children: ["0001:1"] }],
+      "Interface.getParamsetDescription": (p: { paramsetKey: string }) => {
+        // Many channels don't implement MASTER — that is normal, not an error.
+        if (p.paramsetKey === "MASTER") throw new Error("no such paramset");
+        return ETRV_DESC;
+      },
+    });
+
+    const cache = new DeviceTypeCache(dir, 86400, logger);
+    await cache.warm(session, limiter());
+
+    const channel = cache.get("HmIP-eTRV-2")?.channels["1"];
+    expect(channel?.paramsets.VALUES).toBeDefined();
+    expect(channel?.paramsets.MASTER).toBeUndefined();
+  });
+
+  it("does not start a second warm run while one is in flight", async () => {
+    let listCalls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+
+    const session = fakeSession({
+      "Interface.listInterfaces": async () => { listCalls++; await gate; return []; },
+    });
+
+    const cache = new DeviceTypeCache(dir, 86400, logger);
+    const first = cache.warm(session, limiter());
+    expect(cache.isWarming()).toBe(true);
+
+    // Second call must return immediately instead of duplicating CCU load.
+    await cache.warm(session, limiter());
+    expect(listCalls).toBe(1);
+
+    release();
+    await first;
+    expect(cache.isWarming()).toBe(false);
+  });
+
+  describe("VALUE_LIST parsing (TCL list from getparamsetdescription.tcl)", () => {
+    async function valueListFor(raw: unknown): Promise<string[] | undefined> {
+      const session = fakeSession({
+        "Interface.listInterfaces": () => [{ name: "HmIP-RF" }],
+        "Interface.listDevices": () => [{ type: "T", address: "0001", children: ["0001:1"] }],
+        "Interface.getParamsetDescription": (p: { paramsetKey: string }) =>
+          p.paramsetKey === "VALUES"
+            ? [{ ID: "MODE", TYPE: "ENUM", OPERATIONS: "7", VALUE_LIST: raw }]
+            : [],
+      });
+      const cache = new DeviceTypeCache(dir, 86400, logger);
+      await cache.warm(session, limiter());
+      return cache.get("T")?.channels["1"].paramsets.VALUES?.MODE.valueList;
+    }
+
+    it("passes a real array through untouched", async () => {
+      expect(await valueListFor(["AUTO", "MANU"])).toEqual(["AUTO", "MANU"]);
+    });
+
+    it("splits a plain space-joined string", async () => {
+      expect(await valueListFor("AUTO MANU BOOST")).toEqual(["AUTO", "MANU", "BOOST"]);
+    });
+
+    it("keeps brace-wrapped entries that contain spaces as one label", async () => {
+      // The case the tokenizer exists for: enum indexes must line up with the
+      // real value list, so '{Party Mode}' is ONE entry, not two.
+      expect(await valueListFor("{Party Mode} Off {Boost Mode}")).toEqual([
+        "Party Mode", "Off", "Boost Mode",
+      ]);
+    });
+
+    it("handles nested braces and collapses runs of spaces", async () => {
+      expect(await valueListFor("  {outer {inner} tail}   plain  ")).toEqual([
+        "outer {inner} tail", "plain",
+      ]);
+    });
+
+    it("does not hang or drop data on an unterminated brace", async () => {
+      expect(await valueListFor("{never closed")).toEqual(["never closed"]);
+    });
+  });
+});
+
+describe("DeviceTypeCache.saveToDisk failure handling", () => {
+  it("logs instead of throwing when the cache dir cannot be written", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "ccu-mcp-save-"));
+    // A file where the cache dir should be: mkdir fails with ENOTDIR for any
+    // user, unlike chmod 000 which root ignores.
+    const blocked = join(parent, "not-a-dir");
+    await writeFile(blocked, "", "utf-8");
+
+    const errors: string[] = [];
+    const noisy = new Logger("error");
+    vi.spyOn(noisy, "error").mockImplementation((msg: string) => { errors.push(msg); });
+
+    const cache = new DeviceTypeCache(blocked, 86400, noisy);
+    // Must resolve: a save failure is logged, never propagated into shutdown.
+    await expect(cache.saveToDisk()).resolves.toBeUndefined();
+    expect(errors).toContain("cache_save_failed");
+
+    vi.restoreAllMocks();
+    await rm(parent, { recursive: true, force: true });
+  });
+});

--- a/test/unit/device-type-cache.test.ts
+++ b/test/unit/device-type-cache.test.ts
@@ -143,8 +143,8 @@ describe("DeviceTypeCache", () => {
     const rateLimiter = { acquire: async () => {} } as any;
 
     const [a, b] = await Promise.all([
-      cache.queryAndCache("HmIP-X", "ADDR", "HmIP-RF", ["ADDR:1"], session, rateLimiter),
-      cache.queryAndCache("HmIP-X", "ADDR", "HmIP-RF", ["ADDR:1"], session, rateLimiter),
+      cache.queryAndCache("HmIP-X", "HmIP-RF", ["ADDR:1"], session, rateLimiter),
+      cache.queryAndCache("HmIP-X", "HmIP-RF", ["ADDR:1"], session, rateLimiter),
     ]);
 
     // 1 channel × 2 paramset keys = 2 CCU calls if coalesced, 4 if duplicated
@@ -225,7 +225,7 @@ describe("warm edge cases (coverage round)", () => {
     } as any;
     const rateLimiter = { acquire: async () => {} } as any;
 
-    const cached = await cache.queryAndCache("HmIP-X", "A1", "HmIP-RF", ["A1:1"], session, rateLimiter);
+    const cached = await cache.queryAndCache("HmIP-X", "HmIP-RF", ["A1:1"], session, rateLimiter);
     const param = cached!.channels["1"]!.paramsets["VALUES"]!["LEVEL"]!;
     expect(param).toMatchObject({ type: "FLOAT", operations: 7, min: 0, max: 1.01, unit: "%", valueList: ["a", "b"] });
     await new Promise((r) => setTimeout(r, 25)); // let background save finish

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -27,8 +27,10 @@ function envKeysReferencedInCode(): Set<string> {
     for (const m of text.matchAll(/process\.env(?:\.([A-Z][A-Z0-9_]*)|\["([A-Z][A-Z0-9_]*)"\])/g)) {
       keys.add(m[1] ?? m[2]);
     }
-    // parseIntEnv("FOO", ...) / parseDurationEnv("FOO", ...) — indirect reads
-    for (const m of text.matchAll(/parse(?:Int|Duration)Env\("([A-Z][A-Z0-9_]*)"/g)) {
+    // parseIntEnv("FOO", …) / parseDurationEnv("FOO", …) / parseBoolEnv("FOO")
+    // — indirect reads. Keep this alternation in step with the helpers in
+    // config.ts, or a var read only through a new helper looks undocumented.
+    for (const m of text.matchAll(/parse(?:Int|Duration|Bool)Env\("([A-Z][A-Z0-9_]*)"/g)) {
       keys.add(m[1]);
     }
   }

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -46,6 +46,43 @@ function envKeysInExample(): Set<string> {
   return keys;
 }
 
+// server.json is the MCP REGISTRY manifest — what someone installing from the
+// registry reads. It drifted to 10 of 30 variables because nothing checked it
+// (issue #126). It is not a straight mirror of the code: the manifest declares
+// the STDIO package, so the HTTP-transport variables genuinely do not apply.
+// List those exemptions explicitly, so the exemption is a decision on the
+// record rather than an omission.
+const SERVER_JSON = join(__dirname, "../../server.json");
+const HTTP_ONLY_VARS = new Set([
+  "MCP_TRANSPORT", "MCP_PORT", "MCP_HOST",
+  "MCP_AUTH_TOKEN", "MCP_AUTH_TOKEN_PREVIOUS", "MCP_AUTH_TOKEN_TTL_DAYS", "MCP_AUTH_TOKEN_GRACE_HOURS",
+  "MCP_TLS_CERT", "MCP_TLS_KEY", "MCP_ALLOW_PLAINTEXT",
+  "MCP_ALLOWED_ORIGINS", "MCP_ALLOWED_HOSTS",
+]);
+
+describe("server.json (MCP registry manifest)", () => {
+  const manifest = () => JSON.parse(readFileSync(SERVER_JSON, "utf-8"));
+
+  it("documents every env var that applies to the stdio package", () => {
+    const declared = new Set<string>(
+      (manifest().packages[0].environmentVariables ?? []).map((v: { name: string }) => v.name),
+    );
+    const missing = [...envKeysReferencedInCode()]
+      .filter((k) => !HTTP_ONLY_VARS.has(k) && !declared.has(k))
+      .sort();
+    expect(missing, `env vars read in code but missing from server.json: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("does not declare env vars the code never reads", () => {
+    const code = envKeysReferencedInCode();
+    const stale = ((manifest().packages[0].environmentVariables ?? []) as Array<{ name: string }>)
+      .map((v) => v.name)
+      .filter((n) => !code.has(n))
+      .sort();
+    expect(stale, `env vars in server.json not read anywhere in code: ${stale.join(", ")}`).toEqual([]);
+  });
+});
+
 describe(".env.example", () => {
   it("documents every env var the code reads", () => {
     const code = envKeysReferencedInCode();

--- a/test/unit/http-error-response.test.ts
+++ b/test/unit/http-error-response.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ServerResponse } from "node:http";
+import { endWithInternalError } from "../../src/http/error-response.js";
+
+/** Minimal ServerResponse stand-in recording what the handler did to it. */
+function fakeRes(headersSent: boolean) {
+  const res = {
+    headersSent,
+    writeHead: vi.fn(),
+    end: vi.fn(),
+  };
+  return res as unknown as ServerResponse & typeof res;
+}
+
+describe("endWithInternalError", () => {
+  it("sends a 500 JSON body when nothing has been written yet", () => {
+    const res = fakeRes(false);
+    endWithInternalError(res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(500, { "Content-Type": "application/json" });
+    expect(res.end).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(res.end.mock.calls[0]![0] as string)).toEqual({ error: "Internal error" });
+  });
+
+  // Issue #123: the old code guarded writeHead on headersSent but not end(), so
+  // a failure on an already-open SSE stream appended {"error":"Internal error"}
+  // into the event stream — not a valid `data:` frame, not an event boundary.
+  it("closes an already-committed response without writing a body into it", () => {
+    const res = fakeRes(true);
+    endWithInternalError(res);
+
+    expect(res.writeHead).not.toHaveBeenCalled();
+    expect(res.end).toHaveBeenCalledTimes(1);
+    // the decisive assertion: end() called with NO payload
+    expect(res.end.mock.calls[0]).toEqual([]);
+  });
+});

--- a/test/unit/server-subscriptions.test.ts
+++ b/test/unit/server-subscriptions.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { createMcpServer, serverSubscriptions } from "../../src/server.js";
+import { RESOURCE_URIS } from "../../src/resources/registry.js";
+import { createMockDeps } from "./_helpers.js";
+import {
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+  ErrorCode,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
+
+// resources/subscribe and resources/unsubscribe are hand-registered in
+// src/server.ts because the SDK's McpServer backs no handler for the
+// capability we advertise. Nothing exercised those handlers, so the
+// subscription set the ResourcePoller consults was untested.
+
+/** Invoke a registered request handler the way the SDK transport would. */
+async function callHandler(server: any, schema: any, params: unknown): Promise<unknown> {
+  const method = schema.shape.method.value as string;
+  const handler = server.server._requestHandlers.get(method);
+  expect(handler, `no handler registered for ${method}`).toBeDefined();
+  return handler({ method, params }, { signal: new AbortController().signal });
+}
+
+describe("resources/subscribe handlers", () => {
+  it("records a subscription for a known URI", async () => {
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+    const uri = RESOURCE_URIS[0];
+
+    await callHandler(server, SubscribeRequestSchema, { uri });
+
+    // The poller reads exactly this set to decide who gets notified.
+    expect(serverSubscriptions.get(server)?.has(uri)).toBe(true);
+    deps.rateLimiter.destroy();
+  });
+
+  it("rejects an unknown URI instead of silently accepting it", async () => {
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+
+    // Accepting a typo would leave the client waiting forever for
+    // notifications that can never arrive.
+    await expect(
+      callHandler(server, SubscribeRequestSchema, { uri: "ccu://typo" }),
+    ).rejects.toThrow(McpError);
+
+    try {
+      await callHandler(server, SubscribeRequestSchema, { uri: "ccu://typo" });
+    } catch (err) {
+      expect((err as McpError).code).toBe(ErrorCode.InvalidParams);
+      // The error must name the valid URIs so the client can self-correct.
+      expect((err as McpError).message).toContain(RESOURCE_URIS[0]);
+    }
+
+    expect(serverSubscriptions.get(server)?.size).toBe(0);
+    deps.rateLimiter.destroy();
+  });
+
+  it("unsubscribe removes the URI and is idempotent", async () => {
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+    const uri = RESOURCE_URIS[0];
+
+    await callHandler(server, SubscribeRequestSchema, { uri });
+    await callHandler(server, UnsubscribeRequestSchema, { uri });
+    expect(serverSubscriptions.get(server)?.has(uri)).toBe(false);
+
+    // Unsubscribing something never subscribed must not throw.
+    await expect(
+      callHandler(server, UnsubscribeRequestSchema, { uri }),
+    ).resolves.toEqual({});
+    deps.rateLimiter.destroy();
+  });
+
+  it("keeps subscription sets separate per server instance", async () => {
+    const depsA = createMockDeps();
+    const depsB = createMockDeps();
+    const a = createMcpServer(depsA);
+    const b = createMcpServer(depsB);
+
+    await callHandler(a, SubscribeRequestSchema, { uri: RESOURCE_URIS[0] });
+
+    // In HTTP mode every client gets its own McpServer; one client's
+    // subscribe must not leak notifications to another.
+    expect(serverSubscriptions.get(a)?.has(RESOURCE_URIS[0])).toBe(true);
+    expect(serverSubscriptions.get(b)?.has(RESOURCE_URIS[0])).toBe(false);
+
+    depsA.rateLimiter.destroy();
+    depsB.rateLimiter.destroy();
+  });
+});

--- a/test/unit/tools-control.test.ts
+++ b/test/unit/tools-control.test.ts
@@ -268,6 +268,51 @@ describe("set_system_variable handler", () => {
     expect(result.note).toMatch(/could not be verified/);
     cleanupDeps(deps);
   });
+
+  it("reports CCU_ERROR when setBool answers the -1 script-failure sentinel (#118)", async () => {
+    // setbool.tcl: `if {[hmscript ...]} { response $value } else { response -1 }`.
+    // The old code discarded this, and getValueByName still returned the OLD
+    // value — so a lost write read as a success.
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [{ name: "Anwesenheit", type: "LOGIC" }];
+      if (method === "SysVar.setBool") return -1;
+      if (method === "SysVar.getValueByName") return "false"; // stale value still present
+      return true;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "set_system_variable", { name: "Anwesenheit", value: true });
+    expect(result.isError).toBe(true);
+    const err = JSON.parse(result.content[0].text);
+    expect(err.error).toBe("CCU_ERROR");
+    expect(err.message).toMatch(/NOT written/);
+    cleanupDeps(deps);
+  });
+
+  it("accepts a legitimate -1 on a numeric variable (the sentinel is ambiguous there, and fails open)", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "SysVar.getAll") return [{ name: "Delta", type: "NUMBER" }];
+      if (method === "SysVar.setFloat") return -1; // indistinguishable from success here
+      if (method === "SysVar.getValueByName") return "-1";
+      return true;
+    });
+    const { server, deps } = createTestServer({ sessionCall });
+    const result = parseToolResult(await callTool(server, "set_system_variable", { name: "Delta", value: -1 })) as any;
+    expect(result.value).toBe(-1);
+    expect(result.method).toBe("SysVar.setFloat");
+    cleanupDeps(deps);
+  });
+
+  it("rejects an enum variable the CCU reports with no value list (#122)", async () => {
+    const sessionCall = vi.fn().mockImplementation(async (method: string) =>
+      method === "SysVar.getAll" ? [{ name: "Modus", type: "LIST" }] : true);
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "set_system_variable", { name: "Modus", value: 0 });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("CCU_ERROR");
+    // never attempts the write
+    expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "SysVar.setFloat")).toBe(false);
+    cleanupDeps(deps);
+  });
 });
 
 describe("create_system_variable handler", () => {
@@ -337,6 +382,31 @@ describe("create_system_variable handler", () => {
     cleanupDeps(deps);
   });
 
+  it("rejects min >= max on a float variable (#122)", async () => {
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "create_system_variable", { name: "T", type: "float", min: 100, max: 0 });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).message).toMatch(/must be less than max/);
+    expect(sessionCall).not.toHaveBeenCalled();
+    cleanupDeps(deps);
+  });
+
+  it("rejects arguments that don't apply to the chosen type instead of dropping them (#122)", async () => {
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+    // min/max/unit are float-only — silently ignored before, so this created a plain bool
+    const bad: any = await callTool(server, "create_system_variable", { name: "B", type: "bool", min: 0, max: 40, unit: "°C" });
+    expect(bad.isError).toBe(true);
+    expect(JSON.parse(bad.content[0].text).message).toMatch(/do not apply to a "bool"/);
+    // values is enum-only
+    const bad2: any = await callTool(server, "create_system_variable", { name: "F", type: "float", values: ["a", "b"] });
+    expect(bad2.isError).toBe(true);
+    expect(JSON.parse(bad2.content[0].text).message).toMatch(/values does not apply/);
+    expect(sessionCall).not.toHaveBeenCalled();
+    cleanupDeps(deps);
+  });
+
   it("rejects min/max magnitudes that stringify to exponent notation", async () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => (method === "SysVar.getAll" ? [] : null));
     const { server, deps } = createTestServer({ sessionCall });
@@ -386,13 +456,29 @@ describe("create_system_variable handler", () => {
 
 describe("delete_system_variable handler", () => {
   it("deletes an existing variable via deleteSysVarByName", async () => {
+    // deletesysvarbyname.tcl echoes hmscript's output, whose only Write is "true".
     const sessionCall = vi.fn().mockImplementation(async (method: string) =>
-      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : null);
+      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : "true");
     const { server, deps } = createTestServer({ sessionCall });
 
     const result = parseToolResult(await callTool(server, "delete_system_variable", { name: "Urlaub" })) as any;
     expect(result).toEqual({ name: "Urlaub", deleted: true });
     expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "SysVar.deleteSysVarByName")).toBe(true);
+    cleanupDeps(deps);
+  });
+
+  it("reports CCU_ERROR when the delete script failed, instead of deleted:true (#118)", async () => {
+    // hmscript returns "" on any script error; the old code ignored the result
+    // and reported a successful delete for a variable that is still there.
+    const sessionCall = vi.fn().mockImplementation(async (method: string) =>
+      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : "");
+    const { server, deps } = createTestServer({ sessionCall });
+
+    const result: any = await callTool(server, "delete_system_variable", { name: "Urlaub" });
+    expect(result.isError).toBe(true);
+    const err = JSON.parse(result.content[0].text);
+    expect(err.error).toBe("CCU_ERROR");
+    expect(err.message).toMatch(/NOT deleted/);
     cleanupDeps(deps);
   });
 
@@ -578,6 +664,16 @@ describe("remaining error paths (coverage round)", () => {
 
     const call = sessionCall.mock.calls.find((c: unknown[]) => c[0] === "Interface.putParamset");
     expect((call![1] as any).set).toEqual([{ name: "SET_POINT_TEMPERATURE", type: "double", value: "21.5" }]);
+    cleanupDeps(deps);
+  });
+
+  it("put_paramset rejects an empty set instead of reporting a no-op write as success (#131)", async () => {
+    const sessionCall = vi.fn();
+    const { server, deps } = createTestServer({ sessionCall });
+    const result: any = await callTool(server, "put_paramset", { address: "AAA:1", paramsetKey: "VALUES", set: {}, interface: "HmIP-RF" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("INVALID_INPUT");
+    expect(sessionCall.mock.calls.some((c: unknown[]) => c[0] === "Interface.putParamset")).toBe(false);
     cleanupDeps(deps);
   });
 

--- a/test/unit/tools-targets.test.ts
+++ b/test/unit/tools-targets.test.ts
@@ -152,8 +152,9 @@ describe("per-call confirm for high-impact tools (issue #72)", () => {
   });
 
   it("delete_system_variable refuses without confirm even after the session is unlocked", async () => {
+    // "true" is what deletesysvarbyname.tcl really answers; the tool checks it (#118).
     const sessionCall = vi.fn().mockImplementation(async (method: string) =>
-      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : null);
+      method === "SysVar.getAll" ? [{ name: "Urlaub", type: "BOOL" }] : "true");
     const t = createTestServer({ protected: true, sessionCall });
     deps = t.deps;
     await unlockSession(t.server);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,21 @@ export default defineConfig({
     coverage: {
       // Count every source file, including ones no test imports
       include: ["src/**/*.ts"],
+      // Floor, set just under the numbers at the time of writing so ordinary
+      // work doesn't trip it but a real slide does. Hermetic — a pure function
+      // of the commit under test, so it stays inside the `build-and-test`
+      // contract described in ci.yml.
+      //
+      // GLOBAL only, deliberately: src/index.ts reads as 0% because the e2e
+      // suites spawn it as a subprocess and v8 coverage cannot attribute those.
+      // A per-file threshold would fail on it permanently, for a measurement
+      // artifact rather than a real gap.
+      thresholds: {
+        statements: 85,
+        branches: 79,
+        functions: 87,
+        lines: 85,
+      },
     },
   },
 });


### PR DESCRIPTION
A correctness release. A review pass over the whole source tree found two
classes of problem worth a version of their own: places where a *failed* CCU
write was reported to the client as success, and places where a malformed
environment variable was silently reinterpreted rather than rejected. Both
fail in the same direction — quietly, and in the direction that looks like
everything worked.

**Behavior changes — read before upgrading.** Malformed numeric settings and
non-boolean booleans now abort startup instead of being partially parsed.
`CCU_TIMEOUT=30s` used to become a 30 *millisecond* timeout;
`CCU_PROD_PROTECTED=true ` with a trailing space evaluated to false and
silently disabled the write-confirmation gate on the protected target. Full
detail and the complete list of rejected variables is in `CHANGELOG.md` and
the README's *Configuration errors* table.

Pre-flight, all green: `npm run check:versions`, `npm run lint`, `npm test`
(434 passed, 26 skipped — the `CCU_HOST`-gated live suite), `npm publish
--dry-run`, `mcp-publisher validate`. `npm ci` reports 0 vulnerabilities.

---

Closes #112 — CLI: support --version and --help without a configured CCU environment
Closes #113 — docs: the configuration errors that abort startup are undocumented
Closes #118 — set_system_variable / delete_system_variable report success when the CCU says the write failed
Closes #119 — parseIntEnv accepts trailing garbage: CCU_TIMEOUT=30s silently becomes a 30 ms timeout
Closes #120 — Boolean env vars are compared untrimmed — a trailing space in CCU_<P>_PROTECTED silently disables the write gate
Closes #121 — DeviceTypeCache: paramset-fetch loop duplicated between warm() and doQueryAndCache(), and has already drifted
Closes #122 — System-variable input validation gaps: unchecked float min/max, silently ignored args, degenerate empty enum
Closes #123 — HTTP error path appends a JSON body to an already-streaming SSE response
Closes #124 — Cleanup: wrong env var in a config hint, triplicated slug expression, dead ternaries, off-by-filter log count
Closes #125 — put_paramset stringifies values while set_value sends them raw — needs live verification
Closes #126 — server.json documents 10 of 30 env vars (incl. none of the CCU TLS verification settings) and nothing guards it
Closes #127 — CI: fork PRs into dev run no checks at all; plus double build, no run cancellation, no coverage floor
Closes #128 — Test suite: all six e2e blocks skip silently without dist/, and random port allocation can collide
Closes #129 — fail2ban filter test asserts against a hand-mirrored log line, not the one src/index.ts actually emits
Closes #131 — put_paramset accepts an empty set object and reports success
