### PR TITLE
docs: add OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919/badge)](https://www.bestpractices.dev/projects/13919)
+
 <a href="https://glama.ai/mcp/servers/claymore666/ccu-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/claymore666/ccu-mcp/badge" alt="ccu-mcp MCP server" />
 </a>


### PR DESCRIPTION
Adds the [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919) badge (project 13919) under the tagline in `README.md`.

Verified the project record points at this repo — `repo_url` and `homepage_url` are both `https://github.com/claymore666/ccu-mcp`, license MIT.

The badge image is served live from bestpractices.dev, so it tracks the tier automatically as criteria get answered; no README edit needed when it moves.

**Heads-up on what it currently renders:** `in progress 82%`, not `passing`. `achieve_passing` is `Unmet`. The remaining passing-tier criteria are mostly *unanswered* (`?`) rather than failed — several are things the repo already does and just needs to assert on the questionnaire.

`npm run lint` and `npm test` green (444 passed). No test parses this part of the README — `env-example-sync` reads table rows and `docs-drift` reads the `## Tools` section, and the badge line is neither.