### PR TITLE
ci: publish to the MCP registry from the same workflow

### DIFF
--- a/.github/actions/install-mcp-publisher/action.yml
+++ b/.github/actions/install-mcp-publisher/action.yml
@@ -1,0 +1,41 @@
+name: Install mcp-publisher
+description: >-
+  Download the pinned mcp-publisher binary and verify it against the checksum
+  published with that release.
+
+# Pinned, not `latest`. Every third-party action in this repo is pinned to a
+# commit SHA so a retargeted tag cannot inject code into CI; a `latest`
+# download URL is the same hazard wearing different clothes — the bytes can
+# change under a stable URL with no diff here. The checksum is the pin.
+#
+# Bumping: pick the new tag, take its line from
+# registry_<version>_checksums.txt in the release assets, and update both
+# inputs together.
+
+inputs:
+  version:
+    description: mcp-publisher release tag to install
+    required: false
+    default: "v1.8.0"
+  sha256:
+    description: Expected SHA-256 of mcp-publisher_linux_amd64.tar.gz
+    required: false
+    default: "1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf"
+
+runs:
+  using: composite
+  steps:
+    - name: Download and verify mcp-publisher
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        SHA256: ${{ inputs.sha256 }}
+      run: |
+        set -euo pipefail
+        url="https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.tar.gz"
+        curl -fsSL "$url" -o mcp-publisher.tar.gz
+        echo "${SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+        tar xzf mcp-publisher.tar.gz mcp-publisher
+        rm -f mcp-publisher.tar.gz
+        chmod +x mcp-publisher
+        ./mcp-publisher --version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,15 @@ jobs:
       - name: Show what would be published
         run: npm pack --dry-run
 
+      - name: Install mcp-publisher
+        uses: ./.github/actions/install-mcp-publisher
+
+      # `validate` needs no authentication, so a malformed server.json fails
+      # here rather than after someone has approved the deployment and npm has
+      # already taken an immutable version.
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
   publish:
     needs: verify
     runs-on: ubuntu-latest
@@ -196,6 +205,57 @@ jobs:
             console.log("provenance present:", JSON.stringify(v.dist.attestations));
           '
 
+      # The MCP registry entry points consumers at the npm package, so npm must
+      # land first. Same job, not a second one, so the release costs ONE
+      # approval rather than two — a gate people click twice per release is a
+      # gate they stop reading.
+      - name: Install mcp-publisher
+        if: steps.publish.outputs.published == 'true'
+        uses: ./.github/actions/install-mcp-publisher
+
+      # Same OIDC token that authenticated npm. The registry authorises the
+      # `io.github.claymore666/*` namespace from the repository owner in the
+      # claim, so there is no registry credential to store either.
+      - name: Authenticate with the MCP registry
+        if: steps.publish.outputs.published == 'true'
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to the MCP registry
+        if: steps.publish.outputs.published == 'true'
+        run: ./mcp-publisher publish
+
+      # A publish that reports success but does not become isLatest leaves
+      # consumers resolving the previous version — the failure mode the release
+      # checklist's fourth target exists to catch.
+      - name: Verify the registry shows this version as latest
+        if: steps.publish.outputs.published == 'true'
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          name=$(node -p "require('./server.json').name")
+          for attempt in 1 2 3 4 5; do
+            if curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=${name}" -o registry.json; then
+              if node -e '
+                const want = process.argv[1];
+                const j = require("./registry.json");
+                const hit = (j.servers || []).find((s) => {
+                  const v = s.version || (s.server && s.server.version);
+                  const meta = s._meta && s._meta["io.modelcontextprotocol.registry/official"];
+                  return v === want && meta && meta.isLatest;
+                });
+                process.exit(hit ? 0 : 1);
+              ' "$version"; then
+                echo "registry reports ${name}@${version} as isLatest"
+                exit 0
+              fi
+            fi
+            echo "attempt ${attempt}: not visible as latest yet, waiting"
+            sleep 15
+          done
+          echo "::error::${name}@${version} did not appear as isLatest on the MCP registry."
+          echo "::error::The registry read path is intermittently flaky — re-check by hand before assuming the publish failed."
+          exit 1
+
       - name: Summary
         if: always()
         env:
