### PR TITLE
ci: move CodeQL from default setup to a workflow file

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,88 @@
+name: CodeQL
+
+# CodeQL ran as GitHub's DEFAULT SETUP until this file existed: configured in
+# repository settings, invisible to anyone reading the repository, and
+# unreviewable in a PR. It worked — it is what caught the js/polynomial-redos in
+# extractBearerToken — but a scanner whose configuration only one person can see
+# is a scanner nobody can check. A file-based survey of this repo missed it
+# entirely and briefly reported "no CodeQL" (issue #156).
+#
+# NON-HERMETIC, like audit.yml and fuzz.yml, and for the same reason: the query
+# packs are downloaded at run time and improve without a diff. A finding can
+# appear on an unchanged tree. Never make this a required status check — that is
+# what build-and-test is for.
+#
+# DEFAULT SETUP AND THIS FILE ARE MUTUALLY EXCLUSIVE. With default setup still
+# enabled the SARIF upload here is rejected outright, so it was disabled in
+# repository settings in the same change that added this file. Re-enabling it
+# would silently break this workflow; if this file is ever deleted, re-enable
+# default setup in Settings → Code security, or the repository ends up with no
+# scanning at all — which looks identical to a clean report.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    # Weekly, matching what default setup ran. Off the hour: GitHub's cron
+    # queue is heavily oversubscribed at :00. Scheduled workflows only run from
+    # the default branch (`dev`).
+    - cron: "23 4 * * 1"
+
+# Least privilege at the top; the analyze job adds only what it needs.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Upload the SARIF results. This is the one privilege the job exists for.
+      security-events: write
+      # Read workflow run metadata — required by the CodeQL action itself.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # javascript-typescript covers what default setup listed as three
+          # separate languages (javascript, typescript, javascript-typescript);
+          # they are the same extractor.
+          - language: javascript-typescript
+          # Analysing the workflows themselves is not decoration here: this
+          # repository's release path, publish credentials and gates all live in
+          # .github/workflows, and that is where an injection would matter most.
+          - language: actions
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          # No compiled languages here, so there is nothing to build: analysing
+          # the checkout directly is both correct and faster.
+          build-mode: none
+          # Default setup ran the `default` suite. `security-extended` adds the
+          # lower-precision security queries — more findings to triage, which is
+          # the trade being made deliberately: this is a network-facing server
+          # that parses whatever a CCU sends back, and the alerts land in a
+          # dashboard rather than turning branches red.
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ behaviour changes to any tool.
   Certificate of Origin 1.1. No CLA, no copyright assignment.
 - Named coding standard (Google TypeScript Style Guide, two documented
   deviations) in `CONTRIBUTING.md`.
+- **CodeQL configuration moved into the repository** (#156). It ran as GitHub's
+  *default setup* — effective, but configured in repository settings, so a
+  file-based survey of the project found no scanner at all. It is now
+  `.github/workflows/codeql.yml`: SHA-pinned like every other action and bumped
+  by Dependabot, least-privilege permissions, an explicit timeout, and the
+  `security-extended` query suite instead of the default one. Default setup was
+  disabled in the same change — the two are mutually exclusive.
 
 ### Fixed
 

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -226,6 +226,10 @@ diverges from the code. Countermeasures:
   directory's tests cannot hide inside a healthy average.
 - Nightly fuzzing runs against a seeded corpus; the seeds are load-bearing, and
   the runner treats a missing corpus as a hard failure rather than a clean run.
+- CodeQL analyses both the source and the workflows on every PR and weekly, with
+  its configuration in `.github/workflows/codeql.yml` rather than in repository
+  settings — so what is scanned, and with which query suite, is reviewable in a
+  diff instead of visible only to whoever holds admin.
 
 Where the argument is weakest: it is written and reviewed by one person, and no
 external security review has been performed. Independent review is welcome —


### PR DESCRIPTION
Closes #156.

CodeQL ran as GitHub's **default setup**: configured in repository settings, invisible to anyone reading the repository, unreviewable in a PR. It worked — it's what caught the `js/polynomial-redos` in `extractBearerToken` — but a file-based survey of this project found no scanner at all, which is how it briefly got mis-reported as "no CodeQL".

The workflow now gets what everything else in `.github/workflows` already has: actions pinned to a SHA and bumped by Dependabot, least-privilege permissions (`security-events: write`, otherwise reads), an explicit `timeout-minutes`, a concurrency group, and a header explaining what it is and isn't.

## Two changes of substance

- **`security-extended` instead of the default suite.** More findings to triage — the trade made on purpose for a network-facing server that parses whatever a CCU sends back. Alerts land in the dashboard; nothing here turns a branch red, and this must never become a required check (it's non-hermetic: query packs update with no diff, so a finding can appear on an unchanged tree).
- **`actions` analysed as its own matrix leg**, alongside `javascript-typescript`. This repository's release path and publish credentials live in `.github/workflows`, so those files are worth analysing in their own right. (`javascript-typescript` covers what default setup listed as three separate languages — same extractor.)

## One thing done outside the diff

**Default setup has been disabled in repository settings**, because the two are mutually exclusive: with it enabled, the SARIF upload from this workflow is rejected outright. I disabled it immediately before pushing this branch, so the gap where nothing scanned is minutes, and CodeQL isn't a required check on either branch.

The consequence is recorded in the workflow header: if this file is ever deleted, default setup has to be re-enabled by hand, because a repository with neither reports exactly like a clean one. Re-enabling is one API call if you want it back:

```sh
gh api -X PATCH repos/claymore666/ccu-mcp/code-scanning/default-setup -f state=configured
```

## Verification

`actionlint` clean. The real check is this PR's own run: the `Analyze (javascript-typescript)` and `Analyze (actions)` jobs here are the first ones under the new configuration, and a rejected SARIF upload would fail them loudly rather than silently.