### PR TITLE
PROBE: verify required checks report on PRs into main

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,71 @@
+# Config for the Dependency Review gate (.github/workflows/dependency-review.yml).
+#
+# Scope and severity deliberately mirror audit.yml and release-gate.yml's
+# `release-audit`, so the three scanners cannot disagree about what counts as a
+# problem — only about when they look.
+#
+# READ THIS BEFORE CONCLUDING THE LICENCE CHECK IS BROKEN. The action reports
+# the FIRST failing category and stops. A PR that introduces both a vulnerable
+# dependency and a disallowed licence shows only the "Vulnerabilities" group —
+# no "Licences" group appears at all, which reads exactly like a licence check
+# that never ran. It did; it was masked. Fix the vulnerability and the licence
+# failure surfaces on the next run. Verified on a throwaway PR that introduced
+# both at once (lodash@4.17.4 and AGPL-3.0 pm2): the licence findings appeared
+# only once the vulnerability check was disabled.
+
+# High and critical only. Moderate and low ride the weekly Dependabot cadence,
+# exactly as in audit.yml.
+fail-on-severity: high
+
+# Production dependencies only. package.json's `files` publishes dist/ alone, so
+# a devDependency advisory never reaches a user; the same reasoning that scopes
+# audit.yml to `--omit=dev`. This is also the action's default — stated
+# explicitly because it is a decision, not an accident of the default.
+fail-on-scopes:
+  - runtime
+
+# The summary is not posted as a PR comment: that needs `pull-requests: write`,
+# and a forked PR gets a read-only token regardless of what the workflow asks
+# for, so the comment could not post there anyway. The findings are in the job
+# summary and the step log, which is where you land when the check goes red.
+comment-summary-in-pr: never
+
+# Licence policy. This package is MIT and publishes dist/ with its dependencies
+# resolved at the user's install time, so the thing actually worth catching is a
+# strong-copyleft dependency arriving in the shipped tree.
+#
+# An allowlist, not `deny-licenses` — that option is deprecated for removal in
+# the action's next major (actions/dependency-review-action#938).
+#
+# The list is deliberately generous: it covers the permissive licences that
+# recur across npm trees, not just the six present today (MIT, ISC, BSD-2/3,
+# Apache-2.0, MPL-2.0 — the last two dev-only, via typescript and lightningcss).
+# Anything outside it is the GPL/AGPL/SSPL/BUSL family, which genuinely wants a
+# human decision before it lands.
+#
+# When a legitimate permissive licence is missing here, the check goes red with
+# the offending identifier named in the log; add it in the same PR. A dependency
+# whose licence cannot be detected does NOT fail the action — it is reported
+# only, so missing metadata never blocks a merge.
+allow-licenses:
+  - 0BSD
+  - Apache-2.0
+  - BlueOak-1.0.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - CC0-1.0
+  - ISC
+  - MIT
+  - MPL-2.0
+  - Python-2.0
+  - Unlicense
+
+# Accepted advisories go here, and follow the same rules as any accepted
+# finding in this repo: never a bare id.
+#   - Every entry carries a justification and a review date.
+#   - Only for a finding with no fixed release available on the path we depend
+#     on. The moment a fix ships, the bump lands and the entry is removed.
+#   - An entry is acceptable only while the vulnerable code path is genuinely
+#     unreachable from what ships in dist/.
+# Empty is the correct state; it is not a placeholder to fill.
+allow-ghsas: []

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -49,8 +49,13 @@ env:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The `gh` steps below authenticate via GH_TOKEN, not via the
+          # credential checkout leaves in .git/config. Nothing pushes to git.
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,20 @@ jobs:
   #   - release-gate.yml job `release-audit` — blocks PRs into main
   build-and-test:
     runs-on: ubuntu-latest
+    # Without this a wedged `npm ci` (registry hang, DNS black hole) burns the
+    # 6-hour default before anyone sees a verdict.
+    timeout-minutes: 15
 
     steps:
       # Third-party actions pinned to a commit SHA (supply-chain hardening):
       # a retargeted mutable tag can't inject code into CI. Dependabot bumps
       # the SHA + comment together.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing here pushes to git — npm pulls from the registry. Don't
