### PR TITLE
ci: carry the fuzzing corpus between nightly runs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,12 +17,26 @@ name: Fuzz
 # workflow that mails a failure every time it finds something earns a filter
 # rule within a week, and then the mechanism is dead.
 #
-# Corpus: the committed seeds under fuzz/corpus/ only — nothing is persisted
-# between runs. That is a deliberate trade. These targets are small pure
-# functions, so the marginal value of a grown corpus is low, while a cache is
-# one more moving part that fails silently. The seeds carry the inputs that
-# matter: byte-level mutation will never invent the literal key "__proto__",
-# and without that seed the parse target reports green while testing nothing.
+# Corpus: the committed seeds under fuzz/corpus/, PLUS whatever previous runs
+# discovered, carried in an actions/cache entry (issue #155). The seeds are
+# still the load-bearing half — byte-level mutation will never invent the
+# literal key "__proto__", and without that seed the parse target reports green
+# while testing nothing — so scripts/fuzz.sh still treats a missing seed corpus
+# as a hard failure, cache or no cache.
+#
+# Two properties keep the cache from being the "moving part that fails
+# silently" this was originally rejected for:
+#
+#   - The cache is passed as a SEPARATE directory, listed FIRST, which is where
+#     libFuzzer writes new units. fuzz/corpus/ is never written to, so a bad
+#     cache cannot corrupt the reviewed seeds — worst case it is empty and the
+#     run degrades to exactly the old behaviour.
+#   - Every PASS line reports how many inputs were carried forward. A cache
+#     that silently stopped round-tripping shows up as that number sitting at
+#     zero run after run, in the step summary, instead of nowhere.
+#
+# Restoring is best-effort by design: `cache` is not `cache/restore` with a
+# fail-on-miss, because a cold cache must never turn a fuzzing night red.
 #
 # Scheduled workflows only run from the DEFAULT branch (`dev`), so this file
 # must be on `dev` to fire at all.
@@ -77,10 +91,35 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Keyed on the run id so it never hits, which is the point: the post-job
+      # save then always writes a fresh entry, and `restore-keys` pulls the most
+      # recent previous one in. A stable key would restore the same first-ever
+      # corpus forever and quietly stop accumulating — the exact silent failure
+      # this workflow's header warns about.
+      #
+      # Scoped to the default branch: scheduled runs are on `dev`, and GitHub
+      # gives every branch read access to the default branch's caches, so a
+      # dispatch from a work branch inherits the corpus without being able to
+      # poison it for `dev`.
+      #
+      # restore/save rather than the combined `cache` action so the save can be
+      # `if: always()`. The run that finds something is the run whose corpus is
+      # most worth keeping, and that is also the run most likely to end red.
+      - name: Restore the accumulated corpus
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .fuzz-corpus
+          key: fuzz-corpus-v1-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-v1-
+
       - name: Fuzz
         id: fuzz
         env:
           FUZZ_SECONDS: ${{ github.event.inputs.seconds || '300' }}
+          # Absolute: fuzz.sh resolves the seed corpus relative to its own
+          # location, and a relative value here would land somewhere else.
+          FUZZ_CORPUS_DIR: ${{ github.workspace }}/.fuzz-corpus
         run: |
           set -uo pipefail
 
@@ -106,6 +145,13 @@ jobs:
             grep -E "^(===|PASS|FOUND|FAIL)" fuzz.log || true
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Save the accumulated corpus
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .fuzz-corpus
+          key: fuzz-corpus-v1-${{ github.run_id }}
 
       # Reproducers are the whole point of a finding — without the input the
       # report is unactionable.

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ occu-issue-*.md
 findings/
 # libFuzzer default artifact location when -artifact_prefix is not passed
 crash-*
