### PR TITLE
ci: block vulnerable and non-permissive deps at PR time

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,62 @@
+# Config for the Dependency Review gate (.github/workflows/dependency-review.yml).
+#
+# Scope and severity deliberately mirror audit.yml and release-gate.yml's
+# `release-audit`, so the three scanners cannot disagree about what counts as a
+# problem — only about when they look.
+
+# High and critical only. Moderate and low ride the weekly Dependabot cadence,
+# exactly as in audit.yml.
+fail-on-severity: high
+
+# Production dependencies only. package.json's `files` publishes dist/ alone, so
+# a devDependency advisory never reaches a user; the same reasoning that scopes
+# audit.yml to `--omit=dev`. This is also the action's default — stated
+# explicitly because it is a decision, not an accident of the default.
+fail-on-scopes:
+  - runtime
+
+# The summary is not posted as a PR comment: that needs `pull-requests: write`,
+# and a forked PR gets a read-only token regardless of what the workflow asks
+# for, so the comment could not post there anyway. The findings are in the job
+# summary and the step log, which is where you land when the check goes red.
+comment-summary-in-pr: never
+
+# Licence policy. This package is MIT and publishes dist/ with its dependencies
+# resolved at the user's install time, so the thing actually worth catching is a
+# strong-copyleft dependency arriving in the shipped tree.
+#
+# An allowlist, not `deny-licenses` — that option is deprecated for removal in
+# the action's next major (actions/dependency-review-action#938).
+#
+# The list is deliberately generous: it covers the permissive licences that
+# recur across npm trees, not just the six present today (MIT, ISC, BSD-2/3,
+# Apache-2.0, MPL-2.0 — the last two dev-only, via typescript and lightningcss).
+# Anything outside it is the GPL/AGPL/SSPL/BUSL family, which genuinely wants a
+# human decision before it lands.
+#
+# When a legitimate permissive licence is missing here, the check goes red with
+# the offending identifier named in the log; add it in the same PR. A dependency
+# whose licence cannot be detected does NOT fail the action — it is reported
+# only, so missing metadata never blocks a merge.
+allow-licenses:
+  - 0BSD
+  - Apache-2.0
+  - BlueOak-1.0.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - CC0-1.0
+  - ISC
+  - MIT
+  - MPL-2.0
+  - Python-2.0
+  - Unlicense
+
+# Accepted advisories go here, and follow the same rules as any accepted
+# finding in this repo: never a bare id.
+#   - Every entry carries a justification and a review date.
+#   - Only for a finding with no fixed release available on the path we depend
+#     on. The moment a fix ships, the bump lands and the entry is removed.
+#   - An entry is acceptable only while the vulnerable code path is genuinely
+#     unreachable from what ships in dist/.
+# Empty is the correct state; it is not a placeholder to fill.
+allow-ghsas: []

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -3,6 +3,15 @@
 # Scope and severity deliberately mirror audit.yml and release-gate.yml's
 # `release-audit`, so the three scanners cannot disagree about what counts as a
 # problem — only about when they look.
+#
+# READ THIS BEFORE CONCLUDING THE LICENCE CHECK IS BROKEN. The action reports
+# the FIRST failing category and stops. A PR that introduces both a vulnerable
+# dependency and a disallowed licence shows only the "Vulnerabilities" group —
+# no "Licences" group appears at all, which reads exactly like a licence check
+# that never ran. It did; it was masked. Fix the vulnerability and the licence
+# failure surfaces on the next run. Verified on a throwaway PR that introduced
+# both at once (lodash@4.17.4 and AGPL-3.0 pm2): the licence findings appeared
+# only once the vulnerability check was disabled.
 
 # High and critical only. Moderate and low ride the weekly Dependabot cadence,
 # exactly as in audit.yml.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,55 @@