+          # leave the token behind in .git/config where a later step (or a
+          # postinstall script) could reach it.
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
@@ -67,3 +75,90 @@ jobs:
       # function of this commit alone.
       - name: Test
         run: npm test -- --coverage
+
+  # Lints every workflow file, plus shellcheck over the `run:` blocks — and
+  # those blocks are where the real bash in this repo lives (audit.yml's issue
+  # sync, release-gate.yml's audit step).
+  #
+  # The reason this job exists at all: a workflow parse error does NOT fail
+  # loudly on GitHub. It produces zero-job "failed" runs and silently disables
+  # that workflow's triggers — including tag pushes, which is how releases are
+  # cut here. You find out when the tag lands and nothing happens.
+  #
+  # Hermetic, like build-and-test: pinned linter, pinned shellcheck, fixture in
+  # the tree. Same tree in, same verdict out.
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26"
+          cache: false
+
+      # actionlint shells out to shellcheck for `run:` blocks. The linter is
+      # pinned below, but the runner-supplied shellcheck is not — a hosted-image
+      # bump would silently change what this gate reports and could redden
+      # unrelated PRs. Pin it; bump deliberately alongside actionlint.
+      - name: Install shellcheck (pinned)
+        env:
+          SHELLCHECK_VERSION: v0.10.0
+        run: |
+          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+            | tar -xJ
+          sudo install -m 0755 "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+          shellcheck --version
+
+      - name: Install actionlint (pinned)
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+      - name: Lint workflows
+        run: actionlint -color
+
+      # A linter that stopped catching the bug class is worse than none: it
+      # reports green and everyone stops looking. This asserts it still flags
+      # the fixture, so a toothless upgrade turns the job red.
+      - name: Verify actionlint catches known-bad patterns
+        run: bash scripts/test-actionlint.sh actionlint
+
+      # The gate scripts are code too — their self-tests run here so a broken
+      # gate fails like any other test.
+      - name: Gate script self-tests
+        run: bash scripts/test-check-no-ai-attribution.sh
+
+  # CLAUDE.md has said "no Claude/AI attribution in commit messages or PRs"
+  # since day one. This enforces it, because the rule lives in a gitignored
+  # file and a convention is one distracted rebase away from a public branch.
+  # Checks trailers, "generated with" lines, session links — and the commit
+  # AUTHOR IDENTITY, which rebase and cherry-pick preserve even when the
+  # message gets rewritten.
+  #
+  # pull_request only: the gate needs a base..head range and the PR
+  # description, neither of which a push event supplies.
+  attribution:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The gate walks base..head; a shallow clone cannot resolve it.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check commits and PR body for AI attribution
+        env:
+          # Through env, never inlined into the run: body — a PR description is
+          # attacker-controlled text, and interpolating it directly would paste
+          # it into the shell.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
+          bash scripts/check-no-ai-attribution.sh \
+            "$BASE_SHA..$HEAD_SHA" "$RUNNER_TEMP/pr-body.md"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,6 +22,7 @@ jobs:
   auto-merge:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,55 @@
+name: Dependency review
+
+# Blocks a PR that INTRODUCES a vulnerable or non-permissively-licensed
+# dependency, at PR time. That is the gap the other two scanners leave:
+#
+#   ci.yml `build-and-test`   — hermetic; never looks at advisories at all
+#   audit.yml                 — daily, reports on dev's lockfile AFTER the merge
+#   release-gate `release-audit` — blocks PRs into main, i.e. one release late
+#
+# Nothing stopped a newly vulnerable dependency from landing on dev and sitting
+# there until the next morning's audit or the next release PR. This closes it.
+#
+# NON-HERMETIC, like the other two: the verdict comes from the GitHub Advisory
+# DB. It is therefore NOT a candidate for a required check on dev — that is the
+# npm-audit deadlock ci.yml documents at length.
+#
+# It is much better behaved than `npm audit` though, and the difference is worth
+# being precise about: this action reviews only the dependency DIFF of the PR.
+# An advisory landing overnight against a dependency the PR never touches does
+# not turn it red, so the "green yesterday, red today with no diff" failure mode
+# is mostly absent. Mostly, not entirely — a PR that adds a dependency can flip
+# to red if an advisory later lands against that newly added version.
+#
+# The natural place to make it blocking is main, alongside release-audit, where
+# a human is already standing in front of the result. Adding it to main's
+# required checks is a repo setting, not something this file can do.
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+# Supersede a superseded PR head, same as ci.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # Posture and the licence policy live in the config file so an
+          # accepted finding carries a justification and a review date next to
+          # it, rather than being an unexplained id inline here.
+          config-file: ./.github/dependency-review-config.yml

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   release-title:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Require a "Release vX.Y.Z" title
         # Pass the title via env, never interpolate ${{ }} into the script body