@@ -205,9 +265,10 @@ jobs:
           version=$(node -p "require('./package.json').version")
           {
             if [ "$PUBLISHED" = "true" ]; then
-              echo "### Published \`ccu-mcp@${version}\` with provenance"
+              echo "### Published \`ccu-mcp@${version}\`"
               echo
-              echo "https://www.npmjs.com/package/ccu-mcp/v/${version}"
+              echo "- npm, with provenance: https://www.npmjs.com/package/ccu-mcp/v/${version}"
+              echo "- MCP registry: https://registry.modelcontextprotocol.io/v0/servers?search=io.github.claymore666/ccu-mcp"
             else
               echo "### Dry run for \`ccu-mcp@${version}\` — nothing uploaded"
             fi

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -104,11 +104,19 @@ The registry listing is published from `server.json` with the
 is authorized via GitHub login (OIDC) — the GitHub account must own the
 `claymore666` namespace.
 
-1. `mcp-publisher login github` (interactive; opens a device-code flow).
+**Releases need no login at all.** `publish.yml` runs
+`mcp-publisher login github-oidc`, which exchanges the workflow's OIDC token —
+the same one npm uses — for registry authorisation. Nothing to store, nothing
+to expire.
+
+Only publishing **by hand** needs the interactive flow:
+
+1. `mcp-publisher login github` (opens a device-code flow).
 2. Authorization persists locally; re-login only when the token expires.
 
 The `io.github.<user>/*` namespace maps to the GitHub user, so no DNS TXT
-record is needed (that path is only for custom-domain namespaces).
+record is needed (that path is only for custom-domain namespaces). It is also
+why OIDC works: the repository owner in the claim *is* the namespace owner.
 
 ### Pre-flight validation (do this every release, costs nothing)
 
@@ -247,14 +255,24 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    present, then **waits for your approval** on the `release` environment
    before publishing. Approve it in the run's UI.
 
-   The workflow refuses to publish when the tag and `package.json` disagree,
-   and fails the run if the uploaded version comes back without provenance
-   attestations. `prepublishOnly` re-runs `lint && test` on top of that.
+   That one approval covers **both** registries. After npm, the same job
+   authenticates to the MCP registry with the same OIDC token
+   (`mcp-publisher login github-oidc`) and publishes `server.json`. There is no
+   registry credential to store either: the registry authorises the
+   `io.github.claymore666/*` namespace from the repository owner in the claim.
 
-   Then the MCP registry, from the tagged `main` checkout:
-   ```sh
-   mcp-publisher publish             # reads server.json
-   ```
+   Deliberately one job and one approval, not two. A gate clicked twice per
+   release is a gate that stops being read.
+
+   The workflow refuses to publish when the tag and `package.json` disagree,
+   fails the run if the npm upload comes back without provenance attestations,
+   and fails if the MCP registry does not report the new version as
+   `isLatest`. `prepublishOnly` re-runs `lint && test` on top of all that.
+   `server.json` is validated in the `verify` job, before anyone is asked to
+   approve anything.
+
+   **Nothing here needs `mcp-publisher login github` any more.** The
+   interactive device-code flow is only for publishing by hand.
 
    **Rehearsing it, and the limit of a rehearsal.** `workflow_dispatch` on
    `publish.yml` defaults to `dry_run: true`. That checks the workflow wiring,


### PR DESCRIPTION
Yes — the MCP registry supports the same OIDC mechanism npm does. `mcp-publisher login github-oidc` exchanges the workflow's OIDC token for registry authorisation, so **a release now needs no interactive login at all**.

The registry authorises `io.github.claymore666/*` from the repository owner in the claim, which is the same fact that makes the namespace work — so there's no registry credential to store, just as there's no npm token.

## One job, one approval

The registry steps live in the **same** `publish` job as npm, not a second one. A second job using the `release` environment would prompt for a second approval, and a gate clicked twice per release is a gate that stops being read. npm still goes first, since the registry entry points consumers at the npm package.

## Guards, in the order they can catch something

| Guard | Runs |
|---|---|
| `mcp-publisher validate` on `server.json` | In `verify`, **before** anyone is asked to approve — it needs no auth, so a malformed manifest fails while nothing has been spent |
| Registry publish gated on `steps.publish.outputs.published` | A dry run stays a dry run |
| Poll until the registry reports the version as `isLatest` | A publish that succeeds without becoming `isLatest` leaves consumers resolving the previous version — the fourth release-checklist target exists for exactly this |

The `isLatest` failure message says explicitly that the registry read path is intermittently flaky and to re-check by hand before concluding the publish failed.

## Supply chain

`mcp-publisher` is installed by a small composite action, **pinned to v1.8.0 and verified against the SHA-256** from that release's `registry_1.8.0_checksums.txt`:

```
1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf  mcp-publisher_linux_amd64.tar.gz
```

`latest` would be the same hazard as an unpinned action tag — bytes that can change under a stable URL with no diff in this repo. I downloaded and checksummed it by hand before committing; it verifies and reports `mcp-publisher 1.8.0`.

## Verification

- `server.json` validates against the live registry (`✅ server.json is valid`)
- Registry API shape confirmed live — the `isLatest` check reads `_meta["io.modelcontextprotocol.registry/official"].isLatest`, which currently reports 1.9.0 as latest
- YAML parses; **shellcheck clean with no exclusions** across all workflows *and* the composite action — the exclusion list is what let SC2016 through last time
- `npm run lint` clean, 469 tests pass

## Note

This takes effect from the **next** release. v1.9.1 is already tagged and on npm, so its registry entry still needs one manual `mcp-publisher publish`.