### PR TITLE
tests: add per-directory coverage ratchet

### DIFF
--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -1,0 +1,52 @@
+# Per-directory coverage floors, in percent, enforced by
+# scripts/coverage-ratchet.mjs in the build-and-test job.
+#
+# Format:  <dir> <statements> <branches>
+#          !exempt <file>      — drop a file from its directory's aggregate
+#
+# vitest.config.ts already sets GLOBAL thresholds. These sit underneath them:
+# a global average hides local collapse, because a directory that loses 20
+# points is absorbed by the well-covered ones around it. Both layers stay
+# hermetic — coverage is a pure function of the commit under test.
+#
+# Rules:
+#   - Raise a floor in the same PR that earns the improvement. The ratchet
+#     prints "beats the floor" when a directory is a full point clear.
+#   - Never lower a floor without recording the reason here, in this file.
+#     Editing a number is easy on purpose; the record is the control, not
+#     friction. A lowered floor with no note is the thing review should catch.
+#   - A new directory with no entry FAILS. That is deliberate: a baseline-driven
+#     loop that only checks what it already knows about lets a whole untested
+#     subsystem in for free.
+#
+# `node scripts/coverage-ratchet.mjs coverage/coverage-summary.json --print-measured`
+# prints the current numbers in this format. It never writes this file.
+#
+# Seeding note (v1.9.0): floors are measured-truncated-to-one-decimal, with
+# RATCHET_EPSILON (0.5) as the only slack. Repeat local runs were verified
+# byte-identical, so the epsilon is headroom for Node-patch differences between
+# CI and a developer's machine, not run-to-run noise.
+#
+# CAUTION when re-measuring locally: with CCU_HOST set, the live-integration
+# suites run and every number comes out higher than CI will ever measure.
+# Floors seeded from such a run would fail in CI permanently. The ratchet
+# prints a warning when it sees CCU_HOST; seed and raise without it.
+
+# src/index.ts measures 0% as an artifact, not a gap: the e2e suites spawn it
+# as a subprocess and v8 coverage cannot attribute a child process back to the
+# parent's report. It is 197 statements, so leaving it in drags the src/ root
+# group from 93.7% down to 46.2% and the floor would have to be set so low it
+# would stop defending config.ts / logger.ts / server.ts / utils.ts entirely.
+# vitest.config.ts declines to set per-file thresholds for the same reason.
+!exempt src/index.ts
+
+src 93.7 91.6
+src/auth 96.8 94.0
+src/cache 99.2 97.7
+src/ccu 91.6 87.1
+src/health 100.0 100.0
+src/http 100.0 100.0
+src/middleware 99.2 92.2
+src/prompts 100.0 100.0
+src/resources 98.6 83.3
+src/tools 96.1 84.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,19 @@ jobs:
       - name: Test
         run: npm test -- --coverage
 
+      # Runs before the ratchet, not after: it proves the ratchet can still
+      # fail. A gate whose failure path has rotted reports the same green as a
+      # clean tree, and the coverage step above would be the only thing left
+      # actually enforcing anything.
+      - name: Coverage ratchet self-test
+        run: node scripts/test-coverage-ratchet.mjs
+
+      # Per-directory floors underneath vitest.config.ts's global thresholds:
+      # the global average absorbs a single directory falling apart. Hermetic —
+      # coverage is a function of this commit alone.
+      - name: Coverage ratchet
+        run: node scripts/coverage-ratchet.mjs coverage/coverage-summary.json .github/coverage-baseline.txt
+
   # Lints every workflow file, plus shellcheck over the `run:` blocks — and
   # those blocks are where the real bash in this repo lives (audit.yml's issue
   # sync, release-gate.yml's audit step).

