### PR TITLE
ci: publish the Smithery listing from the release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -256,6 +256,59 @@ jobs:
           echo "::error::The registry read path is intermittently flaky — re-check by hand before assuming the publish failed."
           exit 1
 
+      # Smithery last, and it is the odd one out. npm and the MCP registry both
+      # authenticate by OIDC, so neither needs a stored credential. Smithery has
+      # no OIDC path, and its restricted service tokens cap at a 24-hour TTL —
+      # too short to sit in a secret between releases. So this step needs a
+      # long-lived API key, which is the class of credential the other two
+      # deliberately removed.
+      #
+      # Mitigations, in order of how much they matter:
+      #   - The key is an ENVIRONMENT secret on `release`, not a repo secret.
+      #     Only a job that named this environment can read it, and reaching
+      #     this environment requires a human approval.
+      #   - It runs after both real registries. A Smithery failure cannot
+      #     abort an npm or MCP publish that already succeeded.
+      #   - The job does NOT take `contents: write`. Attaching the bundle to
+      #     the Release would be convenient, but granting write to the same job
+      #     that holds a publish credential is a worse trade than a download.
+      - name: Build the MCPB bundle
+        if: steps.publish.outputs.published == 'true'
+        run: npm run build:mcpb
+
+      - name: Publish to Smithery
+        if: steps.publish.outputs.published == 'true'
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SMITHERY_API_KEY:-}" ]; then
+            echo "::error::SMITHERY_API_KEY is not set on the 'release' environment."
+            echo "::error::npm and the MCP registry have already published; only the Smithery listing is missing."
+            exit 1
+          fi
+          version=$(node -p "require('./package.json').version")
+          npx -y @smithery/cli@4.11.1 mcp publish "ccu-mcp-${version}.mcpb" \
+            -n christian-kamien/ccu-mcp
+
+      # Smithery is a thin discovery listing for this project — a stdio bundle
+      # is not hosted, so `tools` stays null however the publish goes. Checking
+      # the qualified name came back is all this can honestly assert.
+      - name: Verify the Smithery listing responds
+        if: steps.publish.outputs.published == 'true'
+        run: |
+          set -euo pipefail
+          curl -fsS "https://registry.smithery.ai/servers/christian-kamien/ccu-mcp" -o smithery.json
+          node -e '
+            const j = require("./smithery.json");
+            if (j.qualifiedName !== "christian-kamien/ccu-mcp") {
+              console.error("::error::unexpected Smithery listing: " + JSON.stringify(j.qualifiedName));
+              process.exit(1);
+            }
+            console.log("Smithery listing OK:", j.qualifiedName,
+              "| connection:", (j.connections || [])[0] && j.connections[0].type);
+          '
+
       - name: Summary
         if: always()
         env:
@@ -269,6 +322,7 @@ jobs:
               echo
               echo "- npm, with provenance: https://www.npmjs.com/package/ccu-mcp/v/${version}"
               echo "- MCP registry: https://registry.modelcontextprotocol.io/v0/servers?search=io.github.claymore666/ccu-mcp"
+              echo "- Smithery: https://smithery.ai/servers/christian-kamien/ccu-mcp"
             else
               echo "### Dry run for \`ccu-mcp@${version}\` — nothing uploaded"
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ occu-issue-*.md
 findings/
 # libFuzzer default artifact location when -artifact_prefix is not passed
 crash-*
+
+# MCPB bundles built by scripts/build-mcpb.sh
+*.mcpb

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -274,6 +274,35 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    **Nothing here needs `mcp-publisher login github` any more.** The
    interactive device-code flow is only for publishing by hand.
 