@@ -52,8 +53,11 @@ jobs:
     # only, so release-title keeps its zero-scope token.
     permissions:
       contents: read
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:

--- a/scripts/check-no-ai-attribution.sh
+++ b/scripts/check-no-ai-attribution.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# AI-attribution gate: this project is published under the maintainer's
+# own name (npm, the MCP registry, Smithery), so no commit or PR may
+# credit an AI assistant. The rule has been in CLAUDE.md from the start,
+# which is exactly why it is enforced mechanically here — a convention
+# that lives only in a gitignored file is one distracted rebase away
+# from reaching a public branch.
+#
+# Usage: check-no-ai-attribution.sh <commit-range> [pr-body-file]
+#   <commit-range>: any git range, e.g. origin/dev..HEAD
+#   [pr-body-file]: optional file holding the PR description
+#
+# Exit: 0 clean, 1 attribution found, 2 cannot check (bad usage/range).
+#
+# Four surfaces get checked:
+#   1. message trailers crediting an assistant as co-author
+#   2. assistant session-link trailers and footers
+#   3. "generated with/by <assistant>" marketing lines
+#   4. the commit author/committer IDENTITY itself — cherry-pick and
+#      rebase PRESERVE authorship, so a rewrite that strips trailers
+#      silently keeps a bad author. That is the one a trailer-only gate
+#      misses, and it is invisible in `git log --oneline`.
+#
+# Identity is matched by pattern, NOT against an allowlist of the
+# maintainer: external contributors and dependabot author commits here
+# too, and they are legitimate.
+set -u
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "usage: $0 <commit-range> [pr-body-file]" >&2
+    exit 2
+fi
+
+RANGE="$1"
+BODY="${2-}"
+fail=0
+
+if ! git rev-list "$RANGE" >/dev/null 2>&1; then
+    echo "FAIL  cannot resolve commit range '$RANGE'" >&2
+    exit 2
+fi
+
+# Vendor-agnostic on purpose: the rule is "no AI assistant credit", not
+# "no one specific product". Adding a vendor here is cheaper than
+# discovering the gap after a leak.
+VENDORS='claude|anthropic|copilot|chatgpt|openai|gemini|codex|cursor'
+
+# Attribution in free text, as <label>|<pattern> pairs — the label is
+# what gets reported, because a raw vendor alternation is unreadable in
+# CI output. Each pattern targets a real artifact rather than any
+# mention of a vendor, so prose may still discuss these tools without
+# tripping the gate (this repo's docs discuss Claude constantly).
+text_patterns=(
+    "assistant co-author trailer|co-authored-by:[[:space:]]*[^<]*($VENDORS)"
+    "assistant co-author trailer|co-authored-by:.*@(anthropic|openai)\.com"
+    "assistant session trailer|^[[:space:]]*($VENDORS)-session:"
+    "\"generated with/by\" line|generated (with|by) [^[:space:]]*[[:space:]]*($VENDORS)"
+    "assistant session link|($VENDORS)\.ai/code/session"
+    "robot-emoji generated line|🤖[[:space:]]*generated"
+)
+
+scan_text() {
+    # $1 = what is being scanned (for the message), $2 = the text.
+    # Reports each distinct kind of attribution once, not once per
+    # pattern that happens to match it.
+    local what="$1" text="$2" entry label pat
+    local -a seen=()
+    for entry in "${text_patterns[@]}"; do
+        label="${entry%%|*}"
+        pat="${entry#*|}"
+        printf '%s\n' "$text" | grep -qiE "$pat" || continue
+        case " ${seen[*]-} " in *" $label "*) continue ;; esac
+        seen+=("$label")
+        echo "FAIL  $what: contains attribution — $label"
+        fail=1
+    done
+}
+
+for sha in $(git rev-list "$RANGE"); do
+    short="${sha:0:8}"
+
+    # Identity: name and email of both author and committer.
+    while IFS= read -r ident; do
+        role="${ident%%$'\t'*}"
+        who="${ident#*$'\t'}"
+        if printf '%s\n' "$who" | grep -qiE "($VENDORS)"; then
+            echo "FAIL  commit $short: $role identity is '$who' — commits must not be authored by an AI assistant"
+            fail=1
+        fi
+    done < <(git log -1 --format="author	%an <%ae>
+committer	%cn <%ce>" "$sha")
+
+    scan_text "commit $short message" "$(git log -1 --format='%B' "$sha")"
+done
+
+if [ -n "$BODY" ]; then
+    if [ ! -f "$BODY" ]; then
+        echo "FAIL  PR body file '$BODY' does not exist" >&2
+        exit 2
+    fi
+    # Strip fenced blocks and inline code spans first: a PR that
+    # documents these patterns (this gate's own, for one) quotes them as
+    # code, while a real attribution footer never is.
+    # shellcheck disable=SC2016  # the backticks are markdown, not shell
+    body_prose=$(sed '/^[[:space:]]*```/,/^[[:space:]]*```/d' "$BODY" | sed 's/`[^`]*`//g')
+    scan_text "PR body" "$body_prose"
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "AI-attribution gate passed"
+fi
+exit "$fail"

--- a/scripts/test-actionlint.sh
+++ b/scripts/test-actionlint.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Regression test for the actionlint gate: assert actionlint still flags
+# the known-bad fixture, in particular the secrets-context-in-a-step-
+# level-`if:` trap, which GitHub rejects at PARSE time and thereby
+# silently disables every trigger of the workflow. If this script fails,
+# the linter has lost the teeth we rely on — treat it like a failing
+# unit test, not a flaky check.
+#
+# Usage: test-actionlint.sh [path-to-actionlint]
+#
+# Exit: 0 linter has its teeth, 1 it lost them, 2 cannot test.
+#
+# The 2 matters. This test asserts a *non-zero* exit from actionlint, so
+# a missing binary exits 127 and sails through that assertion — the run
+# would then die on the grep and blame the linter for a regression when
+# the tool was simply absent. The binary is checked up front, and
+# "cannot test" is its own exit code so it can never be read as either
+# outcome. CI installs actionlint before calling this, so a 2 there
+# means the install step broke and the job should go red — which it
+# does, since any non-zero fails the step.
+set -u
+
+ACTIONLINT="${1:-actionlint}"
+FIXTURE="$(dirname "$0")/testdata/bad-workflow.yml"
+OUT="$(mktemp)"
+trap 'rm -f "$OUT"' EXIT
+
+if ! command -v "$ACTIONLINT" >/dev/null 2>&1; then
+    echo "FAIL  cannot test: '$ACTIONLINT' not found on PATH" >&2
+    echo "      install it with: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12" >&2
+    exit 2
+fi
+
+if [ ! -f "$FIXTURE" ]; then
+    echo "FAIL  cannot test: fixture $FIXTURE is missing" >&2
+    exit 2
+fi
+
+"$ACTIONLINT" -no-color "$FIXTURE" >"$OUT" 2>&1
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+    echo "FAIL: actionlint exited 0 on $FIXTURE — it must flag the fixture"
+    exit 1
+fi
+
+# 126/127 mean the shell couldn't execute it at all (not on PATH after
+# the check above, or not executable) — never a lint verdict.
+if [ "$rc" -eq 126 ] || [ "$rc" -eq 127 ]; then
+    echo "FAIL  cannot test: '$ACTIONLINT' could not be executed (exit $rc)" >&2
+    cat "$OUT" >&2
+    exit 2
+fi
+
+if ! grep -q 'context "secrets" is not allowed' "$OUT"; then
+    echo "FAIL: actionlint no longer flags 'secrets' in a step-level if:"
+    echo "--- actionlint output:"
+    cat "$OUT"
+    exit 1
+fi
+
+echo "PASS: actionlint flags the known-bad fixture (including the secrets-in-step-if trap)"

--- a/scripts/test-check-no-ai-attribution.sh
+++ b/scripts/test-check-no-ai-attribution.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Tests for check-no-ai-attribution.sh: a throwaway git repo with
+# deliberately-bad commits, so the identity checks are exercised
+# against real git metadata rather than synthetic text.
+#
+# Run standalone (`bash scripts/test-check-no-ai-attribution.sh`) or via
+# the `gate-scripts` job in .github/workflows/ci.yml. The CI gates are
+# code too — a silently-toothless gate is worse than no gate.
+set -u
+
+GATE="$(cd "$(dirname "$0")" && pwd)/check-no-ai-attribution.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git init -q -b main "$REPO"
+git -C "$REPO" config user.name "Chris"
+git -C "$REPO" config user.email "chris@example.com"
+# The maintainer signs commits; the fixture repo has no key and must not
+# try to use one.
+git -C "$REPO" config commit.gpgsign false
+
+failures=0
+
+# commit <subject-and-body> [author-name] [author-email]
+commit() {
+    local msg="$1" name="${2-Chris}" email="${3-chris@example.com}"
+    echo "$RANDOM" >> "$REPO/file.txt"
+    git -C "$REPO" add -A
+    GIT_AUTHOR_NAME="$name" GIT_AUTHOR_EMAIL="$email" \
+    GIT_COMMITTER_NAME="$name" GIT_COMMITTER_EMAIL="$email" \
+        git -C "$REPO" commit -q -m "$msg"
+}
+
+check() {
+    local name="$1" want_exit="$2"
+    shift 2
+    (cd "$REPO" && bash "$GATE" "$@") > "$TMP/out" 2>&1
+    local got=$?
+    if [ "$got" -eq "$want_exit" ]; then
+        echo "PASS: $name"
+    else
+        echo "FAIL: $name (want exit $want_exit, got $got)"
+        sed 's/^/    /' "$TMP/out"
+        failures=$((failures + 1))
+    fi
+}
+
+commit "feat: the baseline commit"
+BASE=$(git -C "$REPO" rev-parse HEAD)
+
+commit "fix: an ordinary change
+
+Explains itself over several lines, mentions no assistant."
+check "clean history passes" 0 "$BASE..HEAD"
+
+# 1. co-author trailer
+commit "fix: something
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+check "co-author trailer fails" 1 "$BASE..HEAD"
+grep -q 'co-author trailer' "$TMP/out" || { echo "FAIL: missing trailer diagnostic"; failures=$((failures+1)); }
+git -C "$REPO" reset -q --hard "$BASE"
+
+# 2. session trailer
+commit "fix: something
+
+Claude-Session: https://example.invalid/session_0123"
+check "session trailer fails" 1 "$BASE..HEAD"
+git -C "$REPO" reset -q --hard "$BASE"
+
+# 3. generated-with line
+commit "fix: something
+
+Generated with Claude Code"
+check "generated-with line fails" 1 "$BASE..HEAD"
+git -C "$REPO" reset -q --hard "$BASE"
+
+# 4. clean message, assistant IDENTITY — the case a trailer-only gate
+#    misses entirely, because rebase and cherry-pick preserve authorship.
+commit "fix: a perfectly clean message" "Claude" "noreply@anthropic.com"
+check "assistant author identity fails despite clean message" 1 "$BASE..HEAD"
+grep -q 'identity' "$TMP/out" || { echo "FAIL: missing identity diagnostic"; failures=$((failures+1)); }
+git -C "$REPO" reset -q --hard "$BASE"
+
+# Legitimate non-maintainer authors must NOT trip the gate: external
+# contributors and dependabot commit here too (and dependabot's PRs are
+# auto-merged, so a false positive there would jam the whole flow).
+commit "build(deps): bump something" "dependabot[bot]" "49699333+dependabot[bot]@users.noreply.github.com"
+commit "fix: an outside contribution" "Jane Contributor" "jane@example.org"
+check "external and bot authors pass" 0 "$BASE..HEAD"
+git -C "$REPO" reset -q --hard "$BASE"
+
+# Prose that merely discusses the tools is not attribution. This repo is
+# an MCP server FOR Claude — its commits name it constantly.
+commit "docs: note which assistants the project does not credit
+
+The rule is that no AI assistant, Claude or otherwise, may be credited
+in commits. This message discusses that policy and must stay legal."
+check "prose mentioning assistants passes" 0 "$BASE..HEAD"
+git -C "$REPO" reset -q --hard "$BASE"
+
+# PR body scanning.
+commit "fix: clean commit for body tests"
+
+printf 'Ordinary description.\n\nNothing to see here.\n' > "$TMP/body-clean.md"
+check "clean PR body passes" 0 "$BASE..HEAD" "$TMP/body-clean.md"
+
+printf 'Some description.\n\n🤖 Generated with Claude Code\n' > "$TMP/body-bad.md"
+check "PR body attribution fails" 1 "$BASE..HEAD" "$TMP/body-bad.md"
+grep -q 'PR body' "$TMP/out" || { echo "FAIL: missing PR-body diagnostic"; failures=$((failures+1)); }
+
+printf 'Session footer.\n\nhttps://claude.ai/code/session_01ABC\n' > "$TMP/body-session.md"
+check "PR body session link fails" 1 "$BASE..HEAD" "$TMP/body-session.md"
+
+# A PR that DOCUMENTS the patterns quotes them as code — including this
+# gate's own PR. Fenced blocks and inline spans are stripped first.
+cat > "$TMP/body-doc.md" <<'EOF'
+This gate rejects the following in commit messages:
+
+```
+Co-Authored-By: Claude <noreply@anthropic.com>
+Generated with Claude Code
+```
+
+It also rejects `Claude-Session:` trailers and `claude.ai/code/session` links.
+EOF
+check "PR body documenting the patterns in code spans passes" 0 "$BASE..HEAD" "$TMP/body-doc.md"
+
+# Harness errors are distinguishable from findings.
+check "unresolvable range exits 2" 2 "no-such-ref..HEAD"
+check "missing body file exits 2" 2 "$BASE..HEAD" "$TMP/does-not-exist.md"
+(cd "$REPO" && bash "$GATE") >/dev/null 2>&1
+if [ $? -eq 2 ]; then
+    echo "PASS: usage error exits 2"
+else
+    echo "FAIL: usage error should exit 2"
+    failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures attribution-gate test(s) failed"
+    exit 1
+fi
+echo "All AI-attribution-gate tests passed"

--- a/scripts/testdata/bad-workflow.yml
+++ b/scripts/testdata/bad-workflow.yml
@@ -1,0 +1,30 @@
+# Deliberately broken workflow — regression fixture for actionlint.
+#
+# This file lives OUTSIDE .github/workflows/ on purpose: GitHub must
+# never parse it, it exists only so scripts/test-actionlint.sh can
+# assert that actionlint still catches the patterns that break a
+# workflow silently. If actionlint ever stops flagging these, the
+# `actionlint` CI job goes red and we know our linter lost its teeth.
+name: bad fixture
+on:
+  push:
+    branches: [never-runs]
+jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      # The trap: a `secrets` context in a step-level `if:` is rejected
+      # by GitHub at parse time, which silently disables ALL triggers of
+      # the workflow — including tag pushes. Materialize the check into
+      # a job-level `env:` instead and compare against that.
+      - name: secrets in step-level if
+        if: ${{ secrets.SOME_TOKEN != '' }}
+        run: echo never
+      # Reference to an undefined job output.
+      - name: undefined needs reference
+        run: echo "${{ needs.nonexistent.outputs.foo }}"
+      # Shellcheck must fire on run: blocks (unquoted var with glob).
+      - name: shellcheck target
+        run: |
+          FILES=$(ls *.txt)
+          for f in $FILES; do echo $f; done

--- a/test/unit/docs-drift.test.ts
+++ b/test/unit/docs-drift.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
+
+// Docs-drift guard for the TOOL surfaces. Four places name the tool set, and
+// exactly one of them is the truth:
+//
+//   1. the MCP registration itself           — the truth
+//   2. the `help` tool's per-tool docs       — TOOL_HELP in src/tools/meta.ts
+//   3. the `help` tool's conceptual guide    — "## Available Tools", same file
+//   4. README.md's "## Tools" section        — plus its hardcoded tool COUNT
+//
+// A tool added without touching 2-4 ships invisible: it works over MCP, but the
+// help tool — which is how a model discovers what it can do here — never
+// mentions it, and the README undersells the server. CLAUDE.md's QA loop lists
+// "update the help tool's text" as a MANUAL step after every change, which is
+// exactly the kind of instruction that holds until the one time it doesn't.
+//
+// Everything below is derived BEHAVIOURALLY: the registry is read off a real
+// server, and both help surfaces come from actually calling `help`. Nothing
+// regex-scrapes meta.ts, because tool names are not always literals at the
+// registration site — `registerAssignChannel(server, deps, "add")` builds
+// `assign_channel` at runtime, so a static scan silently under-reports and the
+// guard would pass by never learning about the tool it was meant to catch.
+
+const README = join(__dirname, "../../README.md");
+
+/** Every tool actually registered on the server — the source of truth. */
+function registeredTools(): string[] {
+  const { server, deps } = createTestServer();
+  try {
+    const reg = (server as unknown as { _registeredTools: Record<string, unknown> })._registeredTools;
+    return Object.keys(reg).sort();
+  } finally {
+    cleanupDeps(deps);
+  }
+}
+
+/**
+ * The tools `help` has per-tool docs for. Recovered from the unknown-topic
+ * reply, which enumerates `Object.keys(TOOL_HELP)` — behaviour rather than
+ * source text, so it stays correct if that table is ever refactored.
+ */
+async function toolsWithHelpEntries(): Promise<string[]> {
+  const { server, deps } = createTestServer();
+  try {
+    const res = await callTool(server, "help", { topic: "no such topic" });
+    const text = parseToolResult(res) as string;
+    const line = text.split("\n").find((l) => l.startsWith("Available tools:"));
+    if (!line) throw new Error(`help's unknown-topic reply changed shape:\n${text}`);
+    return line
+      .replace("Available tools:", "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .sort();
+  } finally {
+    cleanupDeps(deps);
+  }
+}
+
+/** The conceptual guide `help` returns when given no topic. */
+async function conceptualGuide(): Promise<string> {
+  const { server, deps } = createTestServer();
+  try {
+    return parseToolResult(await callTool(server, "help", {})) as string;
+  } finally {
+    cleanupDeps(deps);
+  }
+}
+
+/**
+ * Tool names appearing in one markdown section, located by heading and ending
+ * at the next heading of the same or higher level. Tool names are snake_case;
+ * `help` is the only one without an underscore.
+ */
+function toolNamesInSection(text: string, heading: string): string[] {
+  const start = text.indexOf(heading);
+  if (start === -1) throw new Error(`section "${heading}" not found — was the heading renamed?`);
+  const rest = text.slice(start + heading.length);
+  const level = heading.match(/^#+/)?.[0].length ?? 2;
+  const next = rest.search(new RegExp(`^#{1,${level}} `, "m"));
+  const body = next === -1 ? rest : rest.slice(0, next);
+  const found = [...body.matchAll(/\b(help|[a-z]+(?:_[a-z]+)+)\b/g)].map((m) => m[1]);
+  return [...new Set(found)].sort();
+}
+
+describe("docs drift: the help tool vs the registered tools", () => {
+  it("has a help entry for every registered tool", async () => {
+    const documented = new Set(await toolsWithHelpEntries());
+    const missing = registeredTools().filter((t) => !documented.has(t));
+    expect(
+      missing,
+      `registered but absent from TOOL_HELP in src/tools/meta.ts: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("has no help entry for a tool that isn't registered", async () => {
+    const registered = new Set(registeredTools());
+    const stale = (await toolsWithHelpEntries()).filter((t) => !registered.has(t));
+    expect(
+      stale,
+      `documented in TOOL_HELP but no longer registered: ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("lists every registered tool in the guide's Available Tools section", async () => {
+    const listed = new Set(toolNamesInSection(await conceptualGuide(), "## Available Tools"));
+    const missing = registeredTools().filter((t) => !listed.has(t));
+    expect(
+      missing,
+      `missing from CONCEPTUAL_GUIDE's "## Available Tools": ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("lists no unregistered tool in the guide's Available Tools section", async () => {
+    const registered = new Set(registeredTools());
+    const stale = toolNamesInSection(await conceptualGuide(), "## Available Tools").filter(
+      (t) => !registered.has(t),
+    );
+    expect(
+      stale,
+      `listed in CONCEPTUAL_GUIDE's "## Available Tools" but not registered: ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+});
+
+describe("docs drift: README vs the registered tools", () => {
+  const readme = () => readFileSync(README, "utf-8");
+
+  it("names every registered tool in the Tools section", () => {
+    const listed = new Set(toolNamesInSection(readme(), "## Tools"));
+    const missing = registeredTools().filter((t) => !listed.has(t));
+    expect(
+      missing,
+      `registered but absent from README's "## Tools": ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("names no unregistered tool in the Tools section", () => {
+    const registered = new Set(registeredTools());
+    const stale = toolNamesInSection(readme(), "## Tools").filter((t) => !registered.has(t));
+    expect(
+      stale,
+      `named in README's "## Tools" but not registered: ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  // The count is prose, so nothing else can catch it going stale — and it is
+  // the first thing a reader checks the list against.
+  it("states the correct tool count", () => {
+    const m = readme().match(/(\d+) tools organized/);
+    expect(m, 'README must state "<N> tools organized by ..." in the Tools section').not.toBeNull();
+    const count = registeredTools().length;
+    expect(Number(m![1]), `README says ${m![1]} tools; ${count} are registered`).toBe(count);
+  });
+});

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -98,3 +98,55 @@ describe(".env.example", () => {
     expect(stale, `env vars in .env.example not read anywhere in code: ${stale.join(", ")}`).toEqual([]);
   });
 });
+
+// README.md is the third surface, and the only one a user reads BEFORE
+// installing — .env.example and server.json are both things you meet after
+// you've already committed to the server. It was the one surface nothing
+// checked.
+const README = join(__dirname, "../../README.md");
+
+// Documented in the "Multiple CCU targets (profiles)" section as a worked
+// .env example rather than as table rows, because they are not standalone
+// settings: CCU_PROFILES names the profiles, and every other profile variable
+// is spelled CCU_<PROFILE>_* and so cannot be tabulated by a fixed name at all.
+// Listed explicitly so the exemption is a decision on the record rather than an
+// omission — same convention as HTTP_ONLY_VARS above.
+const PROSE_DOCUMENTED_VARS = new Set(["CCU_PROFILES", "CCU_DEFAULT_PROFILE"]);
+
+/**
+ * Env vars appearing in a README markdown table's first cell. One cell may
+ * carry several — `MCP_TLS_CERT` / `MCP_TLS_KEY` share a row, since setting
+ * only one of them is a configuration error and they document as a pair.
+ */
+function envKeysInReadmeTables(): Set<string> {
+  const keys = new Set<string>();
+  for (const row of readFileSync(README, "utf-8").matchAll(/^\|([^|]+)\|/gm)) {
+    for (const m of row[1].matchAll(/`([A-Z][A-Z0-9_]*)`/g)) keys.add(m[1]);
+  }
+  return keys;
+}
+
+describe("README.md", () => {
+  it("documents every env var the code reads", () => {
+    const documented = envKeysInReadmeTables();
+    const missing = [...envKeysReferencedInCode()]
+      .filter((k) => !documented.has(k) && !PROSE_DOCUMENTED_VARS.has(k))
+      .sort();
+    expect(missing, `env vars read in code but missing from README's tables: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("does not document env vars the code never reads", () => {
+    const code = envKeysReferencedInCode();
+    const stale = [...envKeysInReadmeTables()].filter((k) => !code.has(k)).sort();
+    expect(stale, `env vars in README's tables not read anywhere in code: ${stale.join(", ")}`).toEqual([]);
+  });
+
+  // Without this, dropping a var from the code and from the README together
+  // leaves a permanent exemption nobody revisits — the stale-allowlist problem
+  // that .github/vuln-allowlist.txt's gate warns about for advisories.
+  it("has no stale prose-documented exemptions", () => {
+    const code = envKeysReferencedInCode();
+    const stale = [...PROSE_DOCUMENTED_VARS].filter((k) => !code.has(k)).sort();
+    expect(stale, `PROSE_DOCUMENTED_VARS entries no longer read in code: ${stale.join(", ")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Throwaway. Verifying that `dependency-review` — just added to main's required status checks — actually reports on a PR into `main`, given the workflow file currently exists only on `dev`. If it never reports, every release PR would sit at BLOCKED. Closing as soon as the checks land; nothing here is intended for merge.