### PR TITLE
chore(release): v1.9.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Dry run — verify OIDC and the tarball without uploading"
+        description: "Dry run — check packaging and workflow wiring, upload nothing (does NOT exercise OIDC)"
         type: boolean
         default: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,84 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
+## v1.9.1 — 2026-08-01
+
+A supply-chain and verification release. Nothing here changes what the tools do;
+it changes what can be trusted about the artifact and what CI will let through.
+
+The three source fixes were all found by testing that did not exist before this
+version — property-based tests and a fuzzer, applied to the code that parses
+whatever the CCU sends back. None is exploitable, and the values involved are
+implausible on real hardware, so this is not an urgent upgrade.
+
+### Behavior changes (read before upgrading)
+
+Both are robustness fixes, and both are only observable if you were relying on
+the old failure:
+
+- **`parseValue` returns `null` instead of throwing.** Given an object with no
+  usable primitive conversion (`{"toString": false}`), `String()` throws
+  `TypeError: Cannot convert object to primitive value`. Because this parses
+  JSON-RPC payloads arriving over the network, a malformed response crashed the
+  tool call rather than degrading. Anything catching that throw will now see a
+  `null` value instead.
+- **`normalizeClientIp` returns `"unknown"` for a bare `::ffff:`.** It returned
+  an empty string, which matches no fail2ban `<HOST>` rule and collapses every
+  such client into a single rate-limit bucket. Not reachable from the network —
+  `remoteAddress` comes from the OS — but it contradicted the function's own
+  documented contract that it is total.
+
+### Fixed
+
+- **Keys that collide with `Object.prototype` no longer disappear.** Building an
+  object with `obj[key] = …`, where the key comes from outside, routes a
+  `"__proto__"` key through the prototype setter instead of creating an own
+  property — so the field silently vanished. Four sites: log redaction (a field
+  dropped out of the log line; redaction itself was never affected), the device
+  type cache in two places (a CCU parameter or channel index named `__proto__`
+  fell out of the cached schema), and the resolver, which additionally now
+  checks `Object.hasOwn` before indexing with a caller-supplied channel index,
+  paramset key or parameter name.
+- **A trailing-colon address resolves to channel 0.** `"ABC123:"` produced an
+  empty channel index in the resolver while the device type cache derived `"0"`
+  for the same address. The disagreement was harmless — an unresolved type makes
+  a write ineligible for auto-retry, so a one-shot `ACTION` trigger was never at
+  risk — but the two now agree.
+
+### Added
+
+- **npm releases are published with provenance.** Publishing moves from a token
+  on a maintainer's machine to [npm trusted publishing](https://docs.npmjs.com/trusted-publishers)
+  (OIDC) in a GitHub Actions workflow gated on a required approval. There is no
+  publish token any more: the package is set to *require two-factor
+  authentication and disallow tokens*, so a leaked token cannot publish it. This
+  is the first ccu-mcp release whose npm artifact can be cryptographically traced
+  back to the commit and workflow that built it.
+- **Property-based tests and coverage-guided fuzzing.** `fast-check` with a
+  pinned seed runs in the required build, and a nightly Jazzer.js workflow fuzzes
+  the parsing and escaping surface. The oracle for HM Script escaping is
+  differential — escape, then decode with an independent reader for ReGa's string
+  literal — so both under-escaping (injection) and over-escaping (corruption) are
+  caught by one property.
+- **A per-directory coverage ratchet.** Global thresholds hide local collapse:
+  deleting one test file takes `src/http` from 100% to 0% while the global
+  statement figure moves only 86.05% → 85.79%, staying clear of its floor — so
+  the build passes and nothing reports the loss. Floors are now enforced per
+  directory as well as globally.
+- **`SECURITY.md` and `CONTRIBUTING.md`**, including a published vulnerability
+  reporting process and the project's test policy. ccu-mcp now carries the
+  [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919) badge at
+  *passing*.
+
+### Changed
+
+- CI now lints its own workflows (actionlint + shellcheck), gates AI attribution
+  in commits and PR bodies, bounds every job's runtime, and blocks pull requests
+  that introduce vulnerable or non-permissively-licensed dependencies.
+- Tool and environment-variable documentation is guarded by tests: a tool added
+  to the server but missing from the README or the in-server `help` text now
+  fails the build rather than reaching a user.
+
 ## v1.9.0 — 2026-07-31
 
 A correctness release. A sustained review pass over the whole source tree found

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -256,10 +256,25 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    mcp-publisher publish             # reads server.json
    ```
 
-   **Rehearsing it.** `workflow_dispatch` on `publish.yml` defaults to
-   `dry_run: true`, which exercises OIDC and packaging and uploads nothing.
-   Worth doing once after any change to the workflow, the environment, or the
-   npmjs trusted-publisher config.
+   **Rehearsing it, and the limit of a rehearsal.** `workflow_dispatch` on
+   `publish.yml` defaults to `dry_run: true`. That checks the workflow wiring,
+   the environment gate and the tarball contents, and uploads nothing.
+
+   It does **not** exercise the OIDC credential exchange, and cannot:
+   `npm publish --dry-run` never issues the PUT, so no credential is ever
+   requested. A dry run against an already-published version stops earlier
+   still, at `You cannot publish over the previously published versions`,
+   which the registry answers without authentication. **The first real publish
+   is the only test of the OIDC path.**
+
+   That is acceptable because it fails closed. If the exchange fails,
+   `npm publish` errors on authentication, the job goes red and nothing
+   reaches the registry; if something published without provenance, the
+   "Verify provenance landed" step re-reads the registry and fails the run.
+
+   Rehearse after any change to the workflow, the environment, or the npmjs
+   trusted-publisher config — just don't read a green dry run as proof the
+   credentials work.
 
    **If CI publishing is broken mid-release**, fall back to `npm publish` from
    the tagged checkout with `--otp=<code>`. It works, but produces no

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.9.0",
+  "version": "1.9.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,10 +22,12 @@ export default defineConfig({
       // artifact rather than a real gap.
       //
       // These numbers alone are not enough, because an average hides local
-      // collapse — deleting the src/http tests takes that directory from 100%
-      // to 0% and moves the global statement figure UP, to 85.51%. The
-      // per-directory floors in .github/coverage-baseline.txt cover that gap;
-      // src/index.ts is exempted there for the reason above.
+      // collapse. Deleting the src/http tests takes that directory from 100%
+      // to 0%, and the global statement figure moves 86.05% -> 85.79% — a
+      // quarter of a point, still clear of the 85% floor, so `npm test` passes
+      // and nothing reports the loss. The per-directory floors in
+      // .github/coverage-baseline.txt cover that gap; src/index.ts is exempted
+      // there for the reason above.
       thresholds: {
         statements: 85,
         branches: 79,


### PR DESCRIPTION
Runbook steps 2–4 for v1.9.1. **This PR does not release anything** — no tag, no publish. It targets `dev`.

## Version bump

`npm version patch --no-git-tag-version`, which runs `scripts/sync-server-version.mjs` and keeps all three spots in step. `npm run check:versions` clean:

```
package.json       1.9.1
server.json root   1.9.1
server.json pkg[0] 1.9.1
```

## CHANGELOG

Written against the milestone, not from memory — all nine PRs (#142, #143, #144, #148, #149, #150, #151, #152, #157).

Two **behaviour changes** are called out for anyone relying on the old failure mode: `parseValue` now returns `null` where it threw `TypeError`, and `normalizeClientIp("::ffff:")` returns `"unknown"` instead of `""`.

The entry says plainly that nothing here changes what the tools do, that the three source fixes came from testing that didn't exist before, and that none is exploitable — so it isn't an urgent upgrade.

## Two corrections

**A factual error I introduced in #148 and then repeated.** `vitest.config.ts` claimed deleting the `src/http` tests "moves the global statement figure **UP**, to 85.51%". I re-measured before writing the CHANGELOG:

```
baseline   Statements : 86.05% (1605/1865)
without    Statements : 85.79% (1600/1865)   npm test exit=0
src/http   0%
```

It moves **down**, by a quarter of a point. The argument for a per-directory ratchet is unchanged and arguably clearer — a directory collapses to 0% while the global number stays clear of its 85% floor, so the build passes and nothing reports it — but the direction I stated was wrong. Fixed in `vitest.config.ts` and written correctly in the CHANGELOG.

**The dry-run overclaim.** `publish.yml`'s input description and the runbook both said a dry run verifies OIDC. It cannot: `npm publish --dry-run` never issues the PUT, so no credential is ever requested, and against an already-published version it stops earlier still at a version conflict the registry answers unauthenticated. The runbook now says the first real publish is the only test of that path, and why that's acceptable — it fails closed in both directions.

## Verification

`npm run check:versions`, `npm run lint`, `npm test` (469 passed) all clean.

## After merge

Steps 5–10 remain, and none happens without your explicit go: release PR `dev` → `main` titled `Release v1.9.1`, signed tag on `main`, GitHub Release (which triggers `publish.yml` and waits for **your** approval), then `mcp-publisher publish`.