+   Finally the same job builds the MCPB bundle (`npm run build:mcpb`) and
+   publishes the Smithery listing. All three registries, one approval.
+
+   **Smithery is the one place a stored credential remains.** npm and the MCP
+   registry authenticate by OIDC; Smithery has no OIDC path, and its restricted
+   service tokens cap at a 24-hour TTL — too short to survive between releases.
+   So `SMITHERY_API_KEY` is stored as an **environment** secret on `release`,
+   not a repo secret: only a job naming that environment can read it, and
+   reaching that environment needs a human approval. Rotate it there
+   (Settings → Environments → release → Secrets), never as a repo secret.
+
+   Smithery runs last on purpose — a failure there cannot abort an npm or MCP
+   publish that has already succeeded. If it does fail, everything else is
+   already live and the fix is a local rerun:
+   ```sh
+   npm run build && npm run build:mcpb
+   SMITHERY_API_KEY=… npx @smithery/cli mcp publish ccu-mcp-X.Y.Z.mcpb -n christian-kamien/ccu-mcp
+   ```
+
+   The bundle manifest is **generated** by `scripts/build-mcpb.sh` from
+   `smithery/manifest.template.json`, with the version injected from
+   `package.json`. The template carries no version deliberately — a committed
+   one would be a fourth place the release version lives, and three already
+   need a sync script and a CI gate to stay honest.
+
+   The `description` shown on Smithery is **not** settable from the bundle;
+   it is a web-dashboard field. Re-publishing appears to blank it, so check
+   the listing after a release.
+
    **Rehearsing it, and the limit of a rehearsal.** `workflow_dispatch` on
    `publish.yml` defaults to `dry_run: true`. That checks the workflow wiring,
    the environment gate and the tarball contents, and uploads nothing.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "check:versions": "node scripts/check-version-sync.mjs",
     "version": "node scripts/sync-server-version.mjs && git add server.json",
     "prepublishOnly": "npm run check:versions && npm run lint && npm test",