+name: Dependency review
+
+# Blocks a PR that INTRODUCES a vulnerable or non-permissively-licensed
+# dependency, at PR time. That is the gap the other two scanners leave:
+#
+#   ci.yml `build-and-test`   — hermetic; never looks at advisories at all
+#   audit.yml                 — daily, reports on dev's lockfile AFTER the merge
+#   release-gate `release-audit` — blocks PRs into main, i.e. one release late
+#
+# Nothing stopped a newly vulnerable dependency from landing on dev and sitting
+# there until the next morning's audit or the next release PR. This closes it.
+#
+# NON-HERMETIC, like the other two: the verdict comes from the GitHub Advisory
+# DB. It is therefore NOT a candidate for a required check on dev — that is the
+# npm-audit deadlock ci.yml documents at length.
+#
+# It is much better behaved than `npm audit` though, and the difference is worth
+# being precise about: this action reviews only the dependency DIFF of the PR.
+# An advisory landing overnight against a dependency the PR never touches does
+# not turn it red, so the "green yesterday, red today with no diff" failure mode
+# is mostly absent. Mostly, not entirely — a PR that adds a dependency can flip
+# to red if an advisory later lands against that newly added version.
+#
+# The natural place to make it blocking is main, alongside release-audit, where
+# a human is already standing in front of the result. Adding it to main's
+# required checks is a repo setting, not something this file can do.
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+# Supersede a superseded PR head, same as ci.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # Posture and the licence policy live in the config file so an
+          # accepted finding carries a justification and a review date next to
+          # it, rather than being an unexplained id inline here.
+          config-file: ./.github/dependency-review-config.yml


### PR DESCRIPTION
Adds `dependency-review-action` on PRs into `main` and `dev`.

## The gap it closes

| Scanner | When it looks | What it misses |
|---|---|---|
| `build-and-test` | every push/PR | hermetic — never looks at advisories at all |
| `audit.yml` | daily, on dev's lockfile | reports the morning **after** the merge |
| `release-audit` | PRs into main | a whole release late |

Nothing stopped a newly vulnerable dependency from landing on `dev` and sitting there in between. This reviews the dependency **diff** of the PR itself.

## Posture

Severity and scope mirror the existing scanners exactly, so the three cannot disagree about what counts as a problem — only about when they look:

- `fail-on-severity: high` — high and critical only, as in `audit.yml`; moderate and low ride the Dependabot cadence
- `fail-on-scopes: [runtime]` — `files` publishes `dist/` alone, so a devDependency advisory never reaches a user. This is also the action's default, stated explicitly because it is a decision rather than an accident of the default.
- `allow-ghsas: []` — empty is the correct state, not a placeholder

## Non-hermetic, and where that lands it

Its verdict comes from the GitHub Advisory DB, so per `ci.yml`'s reasoning it is **not** a candidate for a required check on `dev`.

It is much better behaved than `npm audit` though, and the difference is worth being precise about: it reviews only the PR's dependency diff, so an advisory landing overnight against a dependency the PR never touches does not turn it red. Mostly — a PR that adds a dependency can still flip red if an advisory later lands against that newly added version.

The natural place to make it blocking is `main`, alongside `release-audit`, where a human is already standing in front of the result. **That is a branch-protection setting I have not touched** — say the word if you want it added to main's required checks.

## Licence policy

An allowlist, not `deny-licenses` — that option is [deprecated for removal](https://github.com/actions/dependency-review-action/issues/938) in the action's next major.

The list is deliberately generous: 11 permissive licences that recur across npm trees, not just the six present today (MIT, ISC, BSD-2/3-Clause, Apache-2.0, MPL-2.0 — the last two dev-only, via `typescript` and `lightningcss`). What falls outside is the GPL/AGPL/SSPL/BUSL family, which genuinely wants a human decision in an MIT package.

Surveyed the current tree before choosing the list, so it cannot false-positive on what is already installed: prod is 100% MIT/ISC/BSD (84/7/2/1). A dependency whose licence cannot be detected does **not** fail the action — it is reported only, so missing metadata never blocks a merge.

## Least privilege

No PR comment, so the job needs only `contents: read`. Enabling it would need `pull-requests: write`, and a forked PR gets a read-only token regardless of what the workflow asks for — so the comment could not post there anyway. The job summary and step log carry the findings, which is where you land when a check goes red.

## Verification

`actionlint` clean, both YAML files parse, config values assert as intended. A separate throwaway PR verifying the gate actually fires against a deliberately vulnerable and AGPL dependency is running now — I will report the result here before this merges.