--- a/scripts/coverage-ratchet.mjs
+++ b/scripts/coverage-ratchet.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+// Per-directory coverage ratchet. vitest.config.ts already enforces GLOBAL
+// thresholds; this enforces a floor per directory underneath them, because a
+// global average hides local collapse — src/ccu could lose 20 points and the
+// global number would barely move, absorbed by the well-covered directories
+// around it.
+//
+// Hermetic: coverage is a pure function of the commit under test, so this
+// belongs inside the `build-and-test` contract (see .github/workflows/ci.yml).
+//
+// Usage:
+//   node scripts/coverage-ratchet.mjs <coverage-summary.json> <baseline-file>
+//   node scripts/coverage-ratchet.mjs <coverage-summary.json> --print-measured
+//
+// Exit codes: 0 pass, 1 ratchet failure, 2 cannot check (usage/harness error).
+// 1 and 2 are kept distinct so a broken harness can never read as a pass OR
+// as a coverage regression — the same rule scripts/test-actionlint.sh follows.
+//
+// RATCHET_EPSILON (default 0.5): tolerated drop in percentage points. Coverage
+// here is deterministic run-to-run (verified byte-identical across repeat local
+// runs), so this is not noise absorption — it is headroom for cross-environment
+// drift: a different Node patch release can shift v8's statement attribution
+// slightly, and CI's Node is not pinned to the developer's.
+
+import { readFileSync } from "node:fs";
+import { relative, dirname } from "node:path";
+
+const METRICS = ["statements", "branches"];
+const EPSILON = Number(process.env.RATCHET_EPSILON ?? "0.5");
+
+function die(msg) {
+  console.error(msg);
+  process.exit(2);
+}
+
+const [summaryPath, baselinePath] = process.argv.slice(2);
+if (!summaryPath || !baselinePath) {
+  die(
+    "usage: coverage-ratchet.mjs <coverage-summary.json> <baseline-file|--print-measured>",
+  );
+}
+if (!Number.isFinite(EPSILON) || EPSILON < 0) {
+  die(`RATCHET_EPSILON must be a non-negative number, got ${process.env.RATCHET_EPSILON}`);
+}
+
+// --- measured -------------------------------------------------------------
+
+let summary;
+try {
+  summary = JSON.parse(readFileSync(summaryPath, "utf-8"));
+} catch (err) {
+  die(
+    `cannot read ${summaryPath}: ${err.message}\n` +
+      "Run `npm test -- --coverage` first; vitest.config.ts must list the " +
+      "`json-summary` reporter.",
+  );
+}
+
+// coverage-summary.json keys are absolute paths, except the "total" rollup.
+// Relativise against cwd so the baseline can hold stable repo-relative dirs.
+function measuredGroups(exempt) {
+  const groups = new Map();
+  const seenFiles = new Set();
+  for (const [abs, file] of Object.entries(summary)) {
+    if (abs === "total") continue;
+    const rel = relative(process.cwd(), abs).split("\\").join("/");
+    seenFiles.add(rel);
+    if (exempt.has(rel)) continue;
+    // Group by the file's own directory. No fixed depth: a newly nested
+    // src/a/b/ becomes its own group, which is then unbaselined and fails —
+    // a new subsystem cannot slip in uncovered.
+    const dir = dirname(rel);
+    let g = groups.get(dir);
+    if (!g) {
+      g = { statements: [0, 0], branches: [0, 0] };
+      groups.set(dir, g);
+    }
+    for (const m of METRICS) {
+      g[m][0] += file[m].covered;
+      g[m][1] += file[m].total;
+    }
+  }
+  // Aggregate from covered/total counts rather than averaging per-file
+  // percentages: a 3-statement file at 0% must not weigh as much as a
+  // 300-statement file at 100%.
+  const pct = ([covered, total]) => (total === 0 ? 100 : (100 * covered) / total);
+  return {
+    seenFiles,
+    groups: new Map(
+      [...groups].map(([dir, g]) => [
+        dir,
+        Object.fromEntries(METRICS.map((m) => [m, pct(g[m])])),
+      ]),
+    ),
+  };
+}
+
+// --- baseline -------------------------------------------------------------
+
+function parseBaseline(path) {
+  let text;
+  try {
+    text = readFileSync(path, "utf-8");
+  } catch (err) {
+    die(`cannot read baseline ${path}: ${err.message}`);
+  }
+  const floors = new Map();
+  const exempt = new Set();
+  text.split("\n").forEach((raw, i) => {
+    const line = raw.replace(/#.*$/, "").trim();
+    if (!line) return;
+    const parts = line.split(/\s+/);
+    if (parts[0] === "!exempt") {
+      if (parts.length !== 2) {
+        die(`${path}:${i + 1}: !exempt takes exactly one path, got: ${line}`);
+      }
+      exempt.add(parts[1]);
+      return;
+    }
+    if (parts.length !== 1 + METRICS.length) {
+      die(
+        `${path}:${i + 1}: expected "<dir> ${METRICS.map((m) => `<${m}>`).join(" ")}", got: ${line}`,
+      );
+    }
+    const [dir, ...nums] = parts;
+    if (floors.has(dir)) die(`${path}:${i + 1}: duplicate entry for ${dir}`);
+    const want = {};
+    nums.forEach((n, j) => {
+      const v = Number(n);
+      // Guards a silent-pass mode: "src/ccu 91.6 hgh" would parse to NaN, and
+      // every NaN comparison is false, so the directory would sail through.
+      if (!Number.isFinite(v) || v < 0 || v > 100) {
+        die(`${path}:${i + 1}: ${METRICS[j]} floor must be 0-100, got: ${n}`);
+      }
+      want[METRICS[j]] = v;
+    });
+    floors.set(dir, want);
+  });
+  return { floors, exempt };
+}
+
+// --- print-measured -------------------------------------------------------
+
+if (baselinePath === "--print-measured") {
+  // Seeding/raising aid. Deliberately prints to stdout instead of writing the
+  // baseline: floors move only through a reviewed edit with the reason
+  // recorded in the file, never as a side effect of running the tool.
+  const { groups } = measuredGroups(new Set());
+  for (const [dir, got] of [...groups].sort()) {
+    console.log(
+      `${dir} ${METRICS.map((m) => (Math.floor(got[m] * 10) / 10).toFixed(1)).join(" ")}`,
+    );
+  }
+  process.exit(0);
+}
+
+// --- compare --------------------------------------------------------------
+
+const { floors, exempt } = parseBaseline(baselinePath);
+const { groups, seenFiles } = measuredGroups(exempt);
+
+let fail = 0;
+const note = (ok, msg) => {
+  console.log(`${ok ? "PASS " : "FAIL "} ${msg}`);
+  if (!ok) fail = 1;
+};
+
+// A stale exemption is how this gate would rot into decoration: src/index.ts
+// gets renamed, the exemption stops matching anything, and nobody notices that
+// the replacement file is now silently dragging its group down (or worse, is
+// itself exempt by a path that no longer means what it meant).
+for (const path of [...exempt].sort()) {
+  if (!seenFiles.has(path)) {
+    note(false, `!exempt ${path}: no such file in the coverage report — moved or deleted? Update ${baselinePath}.`);
+  }
+}
+
+// Unbaselined directories fail. Without this the ratchet is trivially
+// bypassable: add src/newthing/ with no tests, and a baseline-driven loop
+// never looks at it.
+for (const dir of [...groups.keys()].sort()) {
+  if (!floors.has(dir)) {
+    note(
+      false,
+      `${dir}: covered by tests but absent from ${baselinePath} — new directory? ` +
+        `Add a floor (see --print-measured).`,
+    );
+  }
+}
+
+for (const [dir, want] of [...floors].sort()) {
+  const got = groups.get(dir);
+  if (!got) {
+    note(false, `${dir}: in baseline but absent from the coverage report — deleted or renamed? Update ${baselinePath} deliberately.`);
+    continue;
+  }
+  for (const m of METRICS) {
+    const g = got[m];
+    const w = want[m];
+    const shown = `${g.toFixed(2)}% vs floor ${w.toFixed(1)}%`;
+    if (g + EPSILON < w) {
+      note(false, `${dir} ${m}: ${shown} (epsilon ${EPSILON})`);
+    } else if (g >= w + 1) {
+      // Only nudge on a full point, so ordinary +0.2 drift doesn't spam every
+      // run with advice nobody acts on.
+      note(true, `${dir} ${m}: ${shown} — beats the floor, consider raising it`);
+    } else {
+      note(true, `${dir} ${m}: ${shown}`);
+    }
+  }
+}
+
+if (process.env.CCU_HOST) {
+  console.log(
+    "\nNOTE: CCU_HOST is set, so the live-integration suites ran and these " +
+      "numbers are HIGHER than CI will measure. Do not raise floors from this run.",
+  );
+}
+
+if (fail) {
+  console.log(
+    `\nCoverage ratchet failed. Add tests covering what this change touches; ` +
+      `lowering a floor in ${baselinePath} requires the reason recorded in the file.`,
+  );
+}
+process.exit(fail);

--- a/scripts/test-coverage-ratchet.mjs
+++ b/scripts/test-coverage-ratchet.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+// Table-driven tests for coverage-ratchet.mjs. Synthesizes
+// coverage-summary.json fixtures and asserts the verdicts, because a ratchet
+// that has never been observed to fail is indistinguishable from one that
+// cannot fail. Every branch that produces exit 1 or exit 2 gets a case here.
+//
+// Run: node scripts/test-coverage-ratchet.mjs   (no deps, no build)
+
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const RATCHET = join(dirname(fileURLToPath(import.meta.url)), "coverage-ratchet.mjs");
+const TMP = mkdtempSync(join(tmpdir(), "ratchet-test-"));
+process.on("exit", () => rmSync(TMP, { recursive: true, force: true }));
+
+let failures = 0;
+
+// files: { "src/a/x.ts": [stCovered, stTotal, brCovered, brTotal] }
+// Keys are written as absolute paths under `cwd`, matching what v8 emits.
+function writeSummary(name, files, cwd) {
+  const out = { total: {} };
+  for (const [rel, [sc, st, bc, bt]] of Object.entries(files)) {
+    out[join(cwd, rel)] = {
+      statements: { covered: sc, total: st, pct: st ? (100 * sc) / st : 100 },
+      branches: { covered: bc, total: bt, pct: bt ? (100 * bc) / bt : 100 },
+      functions: { covered: 0, total: 0, pct: 100 },
+      lines: { covered: sc, total: st, pct: st ? (100 * sc) / st : 100 },
+    };
+  }
+  const path = join(TMP, `${name}.json`);
+  writeFileSync(path, JSON.stringify(out));
+  return path;
+}
+
+function writeBaseline(name, text) {
+  const path = join(TMP, `${name}.baseline.txt`);
+  writeFileSync(path, text);
+  return path;
+}
+
+// wantOut asserts on the diagnostic, not just the exit code. Without it a case
+// can pass for the wrong reason: an uncaught TypeError also exits non-zero, so
+// "it failed" alone cannot tell a clean verdict from a crash.
+function check(name, wantExit, summaryPath, baselinePath, { env = {}, cwd = TMP, wantOut } = {}) {
+  const res = spawnSync(process.execPath, [RATCHET, summaryPath, baselinePath], {
+    cwd,
+    encoding: "utf-8",
+    env: { ...process.env, CCU_HOST: "", ...env },
+  });
+  const out = res.stdout + res.stderr;
+  const problem =
+    res.status !== wantExit
+      ? `want exit ${wantExit}, got ${res.status}`
+      : wantOut && !out.includes(wantOut)
+        ? `expected output to contain ${JSON.stringify(wantOut)}`
+        : null;
+  if (!problem) {
+    console.log(`PASS: ${name}`);
+    return res;
+  }
+  console.log(`FAIL: ${name} (${problem})`);
+  console.log(
+    out
+      .split("\n")
+      .map((l) => `    ${l}`)
+      .join("\n"),
+  );
+  failures++;
+  return res;
+}
+
+// A directory sitting exactly on its floor, and one comfortably above it.
+const BASE = writeBaseline(
+  "base",
+  `# comments and blank lines are ignored
+
+src/a 80.0 70.0
+src/b 50.0 50.0
+`,
+);
+
+// --- the happy paths -------------------------------------------------------
+
+check(
+  "exact hold passes",
+  0,
+  writeSummary("hold", { "src/a/x.ts": [80, 100, 70, 100], "src/b/y.ts": [50, 100, 50, 100] }, TMP),
+  BASE,
+);
+
+check(
+  "improvement passes",
+  0,
+  writeSummary("up", { "src/a/x.ts": [90, 100, 85, 100], "src/b/y.ts": [61, 100, 60, 100] }, TMP),
+  BASE,
+);
+
+check(
+  "drop within epsilon passes",
+  0,
+  writeSummary("noise", { "src/a/x.ts": [797, 1000, 70, 100], "src/b/y.ts": [50, 100, 50, 100] }, TMP),
+  BASE,
+);
+
+// --- regressions must fail -------------------------------------------------
+
+check(
+  "statement regression fails",
+  1,
+  writeSummary("down", { "src/a/x.ts": [77, 100, 70, 100], "src/b/y.ts": [50, 100, 50, 100] }, TMP),
+  BASE,
+);
+
+check(
+  "branch regression fails",
+  1,
+  writeSummary("downbr", { "src/a/x.ts": [80, 100, 60, 100], "src/b/y.ts": [50, 100, 50, 100] }, TMP),
+  BASE,
+);
+
+check(
+  "regression in the second directory fails",
+  1,
+  writeSummary("downb", { "src/a/x.ts": [80, 100, 70, 100], "src/b/y.ts": [40, 100, 50, 100] }, TMP),
+  BASE,
+);
+
+// A drop of exactly epsilon is on the pass side of the boundary; one hair more
+// is not. Pins the comparison so a `<=`/`<` slip can't widen the tolerance.
+check(
+  "drop of exactly epsilon passes",
+  0,
+  writeSummary("eps", { "src/a/x.ts": [795, 1000, 70, 100], "src/b/y.ts": [50, 100, 50, 100] }, TMP),
+  BASE,
+);
+check(
+  "drop of epsilon plus a hair fails",
+  1,
+  writeSummary("eps2", { "src/a/x.ts": [7949, 10000, 70, 100], "src/b/y.ts": [50, 100, 50, 100] }, TMP),
+  BASE,
+);
+
+check(
+  "RATCHET_EPSILON is honoured",
+  0,
+  writeSummary("eps3", { "src/a/x.ts": [70, 100, 70, 100], "src/b/y.ts": [50, 100, 50, 100] }, TMP),
+  BASE,
+  { env: { RATCHET_EPSILON: "10" } },
+);
+
+// --- drift between baseline and tree ---------------------------------------
+
+check(
+  "baselined directory absent from coverage fails",
+  1,
+  writeSummary("gone", { "src/a/x.ts": [80, 100, 70, 100] }, TMP),
+  BASE,
+  { wantOut: "src/b: in baseline but absent from the coverage report" },
+);
+
+// The hole a baseline-driven loop leaves open: iterate the baseline only, and
+// a brand-new untested directory is never looked at.
+check(
+  "new directory missing from the baseline fails",
+  1,
+  writeSummary(
+    "new",
+    {
+      "src/a/x.ts": [80, 100, 70, 100],
+      "src/b/y.ts": [50, 100, 50, 100],
+      "src/c/z.ts": [0, 100, 0, 100],
+    },
+    TMP,
+  ),
+  BASE,
+  { wantOut: "src/c: covered by tests but absent from" },
+);
+
+// --- exemptions ------------------------------------------------------------
+
+const EXEMPT_BASE = writeBaseline(
+  "exempt",
+  `!exempt src/a/entry.ts
+src/a 80.0 70.0
+src/b 50.0 50.0
+`,
+);
+
+// Same fixture, with and without the exemption: proves the exempt file is
+// actually dropped from the aggregate rather than the rule being inert.
+const WITH_ENTRY = writeSummary(
+  "withentry",
+  {
+    "src/a/x.ts": [80, 100, 70, 100],
+    "src/a/entry.ts": [0, 100, 0, 100],
+    "src/b/y.ts": [50, 100, 50, 100],
+  },
+  TMP,
+);
+check("exempt file is excluded from its directory's aggregate", 0, WITH_ENTRY, EXEMPT_BASE);
+check("without the exemption the same tree fails", 1, WITH_ENTRY, BASE);
+
+// A renamed exempt file must not fail open — otherwise the replacement drags
+// the group down silently while the dead exemption looks like it's working.
+check(
+  "stale exemption fails",
+  1,
+  writeSummary("stale", { "src/a/x.ts": [80, 100, 70, 100], "src/b/y.ts": [50, 100, 50, 100] }, TMP),
+  EXEMPT_BASE,
+  { wantOut: "!exempt src/a/entry.ts: no such file" },
+);
+
+// --- weighting -------------------------------------------------------------
+
+// 1 covered of 1 in a tiny file, 0 of 99 in a big one is 1% weighted, but 50%
+// as a naive mean of per-file percentages. The floor sits at 40 — between the
+// two — so the case can only pass if the aggregate is genuinely weighted. With
+// the floor at 80 both readings fail and the test proves nothing.
+check(
+  "aggregate is weighted by statement count, not a mean of file percentages",
+  1,
+  writeSummary(
+    "weight",
+    {
+      "src/a/tiny.ts": [1, 1, 1, 1],
+      "src/a/big.ts": [0, 99, 0, 99],
+      "src/b/y.ts": [50, 100, 50, 100],
+    },
+    TMP,
+  ),
+  writeBaseline("weightbase", "src/a 40.0 40.0\nsrc/b 50.0 50.0\n"),
+  { wantOut: "src/a statements: 1.00% vs floor 40.0%" },
+);
+
+// --- harness errors must exit 2, never 0 or 1 ------------------------------
+
+check("missing coverage summary exits 2", 2, join(TMP, "nope.json"), BASE);
+check(
+  "missing baseline exits 2",
+  2,
+  writeSummary("ok1", { "src/a/x.ts": [80, 100, 70, 100], "src/b/y.ts": [50, 100, 50, 100] }, TMP),
+  join(TMP, "nope.txt"),
+);
+
+const OK = writeSummary(
+  "ok2",
+  { "src/a/x.ts": [80, 100, 70, 100], "src/b/y.ts": [50, 100, 50, 100] },
+  TMP,
+);
+
+// A non-numeric floor would become NaN, and every NaN comparison is false, so
+// the directory would pass unconditionally. Must be rejected at parse time.
+check("non-numeric floor exits 2", 2, OK, writeBaseline("nan", "src/a 80.0 hgh\n"));
+check("out-of-range floor exits 2", 2, OK, writeBaseline("range", "src/a 80.0 140\n"));
+check("wrong field count exits 2", 2, OK, writeBaseline("short", "src/a 80.0\n"));
+check("duplicate directory entry exits 2", 2, OK, writeBaseline("dup", "src/a 80.0 70.0\nsrc/a 10.0 10.0\n"));
+check("malformed !exempt exits 2", 2, OK, writeBaseline("badex", "!exempt a b\nsrc/a 80.0 70.0\n"));
+check("negative RATCHET_EPSILON exits 2", 2, OK, BASE, { env: { RATCHET_EPSILON: "-1" } });
+check("non-numeric RATCHET_EPSILON exits 2", 2, OK, BASE, { env: { RATCHET_EPSILON: "wide" } });
+
+// Truncated JSON is a plausible real failure (interrupted run, full disk); it
+// must read as "cannot check", not as a clean tree.
+check("corrupt coverage summary exits 2", 2, writeBaseline("corrupt", "{not json"), BASE);
+
+// --- --print-measured ------------------------------------------------------
+
+{
+  const before = readFileSync(BASE, "utf-8");
+  const res = spawnSync(process.execPath, [RATCHET, OK, "--print-measured"], {
+    cwd: TMP,
+    encoding: "utf-8",
+  });
+  const ok =
+    res.status === 0 &&
+    res.stdout.includes("src/a 80.0 70.0") &&
+    readFileSync(BASE, "utf-8") === before;
+  console.log(`${ok ? "PASS" : "FAIL"}: --print-measured reports floors and writes nothing`);
+  if (!ok) {
+    console.log(`    exit ${res.status}\n${res.stdout}${res.stderr}`);
+    failures++;
+  }
+}
+
+// --- summary ---------------------------------------------------------------
+
+if (failures) {
+  console.log(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log("\nall coverage-ratchet tests passed");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
     coverage: {
       // Count every source file, including ones no test imports
       include: ["src/**/*.ts"],
+      // `text` is vitest's default and the one a human reads; `json-summary`
+      // writes coverage/coverage-summary.json, which scripts/coverage-ratchet.mjs
+      // parses for the per-directory floors in .github/coverage-baseline.txt.
+      // Naming reporters replaces the defaults, so `text` has to be restated.
+      reporter: ["text", "json-summary"],
       // Floor, set just under the numbers at the time of writing so ordinary
       // work doesn't trip it but a real slide does. Hermetic — a pure function
       // of the commit under test, so it stays inside the `build-and-test`
@@ -15,6 +20,12 @@ export default defineConfig({
       // suites spawn it as a subprocess and v8 coverage cannot attribute those.
       // A per-file threshold would fail on it permanently, for a measurement
       // artifact rather than a real gap.
+      //
+      // These numbers alone are not enough, because an average hides local
+      // collapse — deleting the src/http tests takes that directory from 100%
+      // to 0% and moves the global statement figure UP, to 85.51%. The
+      // per-directory floors in .github/coverage-baseline.txt cover that gap;
+      // src/index.ts is exempted there for the reason above.
       thresholds: {
         statements: 85,
         branches: 79,


### PR DESCRIPTION
## Why

`vitest.config.ts` enforces **global** coverage thresholds, but an average hides local collapse.

Concretely — delete `test/unit/http-error-response.test.ts` on `dev` today:

| | before | after |
|---|---|---|
| `src/http` statements | 100.00% | **0.00%** |
| global statements | 85.78% | 85.51% |
| `npm test -- --coverage` | pass | **pass** |

A directory goes to zero, the global figure stays above its 85% floor, and CI is green. That is the gap this closes.

## What

`scripts/coverage-ratchet.mjs` adds a floor per directory underneath the global thresholds, read from `.github/coverage-baseline.txt`. Both layers stay **hermetic** — coverage is a pure function of the commit under test — so this stays inside the `build-and-test` contract rather than becoming another `npm audit`.

Ported from `docker-net-dhcp`'s `scripts/coverage-ratchet.sh`, with two additions that close holes in a purely baseline-driven loop:

- **A directory in the coverage report but absent from the baseline fails.** Otherwise `src/newthing/` lands with no tests and a loop that only iterates known entries never looks at it.
- **A `!exempt` path that no longer matches a file fails.** A rename would otherwise leave a dead exemption behind while its replacement quietly drags the group down.

Exit codes are 0 / 1 / 2, with 2 reserved for "cannot check" — a truncated `coverage-summary.json` or a malformed baseline can never read as either a pass or a coverage regression.

## The `src/index.ts` exemption

It measures 0% as an artifact, not a gap: the e2e suites spawn it as a subprocess and v8 cannot attribute a child process back to the parent's report. At 197 statements it drags the `src/` root group from 93.7% to 46.2%, forcing a floor too low to defend `config.ts` / `logger.ts` / `server.ts` / `utils.ts`. `vitest.config.ts` already declines per-file thresholds for the same reason. The exemption is recorded in the baseline file with that rationale, and fails loudly if the path ever stops matching.

## Floors

Seeded at measured-truncated-to-one-decimal. `RATCHET_EPSILON` (0.5) is the only slack, and it is headroom for Node-patch differences between CI and a developer's machine — **not** run-to-run noise: repeat local runs came back byte-identical.

The baseline file also warns about re-measuring with `CCU_HOST` set, which runs the live-integration suites and inflates every number past what CI can reach. The ratchet prints a warning when it sees it.

## Verification

`scripts/test-coverage-ratchet.mjs` — 26 cases, no deps, no build. It runs in CI **immediately before** the ratchet, so the failure path is exercised on every build rather than assumed.

Twelve deliberate mutations of the ratchet were each caught by the self-test:

| mutation | caught |
|---|---|
| drop unbaselined-directory check | 1 test |
| drop stale-exemption check | 1 |
| ignore epsilon | 3 |
| widen epsilon to `<=` | 2 |
| drop NaN floor guard | 2 |
| drop deleted-directory check | 1 |
| mean of file pcts instead of weighted | 1 |
| harness error exits 1 not 2 | 10 |
| always exit 0 | 9 |
| exemption never applied | 1 |
| duplicate-entry check dropped | 1 |
| stop checking branches | 17 |

Two of those initially **escaped** and drove real fixes to the tests:

- the weighting case put the floor at 80, where both weighted (1%) and per-file-mean (50%) fail — it could not tell the two apart. The floor now sits at 40, between them.
- the deleted-directory case passed on an uncaught `TypeError`, not a clean verdict. Cases now assert on the diagnostic text, not just the exit code.

End-to-end on the real tree: removing `device-type-cache.test.ts` produces `FAIL src/cache statements: 87.86% vs floor 99.2%`, and the clean tree passes all 20 checks.

`npm run lint` and `npm test` both green.