+# Corpus accumulated across runs (FUZZ_CORPUS_DIR). CI keeps this in an
+# actions/cache entry; anything worth keeping permanently gets promoted into
+# fuzz/corpus/ by hand, where it is reviewed like any other committed input.
+.fuzz-corpus/
 
 # MCPB bundles built by scripts/build-mcpb.sh
 *.mcpb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,22 @@ behaviour changes to any tool.
   Certificate of Origin 1.1. No CLA, no copyright assignment.
 - Named coding standard (Google TypeScript Style Guide, two documented
   deviations) in `CONTRIBUTING.md`.
+- **Fuzzing corpus now accumulates between nightly runs** (#155), in an
+  `actions/cache` entry rather than in the repository. Each run starts from the
+  committed seeds *plus* everything previous runs discovered, so coverage
+  compounds instead of resetting every night. Every `PASS` line reports how many
+  inputs were carried forward, which is what makes a cache that quietly stopped
+  round-tripping visible instead of silent.
 
 ### Fixed
 
+- **`npm run fuzz` no longer writes into the committed seed corpus.** Given a
+  single corpus directory libFuzzer treats it as writable, so every local run
+  dropped unreviewed mutation output into `fuzz/corpus/` — inputs that then
+  looked like reviewed seeds in the next `git status`. New units now land in
+  `.fuzz-corpus/` (gitignored); promote one into `fuzz/corpus/` by hand when it
+  is worth keeping. The seeds remain load-bearing and a missing seed corpus is
+  still a hard failure, not a clean run.
 - Two unit tests asserted nothing at all. `RateLimiter` "allows burst up to max"
   now bounds the elapsed time, and the `ResourcePoller` start/stop test now
   asserts the pending-timer count — previously both passed even if the

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -226,6 +226,8 @@ diverges from the code. Countermeasures:
   directory's tests cannot hide inside a healthy average.
 - Nightly fuzzing runs against a seeded corpus; the seeds are load-bearing, and
   the runner treats a missing corpus as a hard failure rather than a clean run.
+  Inputs discovered by a run accumulate in a cache alongside those seeds, never
+  inside them, so what each night starts from is still a reviewed set.
 
 Where the argument is weakest: it is written and reviewed by one person, and no
 external security review has been performed. Independent review is welcome —

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -4,8 +4,18 @@
 # Used by `npm run fuzz` and by .github/workflows/fuzz.yml, so both run exactly
 # the same thing. Requires a built dist/ — the targets import from it.
 #
-# FUZZ_SECONDS  per-target time budget (default 60)
-# FINDINGS_DIR  where libFuzzer writes crashing inputs (default ./findings)
+# FUZZ_SECONDS     per-target time budget (default 60)
+# FINDINGS_DIR     where libFuzzer writes crashing inputs (default ./findings)
+# FUZZ_CORPUS_DIR  writable corpus root that outlives a run (default
+#                  ./.fuzz-corpus, gitignored; CI points it at a cache entry).
+#                  <dir>/<target> is passed to libFuzzer FIRST, which is what
+#                  makes new units land there instead of in fuzz/corpus/.
+#
+# Given one corpus directory libFuzzer writes new units into it, so before this
+# split a plain `npm run fuzz` silently added unreviewed mutation output to the
+# committed seeds — they are a reviewed, load-bearing input set, not a scratch
+# directory. Promote something out of .fuzz-corpus into fuzz/corpus/ by hand
+# when it is worth keeping forever.
 #
 # Exit codes, kept distinct on purpose:
 #   0  every target ran to its time limit and found nothing
@@ -20,6 +30,7 @@ set -uo pipefail
 FUZZ_SECONDS="${FUZZ_SECONDS:-60}"
 FINDINGS_DIR="${FINDINGS_DIR:-findings}"
 TARGETS_DIR="$(dirname "$0")/../fuzz"
+FUZZ_CORPUS_DIR="${FUZZ_CORPUS_DIR:-$(dirname "$0")/../.fuzz-corpus}"
 
 if [ ! -d "$(dirname "$0")/../dist" ]; then
     echo "FAIL: dist/ is missing — run 'npm run build' first." >&2
@@ -45,15 +56,24 @@ for target in "$TARGETS_DIR"/*.fuzz.mjs; do
         continue
     fi
 
-    echo "=== $name (${FUZZ_SECONDS}s, $(find "$corpus" -type f | wc -l) seeds) ==="
+    # Order matters: libFuzzer writes newly-discovered units into the FIRST
+    # corpus directory it is given and treats the rest as read-only inputs.
+    # Growable first, committed seeds second.
+    grown="$FUZZ_CORPUS_DIR/$name"
+    mkdir -p "$grown" || { echo "FAIL: cannot create $grown" >&2; broke=1; continue; }
+
+    echo "=== $name (${FUZZ_SECONDS}s, $(find "$corpus" -type f | wc -l) seeds + $(find "$grown" -type f | wc -l) carried over) ==="
     rc=0
-    npx jazzer "$target" "$corpus" --sync -- \
+    npx jazzer "$target" "$grown" "$corpus" --sync -- \
         -max_total_time="$FUZZ_SECONDS" \
         -artifact_prefix="$FINDINGS_DIR/$name-" \
         -print_final_stats=1 || rc=$?
 
     if [ "$rc" -eq 0 ]; then
-        echo "PASS  $name"
+        # Printed because the workflow summary greps PASS lines: a corpus that
+        # never grows across runs is the tell that CI's cache is not actually
+        # round-tripping, which would otherwise fail silently.
+        echo "PASS  $name ($(find "$grown" -type f | wc -l) carried forward)"
         continue
     fi
 


### PR DESCRIPTION
Closes #155.

Each night started from the committed seeds and threw everything it found away. Coverage never compounded — the same 20 minutes re-derived the same shallow inputs, and anything deeper a run stumbled into was gone by morning.

The corpus now lives in an `actions/cache` entry, restored before fuzzing and saved after.

## Why this isn't the moving part that was rejected the first time

The workflow header gave two reasons to skip persistence: low marginal value for small pure functions, and "a cache is one more moving part that fails silently". The second is the real one, and it's addressed directly:

- **The cache is a separate directory, passed to libFuzzer first** — which is where it writes new units. `fuzz/corpus/` is never written to. A bad or empty cache degrades the run to exactly the old behaviour instead of corrupting the reviewed seeds.
- **Every `PASS` line reports how many inputs were carried forward.** A cache that stopped round-tripping shows up as a number stuck at zero in the step summary, run after run, instead of showing up nowhere.

`restore` + `save` rather than the combined action, so the save can be `if: always()`: the run that finds something is both the one whose corpus is most worth keeping and the one most likely to end red. The key carries `github.run_id` so it never hits and the post step always writes a fresh entry; `restore-keys` pulls the most recent previous one. A stable key would restore the same first-ever corpus forever and quietly stop accumulating — the same silent failure in a different place.

## A pre-existing wart this fixes

libFuzzer treats a lone corpus directory as writable, so `npm run fuzz` had always been depositing unreviewed mutation output into `fuzz/corpus/`, where it sat looking exactly like a reviewed seed. I only noticed because `git status` showed five new files after a plain run during this work.

New units now land in `.fuzz-corpus/` (gitignored) and are promoted into `fuzz/corpus/` by hand. The seeds stay load-bearing, and a missing seed corpus is still a hard failure rather than a clean run — `scripts/fuzz.sh` still exits 2.

## Verification

- Two consecutive local runs carry **15 → 26** and **2 → 7** inputs forward, with seed counts unchanged at 141 / 77 / 18 across both. Working tree clean afterwards.
- Hiding a seed directory still exits **2** (`FAIL: bearer-token has no seed corpus`), so the mutation check on the hard-failure path still bites.
- `npm run lint`, `shellcheck scripts/fuzz.sh`, `actionlint` all clean.

The nightly run on `dev` is the first one that exercises the cache end to end; the first night writes a cold entry and the second should report a non-zero carry-forward.