### PR TITLE
ci: publish to npm via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,12 +127,16 @@ jobs:
           set -euo pipefail
           have=$(npm --version)
           echo "npm $have"
+          # String concatenation rather than template literals: shellcheck
+          # cannot tell a JS `${…}` inside a single-quoted heredoc from a shell
+          # expansion that will not expand, and flags SC2016.
           node -e '
-            const [have, want] = [process.argv[1], "11.5.1"];
+            const have = process.argv[1], want = "11.5.1";
             const cmp = (a, b) => a.split(".").map(Number)
               .reduce((r, n, i) => r !== 0 ? r : n - Number(b.split(".")[i]), 0);
             if (cmp(have, want) < 0) {
-              console.error(`::error::npm ${have} is older than ${want}; trusted publishing needs ${want}+`);
+              console.error("::error::npm " + have + " is older than " + want +
+                "; trusted publishing needs " + want + " or newer");
               process.exit(1);
             }
           ' "$have"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,210 @@
+name: Publish
+
+# Publishes ccu-mcp to npm via TRUSTED PUBLISHING (OIDC). There is no
+# NPM_TOKEN secret anywhere in this repository, and there must never be one:
+# the package is configured on npmjs.com with "Require two-factor
+# authentication and disallow tokens", so a token could not publish even if it
+# leaked. npm mints a short-lived credential from the OIDC claim GitHub issues
+# for this specific workflow file, in this repository, in this environment.
+#
+# THE FILENAME AND ENVIRONMENT NAME ARE PART OF THE CONTRACT. npmjs.com pins
+# the trusted publisher to `publish.yml` and the `release` environment; rename
+# either and the publish fails closed rather than falling back to a token.
+#
+# Provenance is generated automatically — no --provenance flag is needed when
+# publishing through a trusted publisher from a public repo.
+#
+# The human gate: the `release` environment requires review from claymore666
+# before the publish job starts. That is the deliberate replacement for the
+# YubiKey touch a local `npm publish` used to demand. Its deployment branch
+# policy allows only `v*` tags and `main`, so a run from `dev` or a feature
+# branch is refused by GitHub before any job starts.
+#
+# Local `npm publish` still works as a fallback — interactive publishing with
+# 2FA is unaffected by the token restriction. See docs/release-runbook.md.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run — verify OIDC and the tarball without uploading"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+# Two runs publishing the same version would race; npm would reject the second
+# with 403 (versions are immutable), but a half-finished release is worse than
+# a queued one.
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  # Everything that can fail WITHOUT a human present runs first, deliberately
+  # outside the `release` environment. Asking someone to approve a deployment
+  # and only then discovering the tests are red wastes the one thing the gate
+  # is spending: attention.
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The tag is what humans read; package.json is what npm publishes. If
+      # they disagree, v1.9.1 ships the contents of 1.9.0 under the wrong name
+      # and npm versions are immutable — there is no taking it back.
+      - name: Tag and package version must agree
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          pkg="v$(node -p "require('./package.json').version")"
+          echo "tag=$TAG package.json=$pkg"
+          if [ "$TAG" != "$pkg" ]; then
+            echo "::error::Tag $TAG does not match package.json $pkg. Refusing to publish."
+            exit 1
+          fi
+
+      - name: Version sync check
+        run: npm run check:versions
+
+      - name: Type check
+        run: npm run lint
+
+      - name: Test
+        run: npm test -- --coverage
+
+      # `files` ships dist/ only. Printing the tarball contents here means a
+      # packaging mistake is visible in the log BEFORE anyone approves.
+      - name: Show what would be published
+        run: npm pack --dry-run
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Requires review from claymore666 before this job starts, and npm matches
+    # this environment name against the OIDC claim.
+    environment: release
+    permissions:
+      contents: read
+      # Mints the OIDC token npm exchanges for a short-lived publish
+      # credential. Without it there is no trusted publishing at all.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # registry-url is required: it writes the .npmrc that points the CLI at
+      # the registry the OIDC credential is valid for.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      # Trusted publishing needs npm >= 11.5.1. Node 24 ships a new enough npm
+      # today, but assert it rather than discover the failure mid-release.
+      - name: Check npm supports trusted publishing
+        run: |
+          set -euo pipefail
+          have=$(npm --version)
+          echo "npm $have"
+          node -e '
+            const [have, want] = [process.argv[1], "11.5.1"];
+            const cmp = (a, b) => a.split(".").map(Number)
+              .reduce((r, n, i) => r !== 0 ? r : n - Number(b.split(".")[i]), 0);
+            if (cmp(have, want) < 0) {
+              console.error(`::error::npm ${have} is older than ${want}; trusted publishing needs ${want}+`);
+              process.exit(1);
+            }
+          ' "$have"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # No --provenance flag and no NODE_AUTH_TOKEN: trusted publishing
+      # generates provenance on its own, and supplying a token here would
+      # defeat the point of having disallowed them.
+      - name: Publish to npm
+        id: publish
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run — validating the tarball and OIDC setup, uploading nothing."
+            npm publish --dry-run
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          else
+            npm publish
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # A publish that silently lands without provenance would still look like
+      # success, and `signed_releases` would be a claim we could not back.
+      - name: Verify provenance landed
+        if: steps.publish.outputs.published == 'true'
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          # The registry is read-your-writes for a fresh version, but give the
+          # CDN a moment before calling it a failure.
+          seen=0
+          for attempt in 1 2 3 4 5; do
+            if npm view "ccu-mcp@${version}" --json > view.json 2>/dev/null; then
+              seen=1
+              break
+            fi
+            echo "attempt ${attempt}: version not visible yet, waiting"
+            sleep 10
+          done
+          if [ "$seen" -ne 1 ]; then
+            echo "::error::ccu-mcp@${version} did not become visible on the registry; cannot confirm provenance."
+            exit 1
+          fi
+          node -e '
+            const v = require("./view.json");
+            if (!v.dist || !v.dist.attestations) {
+              console.error("::error::ccu-mcp@" + v.version + " published WITHOUT provenance attestations.");
+              process.exit(1);
+            }
+            console.log("provenance present:", JSON.stringify(v.dist.attestations));
+          '
+
+      - name: Summary
+        if: always()
+        env:
+          PUBLISHED: ${{ steps.publish.outputs.published }}
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          {
+            if [ "$PUBLISHED" = "true" ]; then
+              echo "### Published \`ccu-mcp@${version}\` with provenance"
+              echo
+              echo "https://www.npmjs.com/package/ccu-mcp/v/${version}"
+            else
+              echo "### Dry run for \`ccu-mcp@${version}\` — nothing uploaded"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -58,15 +58,44 @@ is first wired up.
 (`package.json` `name`). Publishing needs an authenticated npm session with
 publish rights on that package.
 
-1. `npm login` (or set `NPM_TOKEN` / `~/.npmrc` with an automation token).
-   Confirm with `npm whoami`.
-2. If the npm account has 2FA set to **auth-and-publish**, `npm publish`
-   prompts for a one-time code — pass it with `--otp=<code>` in
-   non-interactive shells. 2FA set to **auth-only** doesn't prompt on
-   publish.
+**The normal path is CI, not your laptop.** `.github/workflows/publish.yml`
+publishes through npm **trusted publishing** (OIDC): npm mints a short-lived
+credential from the OIDC claim GitHub issues for that workflow file, in this
+repo, in the `release` environment. There is no `NPM_TOKEN` secret and there
+must never be one.
 
-Symptom if missed: `npm publish` ends `ENEEDAUTH` (not logged in) or
-`EOTP` (OTP required). Neither mutates anything — fix auth and re-run.
+That also means **provenance is generated automatically** — no `--provenance`
+flag — which is what makes the published artifact verifiable.
+
+The package is set to **"Require two-factor authentication and disallow
+tokens"** on npmjs.com. Granular and automation tokens cannot publish it at
+all, regardless of their bypass-2FA setting. Do not add one back; it would not
+work, and it would reintroduce exactly the credential this removed.
+
+Three things are pinned together and must not drift apart — npmjs.com's trusted
+publisher config names all three, and a mismatch fails the publish closed:
+
+| | |
+| --- | --- |
+| Workflow filename | `publish.yml` |
+| Environment | `release` |
+| Repository | `claymore666/ccu-mcp` |
+
+The `release` environment requires review from `claymore666` before the publish
+job runs. That approval click is the deliberate replacement for the YubiKey
+touch a local publish demanded. Its branch policy allows only `v*` tags and
+`main`, so a run from `dev` is refused before any job starts.
+
+**Manual fallback.** Interactive publishing still works and is unaffected by
+the token restriction — only tokens are disallowed, not humans:
+
+1. `npm login` (interactive; the web flow). Confirm with `npm whoami`.
+2. `npm publish` prompts for a one-time code — pass `--otp=<code>` in
+   non-interactive shells.
+
+A manual publish produces **no provenance**, so prefer CI. Symptom if auth is
+missed: `ENEEDAUTH` (not logged in) or `EOTP` (OTP required). Neither mutates
+anything — fix auth and re-run.
 
 ### MCP registry — publisher auth
 
@@ -205,16 +234,36 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    configured; plain `git tag vX.Y.Z` is acceptable if not. Confirm with
    `git tag -v vX.Y.Z` when signed.
 
-8. **Publish — npm, then the MCP registry, then the GitHub Release.** All
-   from the tagged `main` checkout, so the artifacts match the tag:
+8. **Publish.** npm goes first — the MCP registry entry points consumers at the
+   npm package — but the order is now inverted from the old manual flow,
+   because npm publishing is triggered *by* the GitHub Release:
+
    ```sh
-   npm publish                       # add --otp=<code> if 2FA prompts
-   mcp-publisher publish             # reads server.json
    gh release create vX.Y.Z --title "vX.Y.Z" --notes "<step 4 notes>"
    ```
-   `prepublishOnly` re-runs `npm run lint && npm test` before the upload, so a
-   broken build can't ship. Order matters only in that npm must succeed first
-   — the registry entry points consumers at the npm package.
+
+   That fires `publish.yml`. It runs `verify` (version sync, tag-vs-
+   package.json agreement, lint, tests, `npm pack --dry-run`) with no human
+   present, then **waits for your approval** on the `release` environment
+   before publishing. Approve it in the run's UI.
+
+   The workflow refuses to publish when the tag and `package.json` disagree,
+   and fails the run if the uploaded version comes back without provenance
+   attestations. `prepublishOnly` re-runs `lint && test` on top of that.
+
+   Then the MCP registry, from the tagged `main` checkout:
+   ```sh
+   mcp-publisher publish             # reads server.json
+   ```
+
+   **Rehearsing it.** `workflow_dispatch` on `publish.yml` defaults to
+   `dry_run: true`, which exercises OIDC and packaging and uploads nothing.
+   Worth doing once after any change to the workflow, the environment, or the
+   npmjs trusted-publisher config.
+
+   **If CI publishing is broken mid-release**, fall back to `npm publish` from
+   the tagged checkout with `--otp=<code>`. It works, but produces no
+   provenance — note it in the release and re-check `signed_releases`.
 
 9. **Fast-forward `dev` to `main`** so the version bump and any release-branch
    edits land on `dev` too:
@@ -252,8 +301,12 @@ After publishing:
 
 | Symptom | Likely cause | Fix |
 | ------- | ------------ | --- |
-| `npm publish` ends `EOTP` | npm 2FA set to auth-and-publish | re-run with `--otp=<code>` |
-| `npm publish` ends `ENEEDAUTH` | not logged in / token expired | `npm login`, confirm `npm whoami`, re-run |
+| `npm publish` ends `EOTP` | manual fallback path; npm 2FA prompts | re-run with `--otp=<code>` |
+| `npm publish` ends `ENEEDAUTH` | manual fallback path; not logged in / session expired | `npm login`, confirm `npm whoami`, re-run |
+| `publish.yml` never starts | environment branch policy allows only `v*` tags and `main` | check the run was triggered from a tag, not `dev` |
+| `publish.yml` waits forever | `release` environment needs your approval | approve the deployment in the run's UI |
+| npm rejects the OIDC exchange | workflow filename, environment name or repo does not match the trusted-publisher config on npmjs.com | all three are pinned — reconcile them, don't add a token |
+| Published, but "Verify provenance landed" fails | published without attestations (e.g. a manual fallback publish) | the version is immutable; note it, and fix the path before the next release |
 | `npm publish` ends `403 cannot publish over previously published version` | version already on npm (npm is immutable) | bump to the next patch; never re-use a version |
 | `mcp-publisher publish` rejects the version | `server.json` version ≠ npm package version, or `mcpName` missing in `package.json` | align all three version spots (step 2); ensure `package.json` `mcpName` matches `server.json` `name` |
 | `mcp-publisher` 401 / auth error | publisher login expired | `mcp-publisher login github` again |


### PR DESCRIPTION
Closes #154. Publishing moves from a token on the maintainer's laptop to **npm trusted publishing** — npm mints a short-lived credential from the OIDC claim GitHub issues for this workflow file, in this repo, in the `release` environment.

**There is no `NPM_TOKEN` secret and there must never be one.** The package is now set to *"Require two-factor authentication and disallow tokens"* on npmjs.com, so a token could not publish even if it leaked.

Provenance comes automatically as a result — no `--provenance` flag. That closes `signed_releases`, the one real blocker for OpenSSF Best Practices **silver**. Confirmed `ccu-mcp@1.9.0` currently has `dist.attestations: none`, so v1.9.1 would be the first verifiable build.

## Shape

**`verify` runs first, deliberately outside the environment** — version sync, tag-vs-`package.json` agreement, lint, tests, `npm pack --dry-run`. Asking for an approval and *then* discovering the tests are red wastes the one thing the gate spends: attention.

**`publish` needs `verify`**, carries `id-token: write`, and sits behind the `release` environment. That approval click is the deliberate replacement for the YubiKey touch a local publish demanded.

## Failing closed

| Guard | Why |
|---|---|
| Tag must equal `package.json` version | npm versions are immutable. Shipping 1.9.0's contents under `v1.9.1` is not recoverable |
| Environment branch policy: `v*` tags and `main` only | A run from `dev` or a feature branch is refused by GitHub before any job starts |
| npm ≥ 11.5.1 asserted | Trusted publishing needs it; better to fail on the check than mid-release |
| Provenance re-read from the registry after publish | A publish that silently lands *without* attestations would otherwise look like success, and `signed_releases` would be a claim we can't back |
| `dry_run: true` by default on `workflow_dispatch` | Rehearse OIDC and packaging without uploading |

Three names are pinned together by the npmjs trusted-publisher config — workflow filename `publish.yml`, environment `release`, repository `claymore666/ccu-mcp`. A mismatch fails closed rather than falling back to a token.

## Runbook

CI is now the normal path, and the **GitHub Release is what triggers it**, so step 8's order is inverted: create the release, approve the deployment, then `mcp-publisher publish`.

Interactive `npm publish` survives as a fallback — only tokens are disallowed, not humans — but it produces **no provenance**, which the runbook now says explicitly. The auth section drops the `NPM_TOKEN` / automation-token instructions, which no longer work at all, and the troubleshooting table gains the new failure modes (environment never starts, waiting on approval, OIDC exchange rejected, published without attestations).

## Verification

- YAML parses; **shellcheck clean** across every `run:` block, run locally with the same settings actionlint uses in CI
- `npm run lint` clean, 469 tests pass
- Not yet exercised end to end — the first `workflow_dispatch` dry run should happen **after merge**, before the v1.9.1 release, since `publish.yml` must exist on a branch the environment policy allows