### PR TITLE
ci: publish multi-arch container images to GHCR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,14 @@ updates:
     schedule:
       interval: weekly
 
+  # The Dockerfile's base image. Now that the image is published rather than
+  # built by whoever clones the repo, a stale `node:24-alpine` is something we
+  # ship to users rather than something they pick up on their next local build.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
   # npm deps: security + version updates against the committed lockfile.
   - package-ecosystem: npm
     directory: /

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,6 +107,11 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # The container jobs below gate on this rather than re-deriving "was this a
+    # dry run?" from the event. One source of truth for whether anything was
+    # actually released.
+    outputs:
+      published: ${{ steps.publish.outputs.published }}
     # Requires review from claymore666 before this job starts, and npm matches
     # this environment name against the OIDC claim.
     environment: release
@@ -326,4 +331,287 @@ jobs:
             else
               echo "### Dry run for \`ccu-mcp@${version}\` — nothing uploaded"
             fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # The container image, one job per architecture, each on a runner of that
+  # architecture. No QEMU: emulated arm64 turns a two-minute `npm ci` into
+  # something far worse and, as the arm64 work on docker-net-dhcp measured,
+  # emulation can fail in ways that have nothing to do with the code under
+  # test. GitHub hosts arm64 runners free for public repositories, so the
+  # honest option is also the cheap one.
+  #
+  # `needs: publish`, not `needs: verify`, for two reasons:
+  #   - Ordering. An image for a version npm rejected would be a release target
+  #     that exists nowhere else. Let npm decide first.
+  #   - Approvals. This job deliberately does NOT name the `release`
+  #     environment: it has no stored credential to protect (GHCR takes the
+  #     run's own GITHUB_TOKEN, minted per run and scoped by `permissions`
+  #     below), so a second gate would buy nothing and cost a second click.
+  #     A gate clicked twice per release is a gate that stops being read.
+  #     Waiting on `publish` still puts the human approval upstream of it.
+  #
+  # On a dry run the build and the smoke test still happen — only the push is
+  # skipped. That is the point: a Dockerfile that stopped building is worth
+  # discovering on a dispatch, not during a release.
+  docker:
+    needs: publish
+    strategy:
+      # One architecture failing should not hide the other's verdict.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Push to GHCR. Note what is NOT here: no `contents: write`, for the same
+      # reason the npm job refuses it.
+      packages: write
+      # Both required by attest-build-provenance: the OIDC token it signs with,
+      # and the attestations API it writes to.
+      id-token: write
+      attestations: write
+    env:
+      # github.repository is already lowercase here; GHCR rejects uppercase in
+      # a repository name, so a fork with a capitalised owner would need `tr`.
+      IMAGE: ghcr.io/${{ github.repository }}
+      PUSH: ${{ needs.publish.outputs.published == 'true' }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Built and tested BEFORE the push, so a broken image never reaches the
+      # registry — GHCR tags are mutable, but a bad `:latest` that someone
+      # pulled is not un-pulled by fixing it afterwards.
+      #
+      # `.dockerignore` excludes .git, so the build cannot read the repository:
+      # BUILD_COMMIT/BUILD_TAG are how the image learns what it was built from.
+      # Without them every published image reports null provenance from
+      # get_system_info. The smoke test below asserts they actually landed.
+      - name: Build this architecture and load it locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BUILD_COMMIT=${{ github.sha }}
+            BUILD_TAG=${{ github.ref_type == 'tag' && github.ref_name || '' }}
+          # buildx's own provenance attestation would wrap a single-platform
+          # build in an index and break push-by-digest below. GitHub's
+          # attestation (further down) is the one this release actually makes.
+          provenance: false
+          load: true
+          tags: ccu-mcp:smoke
+
+      # Runs the image on its own architecture — the arm64 variant is exercised
+      # on an arm64 runner, which is the whole reason for the matrix. The runner
+      # needs no toolchain of its own: node runs inside the image, grep does the
+      # asserting, so this works on any hosted image.
+      - name: Smoke-test the image on its own architecture
+        run: |
+          set -euo pipefail
+          # `docker run <image> --help` does NOT reach the server: node:24-alpine
+          # ships an ENTRYPOINT that turns a leading `-` argument into a `node`
+          # flag, so that prints Node's help and exits 0 — a smoke test that
+          # passes without ever starting this program. Name the command.
+          docker run --rm ccu-mcp:smoke node dist/index.js --help > help.txt
+          grep -q "ccu-mcp" help.txt
+
+          info=$(docker run --rm --entrypoint node ccu-mcp:smoke \
+            -p 'JSON.stringify(require("/app/dist/build-info.json"))')
+          echo "build-info: $info"
+
+          # The failure this catches: a build-arg rename or a .dockerignore
+          # change silently returns the image to reporting nothing about itself,
+          # and nothing else in the release would notice.
+          want="${GITHUB_SHA:0:7}"
+          if ! printf '%s' "$info" | grep -q "\"commit\":\"${want}\""; then
+            echo "::error::Image build-info does not report commit ${want}; BUILD_COMMIT did not reach gen-build-info.mjs."
+            exit 1
+          fi
+
+      # Pushed by digest, not by tag: two architectures pushing to the same tag
+      # would race, and the loser's manifest would be the one users pull. The
+      # merge job below assembles both digests into one manifest list, which is
+      # what makes `docker pull` resolve per-architecture. A cache hit on the
+      # build above — the layers are already here.
+      - name: Push this architecture by digest
+        id: build
+        if: env.PUSH == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BUILD_COMMIT=${{ github.sha }}
+            BUILD_TAG=${{ github.ref_type == 'tag' && github.ref_name || '' }}
+          provenance: false
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      # Attested per architecture, not once for the index: `docker pull`
+      # resolves a multi-arch tag down to the manifest for the puller's
+      # platform, so that digest is what `gh attestation verify` is handed. An
+      # index-only attestation verifies for nobody.
+      - name: Attest build provenance
+        if: env.PUSH == 'true'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Export the digest for the merge job
+        if: env.PUSH == 'true'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/digests"
+          # The filename IS the payload — empty file, digest as its name.
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - name: Upload the digest
+        if: env.PUSH == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digest-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Turns the two per-architecture digests into the manifest list users actually
+  # pull. Until this runs the digests are unreferenced by any tag — a failure
+  # here leaves the registry with no half-published tag, only garbage the
+  # registry collects.
+  docker-manifest:
+    needs: [publish, docker]
+    if: needs.publish.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+      # Empty on workflow_dispatch, "false" for a normal release.
+      PRERELEASE: ${{ github.event.release.prerelease }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create the manifest list
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('${GITHUB_WORKSPACE}/package.json').version")
+
+          # nullglob so an empty directory yields no refs rather than the
+          # literal "*", which would reach `imagetools create` as a bogus tag.
+          shopt -s nullglob
+          refs=()
+          for digest in *; do
+            refs+=("${IMAGE}@sha256:${digest}")
+          done
+          # Two architectures in, two digests out. Fewer means a matrix leg
+          # failed and fail-fast: false let the rest of the run continue —
+          # publishing a single-architecture image under the release tag is
+          # exactly the silent degradation to refuse.
+          if [ "${#refs[@]}" -ne 2 ]; then
+            echo "::error::Expected 2 per-architecture digests, found ${#refs[@]}. Refusing to tag a partial image."
+            exit 1
+          fi
+
+          tags=(-t "${IMAGE}:${version}")
+          # `latest` must not move backwards onto a pre-release. There are none
+          # today; this costs one line and removes the trap.
+          if [ "${PRERELEASE}" != "true" ]; then
+            tags+=(-t "${IMAGE}:latest")
+          else
+            echo "Pre-release — tagging ${version} only, leaving :latest where it is."
+          fi
+
+          docker buildx imagetools create "${tags[@]}" "${refs[@]}"
+
+      # The tag existing is not the claim being made. The claim is that pulling
+      # it on either architecture gets a working server, so read the published
+      # index back and run what came out of it.
+      - name: Verify the published image
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+
+          docker buildx imagetools inspect "${IMAGE}:${version}" --raw > index.json
+          node -e '
+            const index = require("./index.json");
+            const have = (index.manifests || [])
+              .map((m) => m.platform)
+              .filter((p) => p && p.os === "linux" && p.architecture !== "unknown")
+              .map((p) => p.architecture)
+              .sort();
+            const want = ["amd64", "arm64"];
+            if (JSON.stringify(have) !== JSON.stringify(want)) {
+              console.error("::error::Published index covers " + JSON.stringify(have) +
+                ", expected " + JSON.stringify(want));
+              process.exit(1);
+            }
+            console.log("index covers:", have.join(", "));
+          '
+
+          # Pulls the tag as any user would; on this runner that resolves to the
+          # amd64 manifest. The arm64 half was run on an arm64 runner before it
+          # was ever pushed.
+          docker run --rm "${IMAGE}:${version}" node dist/index.js --help > help.txt
+          grep -q "ccu-mcp" help.txt
+
+      # No `if: always()` here, unlike the npm summary above: this one has
+      # nothing to report but success, and printing a `docker pull` line for a
+      # tag that failed to publish would be worse than printing nothing.
+      - name: Summary
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          {
+            echo "### Container image"
+            echo
+            echo '```sh'
+            echo "docker pull ${IMAGE}:${version}"
+            echo '```'
+            echo
+            echo "- Package: https://github.com/${GITHUB_REPOSITORY}/pkgs/container/$(basename "${GITHUB_REPOSITORY}")"
+            echo "- Platforms: linux/amd64, linux/arm64 — built natively, attested per architecture"
+            echo "- Verify: \`gh attestation verify oci://${IMAGE}:${version} --repo ${GITHUB_REPOSITORY}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,35 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
-Project documentation and an automated style gate, from a sweep against the
-OpenSSF Best Practices **silver** criteria. No behaviour changes to any tool.
+A published container image, plus project documentation and an automated style
+gate from a sweep against the OpenSSF Best Practices **silver** criteria. No
+behaviour changes to any tool.
 
 ### Added
+
+- **Container images on GHCR.** `docker pull ghcr.io/claymore666/ccu-mcp`
+  replaces cloning the repository to build one, for `linux/amd64` and
+  `linux/arm64` — so the image runs on a Raspberry Pi next to the CCU.
+  Published by the release workflow from the same GitHub Release and the same
+  single approval as npm, the MCP registry and Smithery.
+
+  Each architecture is built **natively** on a runner of that architecture (no
+  QEMU), started and exercised before anything is pushed, and carries a
+  [build provenance attestation](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+  verifiable with:
+
+  ```sh
+  gh attestation verify oci://ghcr.io/claymore666/ccu-mcp:latest --repo claymore666/ccu-mcp
+  ```
+
+  `docker-compose.yml` now pulls the published image; swap in `build: .` to run
+  a checkout instead.
+- **Images know what they were built from.** `get_system_info`'s `build` block
+  reported nulls in any container, because `.dockerignore` excludes `.git` and
+  the build had no repository to read. `BUILD_COMMIT` / `BUILD_TAG` build args
+  now carry the commit and tag in, and the release asserts they arrived rather
+  than trusting that they did. A local `docker build` without them behaves as
+  before.
 
 - **Automated lint gate.** `npm run lint` now runs [oxlint](https://oxc.rs)
   over `src`, `test`, `scripts` and `fuzz` before `tsc`, with the ruleset and

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,31 @@ RUN npm ci
 COPY tsconfig.json ./
 COPY src/ ./src/
 COPY scripts/ ./scripts/
-# Full build (tsc + build-info stamp). No .git in the build context ⇒ the git
-# fields are null, but dist/build-info.json exists with builtAt, so
-# get_system_info's `build` block works in the image instead of silently
-# reporting nothing. Pass real values by building from a git checkout in CI.
+# Full build (tsc + build-info stamp). `.dockerignore` excludes .git, so the
+# build has no repository to read: without these two the git fields are null and
+# only builtAt survives. The publish workflow passes them, so a released image
+# reports the commit and tag it was built from; a local `docker build` leaves
+# them empty and gets the old null behaviour, which is honest for a build whose
+# source nobody can pin down.
+ARG BUILD_COMMIT=""
+ARG BUILD_TAG=""
+ENV BUILD_COMMIT=${BUILD_COMMIT} \
+    BUILD_TAG=${BUILD_TAG}
 RUN npm run build
 
 FROM node:24-alpine
+# `image.source` is not decoration: GHCR links a package to a repository by this
+# label, and that link is what carries the README, the licence and the "published
+# by" provenance on the package page. Without it the image floats unattached.
+ARG BUILD_COMMIT=""
+ARG BUILD_TAG=""
+LABEL org.opencontainers.image.title="ccu-mcp" \
+      org.opencontainers.image.description="MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API" \
+      org.opencontainers.image.source="https://github.com/claymore666/ccu-mcp" \
+      org.opencontainers.image.documentation="https://github.com/claymore666/ccu-mcp#readme" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_TAG}"
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev

--- a/README.md
+++ b/README.md
@@ -83,11 +83,26 @@ claude mcp add ccu-mcp -- npx ccu-mcp --stdio
 
 Use this if you want the server running independently — for example on a home server, accessible to multiple clients, or when your MCP client supports HTTP remotes.
 
-**1. Start the container:**
+**1. Start the container.** Images are published to GHCR for `linux/amd64` and
+`linux/arm64` (so a Raspberry Pi next to the CCU works), built natively on each
+architecture and attested — `gh attestation verify oci://ghcr.io/claymore666/ccu-mcp:latest --repo claymore666/ccu-mcp`
+proves the image came from this repository's release workflow.
+
+```bash
+docker pull ghcr.io/claymore666/ccu-mcp:latest
+```
+
+Every release also publishes its own `X.Y.Z` tag — pin that instead of `latest`
+if you'd rather upgrade deliberately. To build from source instead:
 
 ```bash
 git clone https://github.com/claymore666/ccu-mcp.git && cd ccu-mcp
-docker build -t ccu-mcp .
+docker build -t ghcr.io/claymore666/ccu-mcp .
+```
+
+Then run it:
+
+```bash
 docker run -d \
   --name ccu-mcp \
   -e CCU_HOST=your-ccu-hostname-or-ip \
@@ -95,7 +110,7 @@ docker run -d \
   -e MCP_ALLOWED_HOSTS=your-server-ip:3000 \
   -v ccu-data:/data \
   -p 3000:3000 \
-  ccu-mcp
+  ghcr.io/claymore666/ccu-mcp:latest
 ```
 
 > **`MCP_ALLOWED_HOSTS` is required for remote clients.** The server's

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   ccu-mcp:
-    build: .
+    # Published multi-arch (linux/amd64 + linux/arm64) by the release workflow.
+    # Swap for `build: .` to run this checkout instead of the released image.
+    image: ghcr.io/claymore666/ccu-mcp:latest
     restart: unless-stopped
     volumes:
       - ccu-data:/data

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -2,10 +2,11 @@
 
 How to publish a `vX.Y.Z` of `ccu-mcp`. The release is **manual** —
 there is no release workflow (CI only builds and tests). The publish
-targets are **npm** (`npx ccu-mcp`, the primary install path) and the
-**official MCP registry** (`registry.modelcontextprotocol.io`). The Docker
-image is build-your-own (`docker-compose` builds from source); nothing is
-pushed to a container registry, so there is no image-publish step.
+targets are **npm** (`npx ccu-mcp`, the primary install path), the
+**official MCP registry** (`registry.modelcontextprotocol.io`), **Smithery**,
+and the **container image** on GHCR (`ghcr.io/claymore666/ccu-mcp`,
+`linux/amd64` + `linux/arm64`). All four are published by `publish.yml` from
+the one GitHub Release, behind one approval.
 
 The goal: a release is a tag plus two `publish` commands, with version
 numbers that agree everywhere before any of it happens.
@@ -255,7 +256,7 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    present, then **waits for your approval** on the `release` environment
    before publishing. Approve it in the run's UI.
 
-   That one approval covers **both** registries. After npm, the same job
+   That one approval covers **every** publish target. After npm, the same job
    authenticates to the MCP registry with the same OIDC token
    (`mcp-publisher login github-oidc`) and publishes `server.json`. There is no
    registry credential to store either: the registry authorises the
@@ -275,7 +276,8 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    interactive device-code flow is only for publishing by hand.
 
    Finally the same job builds the MCPB bundle (`npm run build:mcpb`) and
-   publishes the Smithery listing. All three registries, one approval.
+   publishes the Smithery listing. Then the container jobs run. Four targets,
+   one approval.
 
    **Smithery is the one place a stored credential remains.** npm and the MCP
    registry authenticate by OIDC; Smithery has no OIDC path, and its restricted
@@ -302,6 +304,32 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    The `description` shown on Smithery is **not** settable from the bundle;
    it is a web-dashboard field. Re-publishing appears to blank it, so check
    the listing after a release.
+
+   **The container image** publishes from the same run, in the `docker` and
+   `docker-manifest` jobs, and needs nothing from you:
+
+   - One job per architecture on a runner of that architecture (`ubuntu-latest`
+     and `ubuntu-24.04-arm`). No QEMU — emulated builds are slow and can fail
+     for reasons that have nothing to do with the code.
+   - Each architecture is **built, loaded and run** (`--help`, plus an assert
+     that `build-info.json` carries the release commit) *before* it is pushed.
+     A broken image never reaches the registry.
+   - Both are pushed **by digest**; `docker-manifest` then assembles them into
+     the `X.Y.Z` and `latest` tags, refusing to tag at all if fewer than two
+     digests arrived. `latest` is skipped for a GitHub pre-release.
+   - Provenance is attested **per architecture** (`actions/attest-build-provenance`,
+     pushed to the registry as a referrer), because `docker pull` resolves a
+     tag to one platform's manifest and that is the digest a verifier sees.
+
+   These jobs deliberately do **not** name the `release` environment. There is
+   no stored credential to protect — GHCR takes the run's own `GITHUB_TOKEN`,
+   scoped by `permissions: packages: write` — and gating on `needs: publish`
+   already puts your approval upstream of the push. One approval per release.
+
+   No GHCR credential, prerequisite or setting exists to maintain. The package
+   links itself to this repository through the `org.opencontainers.image.source`
+   label in the Dockerfile; if that label is ever dropped, the package page
+   loses its README, licence and repository link.
 
    **Rehearsing it, and the limit of a rehearsal.** `workflow_dispatch` on
    `publish.yml` defaults to `dry_run: true`. That checks the workflow wiring,
@@ -355,6 +383,13 @@ After publishing:
   machine pulls and runs it.
 - The MCP registry shows the new version:
   `curl -s 'https://registry.modelcontextprotocol.io/v0/servers?search=io.github.claymore666/ccu-mcp' | jq '.servers[].version'`.
+- The container image covers both architectures and verifies:
+  ```sh
+  docker buildx imagetools inspect ghcr.io/claymore666/ccu-mcp:X.Y.Z
+  gh attestation verify oci://ghcr.io/claymore666/ccu-mcp:X.Y.Z --repo claymore666/ccu-mcp
+  ```
+  The workflow asserts both of these itself; run them by hand only when
+  something looks wrong.
 - `gh release view vX.Y.Z` shows the notes body.
 - The milestone is closed:
   `gh issue list --milestone vX.Y.Z --state open` — should be empty.
@@ -373,6 +408,9 @@ After publishing:
 | `mcp-publisher publish` rejects the version | `server.json` version ≠ npm package version, or `mcpName` missing in `package.json` | align all three version spots (step 2); ensure `package.json` `mcpName` matches `server.json` `name` |
 | `mcp-publisher` 401 / auth error | publisher login expired | `mcp-publisher login github` again |
 | GitHub Release exists but npm/registry don't | published the release before the `publish` commands | run `npm publish` + `mcp-publisher publish` from the tagged checkout |
+| `docker-manifest` fails with "Expected 2 per-architecture digests" | one matrix leg failed; `fail-fast: false` let the other finish | fix the failing architecture and re-run the job — no tag was written, so nothing is half-published |
+| Image smoke test fails on "does not report commit" | `BUILD_COMMIT` stopped reaching `gen-build-info.mjs` (build-arg renamed, `ARG` dropped from the builder stage) | reconcile `Dockerfile` and the `build-args:` block; the image would otherwise ship with null provenance |
+| GHCR package page has no README or licence | `org.opencontainers.image.source` label missing or not matching the repo URL | restore the label in the Dockerfile's final stage and re-run the release jobs |
 
 ## Backports between `dev` and `main`
 
@@ -389,10 +427,12 @@ When a release-blocking hotfix must land on `main` without going through
 These are in the docker-net-dhcp runbook but don't apply here, noted so their
 absence reads as a decision, not an oversight:
 
-- **Container registry publish (GHCR / Docker Hub), image signing (cosign),
-  SBOM, provenance** — no image is published; the Dockerfile is built locally
-  by `docker-compose`. If a published image is ever added, the GHCR-linking
-  and signing prerequisites from that runbook become relevant.
+- **Docker Hub** — the image publishes to GHCR only. A second registry is a
+  second place a tag can go stale, for an audience GHCR already reaches.
+- **cosign signing, SBOM** — GitHub's build provenance attestation covers what
+  cosign would here (who built it, from which workflow and commit, verifiable
+  with `gh attestation verify`) without a key to hold or rotate. An SBOM is
+  worth adding when something consumes it; nothing does yet.
 - **Versioned docs site (mkdocs / GitHub Pages)** — docs are the README plus
   this `docs/` folder; there's no published site to reconcile.
 - **rc dry-run via the release workflow / coverage ratchet** — there's no

--- a/scripts/gen-build-info.mjs
+++ b/scripts/gen-build-info.mjs
@@ -4,6 +4,14 @@
 // (get_system_info exposes it). Best-effort: outside a git checkout (e.g. an
 // npm tarball or `git archive`), every git field is null — the build still
 // succeeds. Runs after `tsc` (see package.json "build"), so dist/ exists.
+//
+// The container image is the case that made the null path worth fixing rather
+// than merely tolerating: `.dockerignore` excludes `.git`, so a build inside
+// the image has no repository to interrogate and every published image would
+// report nothing about its own provenance. BUILD_COMMIT / BUILD_TAG let the
+// caller supply what git would have answered. Git still wins whenever it is
+// available — the environment is a fallback, never an override, so nothing can
+// stamp a checkout with a commit it was not built from.
 import { execFileSync } from "node:child_process";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -17,21 +25,48 @@ const git = (args) => {
   }
 };
 
+// An unset variable and one set to "" mean the same thing here: nothing was
+// supplied. Docker passes an undeclared --build-arg through as an empty string,
+// so treating "" as a value would stamp empty strings where null belongs.
+const env = (name) => {
+  const value = process.env[name];
+  return value && value.trim() !== "" ? value.trim() : null;
+};
+
 const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]);
 // Tracked modifications only (--untracked-files=no), matching `git describe --dirty`
 // semantics: stray untracked files (drafts, build output) don't change which
 // committed source the build came from, so they must not flip the dirty flag.
 const status = git(["status", "--porcelain", "--untracked-files=no"]);
 
+// All-or-nothing, not field-by-field: the environment is consulted only when
+// git answered nothing at all. Falling back per field would let a stray
+// BUILD_TAG in someone's shell label a real checkout with a tag it is not on,
+// producing a record half-read from the repository and half-asserted by
+// whoever set the variable.
+const gitCommit = git(["rev-parse", "--short", "HEAD"]);
+const noRepository = gitCommit === null;
+
+// CI hands over the full 40-character sha because that is what the OCI
+// `revision` label wants; `git rev-parse --short` answers 7. Truncate so the
+// field has one shape whichever path produced it — a consumer comparing
+// build-info against a release should not have to know how the image was built.
+const envCommit = noRepository ? env("BUILD_COMMIT") : null;
+const commit = gitCommit ?? (envCommit === null ? null : envCommit.slice(0, 7));
+// exact-match returns the tag only when HEAD is *on* a tag, else null
+const tag = noRepository ? env("BUILD_TAG") : git(["describe", "--tags", "--exact-match"]);
+
 const buildInfo = {
   // branch is "HEAD" when detached (e.g. a CI checkout of a tag) — report null
   branch: branch === "HEAD" ? null : branch,
-  commit: git(["rev-parse", "--short", "HEAD"]),
-  // exact-match returns the tag only when HEAD is *on* a tag, else null
-  tag: git(["describe", "--tags", "--exact-match"]),
+  commit,
+  tag,
   // human-readable: <tag>-<n>-g<sha>[-dirty], or just <sha> with no tags
-  describe: git(["describe", "--tags", "--dirty", "--always"]),
-  // null when not a git checkout; true if tracked files have uncommitted changes
+  describe: git(["describe", "--tags", "--dirty", "--always"]) ?? tag ?? commit,
+  // null when not a git checkout; true if tracked files have uncommitted changes.
+  // Stays null on the BUILD_COMMIT path on purpose: the caller asserting a
+  // commit says nothing about whether the tree it built was clean, and
+  // answering `false` there would be a claim this script cannot support.
   dirty: status === null ? null : status.length > 0,
   builtAt: new Date().toISOString(),
 };


### PR DESCRIPTION
Publishes `ghcr.io/claymore666/ccu-mcp` for `linux/amd64` and `linux/arm64` from the existing release flow.

Today the Docker path is build-your-own. The only prebuilt image of this server on any registry belongs to a fork, published under the pre-rename name and pinned at v1.8.1 — so the obvious thing to pull is one this repository does not control.

## What runs

Two jobs in `publish.yml`, on the same GitHub Release and the same single approval as npm, the MCP registry and Smithery:

- **`docker`** — one job per architecture on a runner of that architecture (`ubuntu-latest`, `ubuntu-24.04-arm`, both free for public repos). No QEMU: emulated builds are slow and can fail for reasons unrelated to the code.
- Each architecture is **built, loaded and run before anything is pushed** — `--help`, plus an assert that `build-info.json` carries the release commit. A broken image never reaches the registry.
- Both are pushed **by digest** and attested **per architecture** (`actions/attest-build-provenance`, pushed as a registry referrer). Per-architecture because `docker pull` resolves a multi-arch tag to one platform's manifest, and that digest is what `gh attestation verify` is handed; an index-only attestation verifies for nobody.
- **`docker-manifest`** assembles the digests into the `X.Y.Z` and `latest` tags, refuses to tag at all if fewer than two digests arrived, then reads the published index back and runs what came out of it. `latest` is skipped for a pre-release.

Neither job names the `release` environment. There is no stored credential to protect — GHCR takes the run's own `GITHUB_TOKEN`, scoped by `permissions: packages: write` — and `needs: publish` already puts the approval upstream of the push, along with npm's verdict. A gate clicked twice per release is a gate that stops being read.

On a dry run the build and the smoke test still happen; only the push is skipped.

## Provenance inside the image

`.dockerignore` excludes `.git`, so `gen-build-info.mjs` had no repository to read and every container reported nulls from `get_system_info` — the Dockerfile comment already flagged this. `BUILD_COMMIT` / `BUILD_TAG` build args now carry the values in.

Git still wins whenever it is available, and the fallback is **all-or-nothing**: a stray `BUILD_TAG` in a shell cannot label a real checkout with a tag it is not on. A local `docker build` without the args behaves exactly as before.

## Also

- `docker-compose.yml` pulls the published image (`build: .` documented as the swap).
- README leads with `docker pull`, including the `gh attestation verify` line.
- Dependabot now watches the Dockerfile base image — a stale `node:24-alpine` is something we ship now, not something the user picks up on their next local build.
- Runbook: the image is documented as the fourth publish target, with three new troubleshooting rows; the "not applicable" section now records why Docker Hub, cosign and SBOM are still out.

## Verification

- `npm run lint`, `npm test` (469 passed), `actionlint` + its self-test, attribution gate — all green locally.
- Built the image locally with the build args and ran the exact smoke-test commands the workflow uses: `build-info` reports the injected commit, and all seven OCI labels land.
- That local run caught a real bug in a first draft: `docker run <image> --help` never reaches the server, because `node:24-alpine`'s entrypoint turns a leading `-` into a Node flag — it printed Node's help and exited 0. The smoke test now names the command, and the reason is a comment.
- The arm64 leg cannot be exercised from here; its first real run is the first release (or a `workflow_dispatch` dry run from `main`, which builds and smoke-tests both architectures without pushing).

The first release that runs this is still an explicit decision — nothing here publishes anything on its own.