### PR TITLE
docs: add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,131 @@
+# Contributing to ccu-mcp
+
+Bug reports, feature requests and pull requests are all welcome.
+
+## Getting help, reporting bugs, suggesting features
+
+- **Bugs and feature requests** — open an issue:
+  <https://github.com/claymore666/ccu-mcp/issues>. Include the ccu-mcp version
+  (`ccu-mcp --version`), your CCU type and firmware (debmatic, OpenCCU, CCU3),
+  Node.js version, and the tool call or log line that went wrong.
+- **Security vulnerabilities** — do **not** open an issue. Follow
+  [SECURITY.md](SECURITY.md).
+- **Questions, setup help, and general HomeMatic discussion** — the
+  [HomeMatic forum](https://homematic-forum.de/) is the right place, and is
+  where most HomeMatic users already are. The maintainer reads it as
+  `claymore666`. Please keep bug *reports* on GitHub, where they can be tracked
+  against a release.
+
+Please write issues in English or German.
+
+## Test policy
+
+**Any pull request that adds or changes functionality must add or update tests
+covering it.** This is not negotiable for major new functionality: a new tool,
+a new transport, a new configuration surface, or a change in how an existing
+tool behaves all require tests in the same PR.
+
+Bug fixes must include a test that fails before the fix and passes after it. A
+fix without such a test is not considered complete, because nothing then stops
+the bug returning.
+
+Documentation-only and formatting-only changes are exempt.
+
+CI enforces coverage thresholds (see `vitest.config.ts`), so a change that adds
+untested code can fail the build even when every existing test passes.
+
+## Development setup
+
+Requires Node.js >= 24.
+
+```sh
+git clone https://github.com/claymore666/ccu-mcp.git
+cd ccu-mcp
+npm ci
+npm run lint     # tsc --noEmit over src AND test
+npm test         # builds dist/, then runs vitest
+```
+
+Run **both** before opening a PR. `npm run lint` type-checks the test files,
+which `npm test` does not — skipping it is the usual cause of a red build that
+was green locally.
+
+Always use `npm test` rather than a bare `npx vitest`: the `pretest` hook
+rebuilds `dist/`, and the end-to-end suite runs the built server. Without the
+rebuild those tests silently exercise a stale build.
+
+### Testing against a real CCU
+
+The unit and e2e suites run against a mocked CCU and need no hardware. The
+live-integration suites in `test/integration/` are gated on `CCU_HOST` and are
+skipped unless you set it:
+
+```sh
+CCU_HOST=your-ccu CCU_PORT=443 CCU_HTTPS=true \
+CCU_USER=Admin CCU_PASSWORD=... npm test
+```
+
+These round-trip against real hardware and clean up after themselves. Never
+point them at a CCU you are not willing to have written to.
+
+## Branching and pull requests
+
+Two long-lived branches. Older releases exist as tags, not branches.
+
+- **`dev`** is the default branch and the integration branch. **Branch off
+  `dev` and target `dev` with your PR.**
+- **`main`** holds released code and is protected. PRs into `main` are release
+  PRs made by the maintainer.
+
+Name work branches by what they do: `feature/…`, `fix/…`, `ci/…`, `docs/…`,
+`tests/…`.
+
+Keep a PR to one concern. A small, reviewable PR that does one thing gets
+merged; a large one that does five things waits.
+
+### Commit messages
+
+Use a `type: summary` subject — `feat:`, `fix:`, `docs:`, `test:`, `ci:`,
+`refactor:`, `chore:`. Explain *why* in the body when the reason isn't obvious
+from the diff.
+
+**Do not include AI-assistant attribution** in commit messages, commit author
+or committer identity, or PR descriptions — no `Co-Authored-By` lines naming an
+assistant, no "Generated with …" trailers. CI enforces this and the PR will
+fail. Using an assistant to help write the code is fine; the commit history
+just records you as the author.
+
+## Code style
+
+- TypeScript, `strict` mode. `npm run lint` must be clean — warnings are not
+  acceptable in merged code.
+- Match the style of the file you're editing.
+- Comments should explain *why*, not restate *what*. The existing codebase
+  leans on this heavily; a comment recording a decision or a trap is valuable,
+  a comment narrating the next line is noise.
+
+## Adding or changing a tool
+
+Tool documentation is guarded by tests, so all of these must move together or
+the build fails:
+
+1. Register the tool in the relevant `src/tools/*.ts`.
+2. Add its entry to `TOOL_HELP` and the guide in `src/tools/meta.ts` — this is
+   what the in-server `help` tool serves.
+3. Add it to the `## Tools` section of `README.md`, and update the tool count
+   in that section.
+4. Add tests.
+
+`test/unit/docs-drift.test.ts` compares the registered tools against the help
+text and the README in both directions, so a tool that is added in one place
+and forgotten in another is caught at test time rather than by a user.
+
+New environment variables are guarded the same way by
+`test/unit/env-example-sync.test.ts`: add them to `.env.example` and to the
+configuration table in `README.md`.
+
+## Releases
+
+Releases are made by the maintainer. Contributors never need to bump versions,
+edit `CHANGELOG.md` for a release, or tag anything — please leave
+`package.json`'s version alone in your PR.

--- a/README.md
+++ b/README.md
@@ -407,6 +407,18 @@ Release notes — including **behavior changes to check before upgrading**
 (stricter config validation, `/health` response shape, per-session write
 confirmation, retry semantics) — live in [CHANGELOG.md](CHANGELOG.md).
 
+## Getting help and contributing
+
+- **Something broken, or an idea for a feature?** Open an issue:
+  [github.com/claymore666/ccu-mcp/issues](https://github.com/claymore666/ccu-mcp/issues)
+- **Questions, setup help, general HomeMatic talk?** The
+  [HomeMatic forum](https://homematic-forum.de/) — the maintainer reads it as
+  `claymore666`.
+- **Found a security problem?** Please don't post it publicly. See
+  [SECURITY.md](SECURITY.md) for private reporting.
+- **Want to send a patch?** [CONTRIBUTING.md](CONTRIBUTING.md) covers the setup,
+  the branch to target, and the test policy.
+
 ## Related projects
 
 - [OpenCCU](https://github.com/OpenCCU/OpenCCU) — community-maintained, cloud-free CCU firmware for Raspberry Pi, x86/ARM, and CCU3/ELV-Charly hardware (formerly **RaspberryMatic**; built on the OCCU framework)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,99 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems, and please do not
+post them to the [HomeMatic forum](https://homematic-forum.de/).** Both are
+public, and a CCU controls physical devices — locks, heating, sockets — so an
+unfixed report there is an invitation.
+
+Report privately through GitHub Security Advisories:
+
+**https://github.com/claymore666/ccu-mcp/security/advisories/new**
+
+Private vulnerability reporting is enabled on this repository, so the report
+stays visible only to you and the maintainer until a fix is published.
+
+If you cannot use that form, email <christian.kamien@gmail.com> with `ccu-mcp
+security` in the subject.
+
+### What to expect
+
+ccu-mcp is maintained by one person, so please read these as honest targets
+rather than an SLA:
+
+| Stage | Target |
+| --- | --- |
+| Acknowledgement that the report arrived | within 14 days |
+| Initial assessment — accepted, needs more information, or out of scope | within 30 days |
+| Fix released for an accepted report | as fast as severity warrants; you'll get a date once the assessment is done |
+
+Reports are credited in the advisory and in [CHANGELOG.md](CHANGELOG.md) unless
+you ask otherwise.
+
+## Supported versions
+
+Fixes land in the current release line. There are no long-lived maintenance
+branches — older versions exist as tags only.
+
+| Version | Supported |
+| --- | --- |
+| 1.9.x | Yes |
+| < 1.9 | No — upgrade to the latest release |
+
+ccu-mcp requires Node.js >= 24, and inherits that runtime's own security
+support window.
+
+## Threat model
+
+ccu-mcp holds credentials for a CCU, and a CCU controls physical devices —
+locks, heating, sockets. A compromise of this server is a compromise of the
+smart home behind it. Design accordingly.
+
+**In scope** — please report:
+
+- Authentication bypass on the HTTP transport (`MCP_AUTH_TOKEN` handling,
+  token rotation via `MCP_AUTH_TOKEN_PREVIOUS` / `MCP_AUTH_TOKEN_GRACE_HOURS`).
+- Defeating TLS verification against the CCU (`CCU_TLS_VERIFY`,
+  `CCU_TLS_FINGERPRINT` pinning, `CCU_CA_CERT`).
+- DNS-rebinding or origin-confusion attacks that get past `MCP_ALLOWED_HOSTS`
+  or `MCP_ALLOWED_ORIGINS`.
+- Leaking credentials, session IDs, or tokens into logs, error messages, tool
+  output, or the persisted session cache.
+- Bypassing the write-confirmation guard (`CCU_<PROFILE>_PROTECTED` /
+  `confirm: true`) so a write reaches a protected CCU without confirmation.
+- Command or script injection through tool parameters — particularly anything
+  reaching `run_script` / ReGa.
+- Path traversal or unsafe file handling in the device-type cache or session
+  cache.
+
+**Out of scope:**
+
+- Vulnerabilities in the CCU firmware itself (debmatic, OpenCCU, CCU3) —
+  report those upstream.
+- Deliberately exposing this server to the public internet, or running it over
+  plain HTTP on a routable address. It is designed for a trusted LAN, and
+  choosing to drop transport security is a deployment decision, not a defect.
+- Anyone with the CCU password being able to control the CCU. That is what the
+  credential is for.
+- Missing hardening on the host running the server (file permissions outside
+  what ccu-mcp creates, container escape from a misconfigured runtime).
+- Dependency advisories with no exploitable path through this code. These are
+  already tracked daily by `.github/workflows/audit.yml` and gated on release;
+  a report is still welcome if you can show reachability.
+
+## Notes for operators
+
+- Keep `MCP_TRANSPORT=http` behind TLS (`MCP_TLS_CERT` / `MCP_TLS_KEY`), behind
+  a TLS-terminating proxy, or bound to loopback with `MCP_HOST=127.0.0.1`.
+  Serving plain HTTP on a non-loopback address logs a startup warning; note
+  that `MCP_ALLOW_PLAINTEXT=true` only silences that warning — it does not add
+  any protection, and the bearer token still travels in the clear.
+- Pin the CCU certificate with `CCU_TLS_FINGERPRINT` where you can. It is the
+  strongest available protection given most CCUs use a self-signed certificate.
+- The persisted session cache is written `0600` because the session ID it holds
+  grants full CCU access. Do not relax that, and do not place the cache on a
+  shared filesystem.
+- Give the CCU a dedicated user for ccu-mcp rather than reusing `Admin`, and
+  give it USER level unless you actually need script execution — `run_script`
+  and everything built on ReGa require ADMIN.


### PR DESCRIPTION
Closes the two documentation gaps blocking the OpenSSF Best Practices passing tier, and adds the README pointer that closes a third.

## `SECURITY.md`

The repo already has GitHub private vulnerability reporting **enabled** (`/private-vulnerability-reporting` returns `{"enabled": true}`) — nothing documented it, so nobody would find it. This points at the advisory form, and asks people not to post to the public forum or issue tracker.

The threat model says what this actually is: a server holding CCU credentials, where a compromise reaches locks, heating and sockets. In-scope items are concrete (auth bypass on the HTTP transport, defeating `CCU_TLS_FINGERPRINT` pinning, DNS rebinding past `MCP_ALLOWED_HOSTS`, credential leakage into logs, bypassing the `confirm: true` write guard, injection through `run_script`). Out-of-scope is equally explicit, including dependency advisories with no reachable path — those are already handled daily by `audit.yml` and gated on release.

Response targets are stated as targets, not an SLA, because this is a one-maintainer project.

## `CONTRIBUTING.md`

States the **test policy** publicly for the first time — it previously existed only in the maintainer's local notes, which are gitignored, so it could not be claimed or pointed at:

> Any pull request that adds or changes functionality must add or update tests covering it. […] Bug fixes must include a test that fails before the fix and passes after it.

Also documents dev-vs-main and the branch naming, the `npm run lint` trap (it type-checks `test/`, `npm test` doesn't — the usual cause of green-locally-red-in-CI), why `npm test` and never bare `npx vitest`, the `CCU_HOST`-gated live suites, and the no-AI-attribution rule that the `attribution` check already enforces.

The "Adding or changing a tool" section documents the coupling the docs-drift guards create: registration, `TOOL_HELP`, the guide in `src/tools/meta.ts`, the README `## Tools` section and its count all have to move together.

## `README.md`

New "Getting help and contributing" section: issues for bugs, the [HomeMatic forum](https://homematic-forum.de/) for questions and setup help, SECURITY.md for vulnerabilities, CONTRIBUTING.md for patches.

## Accuracy

Every environment variable and behaviour claim was checked against the source rather than assumed. Two drafting errors were caught and corrected that way:

- `MCP_ALLOW_PLAINTEXT` does **not** gate plaintext HTTP — `src/index.ts:439` shows it only silences a startup warning. Documented as such, with the note that the bearer token still travels in the clear.
- The write guard is `CCU_<PROFILE>_PROTECTED` (`src/config.ts:219`), not a single global variable.

`npm run lint` and `npm test` green (444 passed).