### PR TITLE
test: guard the tool and env-var docs against drift

### DIFF
--- a/test/unit/docs-drift.test.ts
+++ b/test/unit/docs-drift.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
+
+// Docs-drift guard for the TOOL surfaces. Four places name the tool set, and
+// exactly one of them is the truth:
+//
+//   1. the MCP registration itself           — the truth
+//   2. the `help` tool's per-tool docs       — TOOL_HELP in src/tools/meta.ts
+//   3. the `help` tool's conceptual guide    — "## Available Tools", same file
+//   4. README.md's "## Tools" section        — plus its hardcoded tool COUNT
+//
+// A tool added without touching 2-4 ships invisible: it works over MCP, but the
+// help tool — which is how a model discovers what it can do here — never
+// mentions it, and the README undersells the server. CLAUDE.md's QA loop lists
+// "update the help tool's text" as a MANUAL step after every change, which is
+// exactly the kind of instruction that holds until the one time it doesn't.
+//
+// Everything below is derived BEHAVIOURALLY: the registry is read off a real
+// server, and both help surfaces come from actually calling `help`. Nothing
+// regex-scrapes meta.ts, because tool names are not always literals at the
+// registration site — `registerAssignChannel(server, deps, "add")` builds
+// `assign_channel` at runtime, so a static scan silently under-reports and the
+// guard would pass by never learning about the tool it was meant to catch.
+
+const README = join(__dirname, "../../README.md");
+
+/** Every tool actually registered on the server — the source of truth. */
+function registeredTools(): string[] {
+  const { server, deps } = createTestServer();
+  try {
+    const reg = (server as unknown as { _registeredTools: Record<string, unknown> })._registeredTools;
+    return Object.keys(reg).sort();
+  } finally {
+    cleanupDeps(deps);
+  }
+}
+
+/**
+ * The tools `help` has per-tool docs for. Recovered from the unknown-topic
+ * reply, which enumerates `Object.keys(TOOL_HELP)` — behaviour rather than
+ * source text, so it stays correct if that table is ever refactored.
+ */
+async function toolsWithHelpEntries(): Promise<string[]> {
+  const { server, deps } = createTestServer();
+  try {
+    const res = await callTool(server, "help", { topic: "no such topic" });
+    const text = parseToolResult(res) as string;
+    const line = text.split("\n").find((l) => l.startsWith("Available tools:"));
+    if (!line) throw new Error(`help's unknown-topic reply changed shape:\n${text}`);
+    return line
+      .replace("Available tools:", "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .sort();
+  } finally {
+    cleanupDeps(deps);
+  }
+}
+
+/** The conceptual guide `help` returns when given no topic. */
+async function conceptualGuide(): Promise<string> {
+  const { server, deps } = createTestServer();
+  try {
+    return parseToolResult(await callTool(server, "help", {})) as string;
+  } finally {
+    cleanupDeps(deps);
+  }
+}
+
+/**
+ * Tool names appearing in one markdown section, located by heading and ending
+ * at the next heading of the same or higher level. Tool names are snake_case;
+ * `help` is the only one without an underscore.
+ */
+function toolNamesInSection(text: string, heading: string): string[] {
+  const start = text.indexOf(heading);
+  if (start === -1) throw new Error(`section "${heading}" not found — was the heading renamed?`);
+  const rest = text.slice(start + heading.length);
+  const level = heading.match(/^#+/)?.[0].length ?? 2;
+  const next = rest.search(new RegExp(`^#{1,${level}} `, "m"));
+  const body = next === -1 ? rest : rest.slice(0, next);
+  const found = [...body.matchAll(/\b(help|[a-z]+(?:_[a-z]+)+)\b/g)].map((m) => m[1]);
+  return [...new Set(found)].sort();
+}
+
+describe("docs drift: the help tool vs the registered tools", () => {
+  it("has a help entry for every registered tool", async () => {
+    const documented = new Set(await toolsWithHelpEntries());
+    const missing = registeredTools().filter((t) => !documented.has(t));
+    expect(
+      missing,
+      `registered but absent from TOOL_HELP in src/tools/meta.ts: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("has no help entry for a tool that isn't registered", async () => {
+    const registered = new Set(registeredTools());
+    const stale = (await toolsWithHelpEntries()).filter((t) => !registered.has(t));
+    expect(
+      stale,
+      `documented in TOOL_HELP but no longer registered: ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("lists every registered tool in the guide's Available Tools section", async () => {
+    const listed = new Set(toolNamesInSection(await conceptualGuide(), "## Available Tools"));
+    const missing = registeredTools().filter((t) => !listed.has(t));
+    expect(
+      missing,
+      `missing from CONCEPTUAL_GUIDE's "## Available Tools": ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("lists no unregistered tool in the guide's Available Tools section", async () => {
+    const registered = new Set(registeredTools());
+    const stale = toolNamesInSection(await conceptualGuide(), "## Available Tools").filter(
+      (t) => !registered.has(t),
+    );
+    expect(
+      stale,
+      `listed in CONCEPTUAL_GUIDE's "## Available Tools" but not registered: ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+});
+
+describe("docs drift: README vs the registered tools", () => {
+  const readme = () => readFileSync(README, "utf-8");
+
+  it("names every registered tool in the Tools section", () => {
+    const listed = new Set(toolNamesInSection(readme(), "## Tools"));
+    const missing = registeredTools().filter((t) => !listed.has(t));
+    expect(
+      missing,
+      `registered but absent from README's "## Tools": ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("names no unregistered tool in the Tools section", () => {
+    const registered = new Set(registeredTools());
+    const stale = toolNamesInSection(readme(), "## Tools").filter((t) => !registered.has(t));
+    expect(
+      stale,
+      `named in README's "## Tools" but not registered: ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  // The count is prose, so nothing else can catch it going stale — and it is
+  // the first thing a reader checks the list against.
+  it("states the correct tool count", () => {
+    const m = readme().match(/(\d+) tools organized/);
+    expect(m, 'README must state "<N> tools organized by ..." in the Tools section').not.toBeNull();
+    const count = registeredTools().length;
+    expect(Number(m![1]), `README says ${m![1]} tools; ${count} are registered`).toBe(count);
+  });
+});

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -98,3 +98,55 @@ describe(".env.example", () => {
     expect(stale, `env vars in .env.example not read anywhere in code: ${stale.join(", ")}`).toEqual([]);
   });
 });
+
+// README.md is the third surface, and the only one a user reads BEFORE
+// installing — .env.example and server.json are both things you meet after
+// you've already committed to the server. It was the one surface nothing
+// checked.
+const README = join(__dirname, "../../README.md");
+
+// Documented in the "Multiple CCU targets (profiles)" section as a worked
+// .env example rather than as table rows, because they are not standalone
+// settings: CCU_PROFILES names the profiles, and every other profile variable
+// is spelled CCU_<PROFILE>_* and so cannot be tabulated by a fixed name at all.
+// Listed explicitly so the exemption is a decision on the record rather than an
+// omission — same convention as HTTP_ONLY_VARS above.
+const PROSE_DOCUMENTED_VARS = new Set(["CCU_PROFILES", "CCU_DEFAULT_PROFILE"]);
+
+/**
+ * Env vars appearing in a README markdown table's first cell. One cell may
+ * carry several — `MCP_TLS_CERT` / `MCP_TLS_KEY` share a row, since setting
+ * only one of them is a configuration error and they document as a pair.
+ */
+function envKeysInReadmeTables(): Set<string> {
+  const keys = new Set<string>();
+  for (const row of readFileSync(README, "utf-8").matchAll(/^\|([^|]+)\|/gm)) {
+    for (const m of row[1].matchAll(/`([A-Z][A-Z0-9_]*)`/g)) keys.add(m[1]);
+  }
+  return keys;
+}
+
+describe("README.md", () => {
+  it("documents every env var the code reads", () => {
+    const documented = envKeysInReadmeTables();
+    const missing = [...envKeysReferencedInCode()]
+      .filter((k) => !documented.has(k) && !PROSE_DOCUMENTED_VARS.has(k))
+      .sort();
+    expect(missing, `env vars read in code but missing from README's tables: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("does not document env vars the code never reads", () => {
+    const code = envKeysReferencedInCode();
+    const stale = [...envKeysInReadmeTables()].filter((k) => !code.has(k)).sort();
+    expect(stale, `env vars in README's tables not read anywhere in code: ${stale.join(", ")}`).toEqual([]);
+  });
+
+  // Without this, dropping a var from the code and from the README together
+  // leaves a permanent exemption nobody revisits — the stale-allowlist problem
+  // that .github/vuln-allowlist.txt's gate warns about for advisories.
+  it("has no stale prose-documented exemptions", () => {
+    const code = envKeysReferencedInCode();
+    const stale = [...PROSE_DOCUMENTED_VARS].filter((k) => !code.has(k)).sort();
+    expect(stale, `PROSE_DOCUMENTED_VARS entries no longer read in code: ${stale.join(", ")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Mechanizes the manual step in CLAUDE.md's QA loop — "update the `help` tool's text (`src/tools/meta.ts`)" — which is exactly the kind of instruction that holds until the one time it doesn't.

## Tool surfaces

Four places name the tool set, and exactly one is the truth:

| # | Surface | Where |
|---|---------|-------|
| 1 | the MCP registration | **the truth** |
| 2 | per-tool help docs | `TOOL_HELP` in `src/tools/meta.ts` |
| 3 | the conceptual guide | `## Available Tools` in the same file |
| 4 | README's tool list | `## Tools`, plus its hardcoded count |

A tool added without touching 2–4 ships invisible: it works over MCP, but `help` — how a model discovers what this server can do — never mentions it, and the README undersells the server.

Both directions are checked on each surface, so a *removed* tool leaves no orphaned docs behind either.

### Why behavioural, not static

Everything is derived by running the code: the registry is read off a real server, and both help surfaces come from actually calling `help` (the per-tool set is recovered from the unknown-topic reply, which enumerates `Object.keys(TOOL_HELP)`).

Nothing regex-scrapes `meta.ts`, because tool names are not always literals at the registration site:

```ts
registerAssignChannel(server, deps, "add");     // → assign_channel
registerAssignChannel(server, deps, "remove");  // → unassign_channel
```

A static scan misses both and reports a smaller tool set than actually exists — so the guard would pass by never learning about the tools it was meant to catch. That is the vacuous-gate shape, and it is worse than no gate because it reports green.

## Env-var surface

`.env.example` and `server.json` were already guarded by `env-example-sync.test.ts`. **README was not** — and it is the only one of the three a user reads *before* installing; the other two you meet after you've already committed to the server.

It turned out to be complete (30/30), so this locks in a state that already holds. Matching is against README's table rows, with one cell able to carry several vars — `` `MCP_TLS_CERT` / `MCP_TLS_KEY` `` share a row because setting only one of them is a configuration error and they document as a pair.

`CCU_PROFILES` and `CCU_DEFAULT_PROFILE` are exempt, explicitly rather than by omission (same convention as the existing `HTTP_ONLY_VARS`): they live in the profiles section as a worked `.env` example, and the rest of that family is spelled `CCU_<PROFILE>_*`, which cannot be tabulated by fixed name at all. The exemption list has its own test, so it fails if an entry stops being read in code — otherwise deleting a var from code and README together would leave a permanent exemption nobody revisits.

## Verification

Currently in sync on every surface: **28/28/28/28 tools**, **30/30 env vars**. These are preventive, not a cleanup.

Since a guard that has never failed is not yet proven, each check was mutation-tested — ten deliberate drifts, reverted after each:

| Mutation | Result |
|---|---|
| `TOOL_HELP` entry removed | 1 failed |
| phantom tool added to `TOOL_HELP` | 1 failed |
| tool dropped from the guide's Available Tools | 1 failed |
| phantom tool added to the guide | 1 failed |
| tool dropped from README's Tools | 1 failed |
| phantom tool added to README | 1 failed |
| README count left stale (28 → 27) | 1 failed |
| README env-var table row removed | 1 failed |
| README documents a var nothing reads | 1 failed |
| exemption goes stale (var renamed in code) | fails, incl. the stale-exemption test |

Each failed **exactly the test that owns it** — precise attribution, no shotgun failures — and the baseline returned green after every revert.

Full run: `npm run lint` clean, `npm test` **444 passed / 26 skipped** (up from 434; the 26 are live-integration, gated on `CCU_HOST`).

## Cost

Runs inside `npm test`, so inside `build-and-test` — no new CI job, no new secrets, and hermetic: a pure function of the commit under test. Adds ~0.3s.