-    "fuzz": "bash scripts/fuzz.sh"
+    "fuzz": "bash scripts/fuzz.sh",
+    "build:mcpb": "bash scripts/build-mcpb.sh"
   },
   "engines": {
     "node": ">=24"

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Build the MCPB bundle published to Smithery.
+#
+# Used by `npm run build:mcpb` and by .github/workflows/publish.yml, so a
+# release and a local rebuild produce the same artifact.
+#
+# The manifest is GENERATED from smithery/manifest.template.json with the
+# version injected from package.json. The template deliberately has no
+# `version` field: a committed one would be a fourth place the release version
+# lives, and the first three already need a sync script and a CI gate to stay
+# honest. Nothing that cannot drift needs checking.
+#
+# Requires: a built dist/ (run `npm run build` first).
+# Output:   ccu-mcp-<version>.mcpb in the repo root.
+#
+# Deliberately NOT in the bundle: devDependencies (npm ci --omit=dev), the
+# source tree, tests, and .github. `files` in package.json ships dist/ only for
+# the same reason — none of it is needed to run the server.
+set -euo pipefail
+
+MCPB_VERSION="${MCPB_VERSION:-2.1.2}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ ! -d dist ]; then
+    echo "FAIL: dist/ is missing — run 'npm run build' first." >&2
+    exit 2
+fi
+if [ ! -f smithery/manifest.template.json ]; then
+    echo "FAIL: smithery/manifest.template.json is missing." >&2
+    exit 2
+fi
+
+version="$(node -p "require('./package.json').version")"
+out="$ROOT/ccu-mcp-${version}.mcpb"
+stage="$(mktemp -d)"
+trap 'rm -rf "$stage"' EXIT
+
+echo "Building MCPB bundle for ccu-mcp ${version}"
+
+# Mirror the layout the manifest's entry_point expects: server/dist/index.js.
+mkdir -p "$stage/server"
+cp -r dist "$stage/server/dist"
+cp package.json package-lock.json "$stage/server/"
+cp README.md LICENSE "$stage/"
+
+# Production dependencies only. `npm ci` needs the lockfile, which is why it is
+# copied above even though it is not published to npm.
+( cd "$stage/server" && npm ci --omit=dev --no-audit --no-fund >/dev/null )
+
+node -e '
+  const fs = require("fs");
+  const tpl = JSON.parse(fs.readFileSync("smithery/manifest.template.json", "utf8"));
+  const version = require("./package.json").version;
+  if (tpl.version) {
+    console.error("FAIL: the template must not carry a version — that is the drift this avoids.");
+    process.exit(2);
+  }
+  // Rebuild in a fixed key order so the generated manifest is byte-stable
+  // across runs: version goes straight after name, where a reader expects it.
+  const out = {};
+  for (const [k, v] of Object.entries(tpl)) {
+    out[k] = v;
+    if (k === "name") out.version = version;
+  }
+  fs.writeFileSync(process.argv[1] + "/manifest.json", JSON.stringify(out, null, 2) + "\n");
+  console.log("manifest.json generated at version " + version);
+' "$stage"
+
+npx -y "@anthropic-ai/mcpb@${MCPB_VERSION}" validate "$stage/manifest.json"
+
+# Smoke test the thing that will actually run. A bundle that packs cleanly but
+# cannot start is the failure a validated manifest does not catch.
+echo "Smoke test: MCP initialize handshake against the staged server"
+handshake='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"build-mcpb","version":"1"}}}'
+reply="$(printf '%s\n' "$handshake" \
+    | CCU_HOST=127.0.0.1 CCU_USER=smoke CCU_PASSWORD=smoke \
+      timeout 30 node "$stage/server/dist/index.js" --stdio 2>/dev/null | head -1 || true)"
+if ! printf '%s' "$reply" | grep -q '"serverInfo"'; then
+    echo "FAIL: staged server did not complete an MCP initialize handshake." >&2
+    echo "  reply: ${reply:-<empty>}" >&2
+    exit 1
+fi
+if ! printf '%s' "$reply" | grep -q "\"version\":\"${version}\""; then
+    echo "FAIL: staged server reported a different version than ${version}." >&2
+    echo "  reply: ${reply}" >&2
+    exit 1
+fi
+echo "  handshake OK, server reports ${version}"
+
+rm -f "$out"
+npx -y "@anthropic-ai/mcpb@${MCPB_VERSION}" pack "$stage" "$out"
+echo "Bundle: $out"

--- a/smithery/manifest.template.json
+++ b/smithery/manifest.template.json
@@ -1,0 +1,106 @@
+{
+  "manifest_version": "0.2",
+  "name": "ccu-mcp",
+  "display_name": "HomeMatic CCU",
+  "description": "Talk to your HomeMatic smart home from any MCP client.",
+  "long_description": "Connects to a HomeMatic CCU's built-in JSON-RPC API and exposes devices, rooms, programs and system variables as MCP tools. No addons, no XML-API, no cloud — a direct connection to the CCU on your local network. Works with debmatic, a CCU3, or OpenCCU (formerly RaspberryMatic).",
+  "author": {
+    "name": "claymore666",
+    "url": "https://github.com/claymore666"
+  },
+  "homepage": "https://github.com/claymore666/ccu-mcp",
+  "documentation": "https://github.com/claymore666/ccu-mcp#readme",
+  "support": "https://github.com/claymore666/ccu-mcp/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/claymore666/ccu-mcp"
+  },
+  "license": "MIT",
+  "keywords": [
+    "homematic",
+    "homematic-ip",
+    "debmatic",
+    "openccu",
+    "raspberrymatic",
+    "smart-home",
+    "home-automation",
+    "ccu",
+    "iot"
+  ],
+  "server": {
+    "type": "node",
+    "entry_point": "server/dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/server/dist/index.js",
+        "--stdio"
+      ],
+      "env": {
+        "CCU_HOST": "${user_config.ccu_host}",
+        "CCU_PORT": "${user_config.ccu_port}",
+        "CCU_HTTPS": "${user_config.ccu_https}",
+        "CCU_USER": "${user_config.ccu_user}",
+        "CCU_PASSWORD": "${user_config.ccu_password}",
+        "CCU_TLS_VERIFY": "${user_config.ccu_tls_verify}",
+        "CCU_TLS_FINGERPRINT": "${user_config.ccu_tls_fingerprint}"
+      }
+    }
+  },
+  "user_config": {
+    "ccu_host": {
+      "type": "string",
+      "title": "CCU hostname or IP",
+      "description": "Hostname or IP of the CCU on your local network, e.g. debmatic or 192.168.1.10",
+      "required": true,
+      "default": "homematic-ccu"
+    },
+    "ccu_port": {
+      "type": "string",
+      "title": "Port",
+      "description": "443 for HTTPS, 80 for plain HTTP",
+      "required": false,
+      "default": "443"
+    },
+    "ccu_https": {
+      "type": "string",
+      "title": "Use HTTPS",
+      "description": "true or false. Leave true unless the CCU only serves plain HTTP.",
+      "required": false,
+      "default": "true"
+    },
+    "ccu_user": {
+      "type": "string",
+      "title": "CCU username",
+      "description": "A CCU user. USER level is enough for reading; script tools need ADMIN.",
+      "required": true,
+      "default": "Admin"
+    },
+    "ccu_password": {
+      "type": "string",
+      "title": "CCU password",
+      "description": "Password for that CCU user. Stored by your MCP client, never sent anywhere but the CCU.",
+      "sensitive": true,
+      "required": true
+    },
+    "ccu_tls_verify": {
+      "type": "string",
+      "title": "Verify the CCU TLS certificate",
+      "description": "true or false. Most CCUs use a self-signed certificate, so this defaults to false; prefer pinning the fingerprint below instead of disabling verification.",
+      "required": false,
+      "default": "false"
+    },
+    "ccu_tls_fingerprint": {
+      "type": "string",
+      "title": "CCU certificate SHA-256 fingerprint (optional)",
+      "description": "Pin the CCU's certificate. The strongest protection available when the CCU is self-signed. Leave blank to skip pinning.",
+      "required": false,
+      "default": ""
+    }
+  },
+  "compatibility": {
+    "runtimes": {
+      "node": ">=24.0.0"
+    }
+  }
+}


### PR DESCRIPTION
Completes the release automation: **one approval now publishes npm, the MCP registry and Smithery.**

## Smithery is the odd one out, and this PR says so

npm and the MCP registry authenticate by OIDC — that's why neither needs a stored credential. Smithery has **no OIDC path**, and its restricted service tokens cap at a **24-hour TTL**, too short to sit in a secret between releases. So this reintroduces exactly the class of credential the other two removed.

Mitigations, in the order they matter:

- `SMITHERY_API_KEY` is an **environment secret on `release`**, not a repo secret. Only a job naming that environment can read it, and reaching that environment requires a human approval. Verified after setting it: the repo has **no repository-level secrets at all**
- Smithery runs **last**, so a failure there cannot abort an npm or MCP publish that already succeeded — and the error message says exactly that
- The job does **not** take `contents: write`. Attaching the bundle to the Release would be convenient, but granting write to the same job that holds a publish credential is a worse trade than a download

## `scripts/build-mcpb.sh`

Used by CI and `npm run build:mcpb`, so a release and a hand rebuild produce the same artifact. Mirrors the layout the manifest expects (`server/dist`), installs production dependencies only, and — before packing — runs a real **MCP `initialize` handshake** against the staged server, asserting the reported version matches:

```
  handshake OK, server reports 1.9.1
```

A bundle that packs cleanly but cannot start is precisely the failure a validated manifest doesn't catch.

## No fourth version spot

The manifest is **generated** from `smithery/manifest.template.json` with the version injected from `package.json`. The template carries no `version` deliberately — a committed one would be a fourth place the release version lives, and the first three already need a sync script *and* a CI gate to stay honest. The build fails if the template ever grows one.

## Verification

- Ran end to end: 2439 files, 3.8 MB — identical file count to the bundle published by hand for v1.9.1
- Manifest validates against `@anthropic-ai/mcpb@2.1.2`; `mcpb` and `@smithery/cli` both version-pinned
- **shellcheck clean with no exclusions** across all workflows, the composite action, and `build-mcpb.sh`
- `npm run lint` clean, 469 tests pass
- `*.mcpb` gitignored

## Runbook

Documents that Smithery is the one place a stored credential remains, where to rotate it (environment secret, never repo), the local rerun if it fails after the other two succeeded, and that the listing `description` is a dashboard-only field that re-publishing appears to blank.