### PR TITLE
Release v1.10.0

### DIFF
--- a/.github/actions/install-mcp-publisher/action.yml
+++ b/.github/actions/install-mcp-publisher/action.yml
@@ -1,0 +1,41 @@
+name: Install mcp-publisher
+description: >-
+  Download the pinned mcp-publisher binary and verify it against the checksum
+  published with that release.
+
+# Pinned, not `latest`. Every third-party action in this repo is pinned to a
+# commit SHA so a retargeted tag cannot inject code into CI; a `latest`
+# download URL is the same hazard wearing different clothes — the bytes can
+# change under a stable URL with no diff here. The checksum is the pin.
+#
+# Bumping: pick the new tag, take its line from
+# registry_<version>_checksums.txt in the release assets, and update both
+# inputs together.
+
+inputs:
+  version:
+    description: mcp-publisher release tag to install
+    required: false
+    default: "v1.8.0"
+  sha256:
+    description: Expected SHA-256 of mcp-publisher_linux_amd64.tar.gz
+    required: false
+    default: "1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf"
+
+runs:
+  using: composite
+  steps:
+    - name: Download and verify mcp-publisher
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        SHA256: ${{ inputs.sha256 }}
+      run: |
+        set -euo pipefail
+        url="https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.tar.gz"
+        curl -fsSL "$url" -o mcp-publisher.tar.gz
+        echo "${SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+        tar xzf mcp-publisher.tar.gz mcp-publisher
+        rm -f mcp-publisher.tar.gz
+        chmod +x mcp-publisher
+        ./mcp-publisher --version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,14 @@ updates:
     schedule:
       interval: weekly
 
+  # The Dockerfile's base image. Now that the image is published rather than
+  # built by whoever clones the repo, a stale `node:24-alpine` is something we
+  # ship to users rather than something they pick up on their next local build.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
   # npm deps: security + version updates against the committed lockfile.
   - package-ecosystem: npm
     directory: /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Version sync check
         run: npm run check:versions
 
-      - name: Type check
+      # oxlint (style/correctness) then tsc over src AND test. Hermetic: every
+      # rule and every opt-out is pinned in .oxlintrc.json, in the commit.
+      - name: Lint and type check
         run: npm run lint
 
       # No separate Build step: package.json's `pretest` already runs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,88 @@
+name: CodeQL
+
+# CodeQL ran as GitHub's DEFAULT SETUP until this file existed: configured in
+# repository settings, invisible to anyone reading the repository, and
+# unreviewable in a PR. It worked — it is what caught the js/polynomial-redos in
+# extractBearerToken — but a scanner whose configuration only one person can see
+# is a scanner nobody can check. A file-based survey of this repo missed it
+# entirely and briefly reported "no CodeQL" (issue #156).
+#
+# NON-HERMETIC, like audit.yml and fuzz.yml, and for the same reason: the query
+# packs are downloaded at run time and improve without a diff. A finding can
+# appear on an unchanged tree. Never make this a required status check — that is
+# what build-and-test is for.
+#
+# DEFAULT SETUP AND THIS FILE ARE MUTUALLY EXCLUSIVE. With default setup still
+# enabled the SARIF upload here is rejected outright, so it was disabled in
+# repository settings in the same change that added this file. Re-enabling it
+# would silently break this workflow; if this file is ever deleted, re-enable
+# default setup in Settings → Code security, or the repository ends up with no
+# scanning at all — which looks identical to a clean report.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    # Weekly, matching what default setup ran. Off the hour: GitHub's cron
+    # queue is heavily oversubscribed at :00. Scheduled workflows only run from
+    # the default branch (`dev`).
+    - cron: "23 4 * * 1"
+
+# Least privilege at the top; the analyze job adds only what it needs.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Upload the SARIF results. This is the one privilege the job exists for.
+      security-events: write
+      # Read workflow run metadata — required by the CodeQL action itself.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # javascript-typescript covers what default setup listed as three
+          # separate languages (javascript, typescript, javascript-typescript);
+          # they are the same extractor.
+          - language: javascript-typescript
+          # Analysing the workflows themselves is not decoration here: this
+          # repository's release path, publish credentials and gates all live in
+          # .github/workflows, and that is where an injection would matter most.
+          - language: actions
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          # No compiled languages here, so there is nothing to build: analysing
+          # the checkout directly is both correct and faster.
+          build-mode: none
+          # Default setup ran the `default` suite. `security-extended` adds the
+          # lower-precision security queries — more findings to triage, which is
+          # the trade being made deliberately: this is a network-facing server
+          # that parses whatever a CCU sends back, and the alerts land in a
+          # dashboard rather than turning branches red.
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,12 +17,26 @@ name: Fuzz
 # workflow that mails a failure every time it finds something earns a filter
 # rule within a week, and then the mechanism is dead.
 #
-# Corpus: the committed seeds under fuzz/corpus/ only — nothing is persisted
-# between runs. That is a deliberate trade. These targets are small pure
-# functions, so the marginal value of a grown corpus is low, while a cache is
-# one more moving part that fails silently. The seeds carry the inputs that
-# matter: byte-level mutation will never invent the literal key "__proto__",
-# and without that seed the parse target reports green while testing nothing.
+# Corpus: the committed seeds under fuzz/corpus/, PLUS whatever previous runs
+# discovered, carried in an actions/cache entry (issue #155). The seeds are
+# still the load-bearing half — byte-level mutation will never invent the
+# literal key "__proto__", and without that seed the parse target reports green
+# while testing nothing — so scripts/fuzz.sh still treats a missing seed corpus
+# as a hard failure, cache or no cache.
+#
+# Two properties keep the cache from being the "moving part that fails
+# silently" this was originally rejected for:
+#
+#   - The cache is passed as a SEPARATE directory, listed FIRST, which is where
+#     libFuzzer writes new units. fuzz/corpus/ is never written to, so a bad
+#     cache cannot corrupt the reviewed seeds — worst case it is empty and the
+#     run degrades to exactly the old behaviour.
+#   - Every PASS line reports how many inputs were carried forward. A cache
+#     that silently stopped round-tripping shows up as that number sitting at
+#     zero run after run, in the step summary, instead of nowhere.
+#
+# Restoring is best-effort by design: `cache` is not `cache/restore` with a
+# fail-on-miss, because a cold cache must never turn a fuzzing night red.
 #
 # Scheduled workflows only run from the DEFAULT branch (`dev`), so this file
 # must be on `dev` to fire at all.
@@ -77,10 +91,35 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Keyed on the run id so it never hits, which is the point: the post-job
+      # save then always writes a fresh entry, and `restore-keys` pulls the most
+      # recent previous one in. A stable key would restore the same first-ever
+      # corpus forever and quietly stop accumulating — the exact silent failure
+      # this workflow's header warns about.
+      #
+      # Scoped to the default branch: scheduled runs are on `dev`, and GitHub
+      # gives every branch read access to the default branch's caches, so a
+      # dispatch from a work branch inherits the corpus without being able to
+      # poison it for `dev`.
+      #
+      # restore/save rather than the combined `cache` action so the save can be
+      # `if: always()`. The run that finds something is the run whose corpus is
+      # most worth keeping, and that is also the run most likely to end red.
+      - name: Restore the accumulated corpus
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .fuzz-corpus
+          key: fuzz-corpus-v1-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-v1-
+
       - name: Fuzz
         id: fuzz
         env:
           FUZZ_SECONDS: ${{ github.event.inputs.seconds || '300' }}
+          # Absolute: fuzz.sh resolves the seed corpus relative to its own
+          # location, and a relative value here would land somewhere else.
+          FUZZ_CORPUS_DIR: ${{ github.workspace }}/.fuzz-corpus
         run: |
           set -uo pipefail
 
@@ -106,6 +145,13 @@ jobs:
             grep -E "^(===|PASS|FOUND|FAIL)" fuzz.log || true
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Save the accumulated corpus
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .fuzz-corpus
+          key: fuzz-corpus-v1-${{ github.run_id }}
 
       # Reproducers are the whole point of a finding — without the input the
       # report is unactionable.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,6 +107,11 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # The container jobs below gate on this rather than re-deriving "was this a
+    # dry run?" from the event. One source of truth for whether anything was
+    # actually released.
+    outputs:
+      published: ${{ steps.publish.outputs.published }}
     # Requires review from claymore666 before this job starts, and npm matches
     # this environment name against the OIDC claim.
     environment: release
@@ -326,4 +331,287 @@ jobs:
             else
               echo "### Dry run for \`ccu-mcp@${version}\` — nothing uploaded"
             fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # The container image, one job per architecture, each on a runner of that
+  # architecture. No QEMU: emulated arm64 turns a two-minute `npm ci` into
+  # something far worse and, as the arm64 work on docker-net-dhcp measured,
+  # emulation can fail in ways that have nothing to do with the code under
+  # test. GitHub hosts arm64 runners free for public repositories, so the
+  # honest option is also the cheap one.
+  #
+  # `needs: publish`, not `needs: verify`, for two reasons:
+  #   - Ordering. An image for a version npm rejected would be a release target
+  #     that exists nowhere else. Let npm decide first.
+  #   - Approvals. This job deliberately does NOT name the `release`
+  #     environment: it has no stored credential to protect (GHCR takes the
+  #     run's own GITHUB_TOKEN, minted per run and scoped by `permissions`
+  #     below), so a second gate would buy nothing and cost a second click.
+  #     A gate clicked twice per release is a gate that stops being read.
+  #     Waiting on `publish` still puts the human approval upstream of it.
+  #
+  # On a dry run the build and the smoke test still happen — only the push is
+  # skipped. That is the point: a Dockerfile that stopped building is worth
+  # discovering on a dispatch, not during a release.
+  docker:
+    needs: publish
+    strategy:
+      # One architecture failing should not hide the other's verdict.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Push to GHCR. Note what is NOT here: no `contents: write`, for the same
+      # reason the npm job refuses it.
+      packages: write
+      # Both required by attest-build-provenance: the OIDC token it signs with,
+      # and the attestations API it writes to.
+      id-token: write
+      attestations: write
+    env:
+      # github.repository is already lowercase here; GHCR rejects uppercase in
+      # a repository name, so a fork with a capitalised owner would need `tr`.
+      IMAGE: ghcr.io/${{ github.repository }}
+      PUSH: ${{ needs.publish.outputs.published == 'true' }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Built and tested BEFORE the push, so a broken image never reaches the
+      # registry — GHCR tags are mutable, but a bad `:latest` that someone
+      # pulled is not un-pulled by fixing it afterwards.
+      #
+      # `.dockerignore` excludes .git, so the build cannot read the repository:
+      # BUILD_COMMIT/BUILD_TAG are how the image learns what it was built from.
+      # Without them every published image reports null provenance from
+      # get_system_info. The smoke test below asserts they actually landed.
+      - name: Build this architecture and load it locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BUILD_COMMIT=${{ github.sha }}
+            BUILD_TAG=${{ github.ref_type == 'tag' && github.ref_name || '' }}
+          # buildx's own provenance attestation would wrap a single-platform
+          # build in an index and break push-by-digest below. GitHub's
+          # attestation (further down) is the one this release actually makes.
+          provenance: false
+          load: true
+          tags: ccu-mcp:smoke
+
+      # Runs the image on its own architecture — the arm64 variant is exercised
+      # on an arm64 runner, which is the whole reason for the matrix. The runner
+      # needs no toolchain of its own: node runs inside the image, grep does the
+      # asserting, so this works on any hosted image.
+      - name: Smoke-test the image on its own architecture
+        run: |
+          set -euo pipefail
+          # `docker run <image> --help` does NOT reach the server: node:24-alpine
+          # ships an ENTRYPOINT that turns a leading `-` argument into a `node`
+          # flag, so that prints Node's help and exits 0 — a smoke test that
+          # passes without ever starting this program. Name the command.
+          docker run --rm ccu-mcp:smoke node dist/index.js --help > help.txt
+          grep -q "ccu-mcp" help.txt
+
+          info=$(docker run --rm --entrypoint node ccu-mcp:smoke \
+            -p 'JSON.stringify(require("/app/dist/build-info.json"))')
+          echo "build-info: $info"
+
+          # The failure this catches: a build-arg rename or a .dockerignore
+          # change silently returns the image to reporting nothing about itself,
+          # and nothing else in the release would notice.
+          want="${GITHUB_SHA:0:7}"
+          if ! printf '%s' "$info" | grep -q "\"commit\":\"${want}\""; then
+            echo "::error::Image build-info does not report commit ${want}; BUILD_COMMIT did not reach gen-build-info.mjs."
+            exit 1
+          fi
+
+      # Pushed by digest, not by tag: two architectures pushing to the same tag
+      # would race, and the loser's manifest would be the one users pull. The
+      # merge job below assembles both digests into one manifest list, which is
+      # what makes `docker pull` resolve per-architecture. A cache hit on the
+      # build above — the layers are already here.
+      - name: Push this architecture by digest
+        id: build
+        if: env.PUSH == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BUILD_COMMIT=${{ github.sha }}
+            BUILD_TAG=${{ github.ref_type == 'tag' && github.ref_name || '' }}
+          provenance: false
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      # Attested per architecture, not once for the index: `docker pull`
+      # resolves a multi-arch tag down to the manifest for the puller's
+      # platform, so that digest is what `gh attestation verify` is handed. An
+      # index-only attestation verifies for nobody.
+      - name: Attest build provenance
+        if: env.PUSH == 'true'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Export the digest for the merge job
+        if: env.PUSH == 'true'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/digests"
+          # The filename IS the payload — empty file, digest as its name.
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - name: Upload the digest
+        if: env.PUSH == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digest-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Turns the two per-architecture digests into the manifest list users actually
+  # pull. Until this runs the digests are unreferenced by any tag — a failure
+  # here leaves the registry with no half-published tag, only garbage the
+  # registry collects.
+  docker-manifest:
+    needs: [publish, docker]
+    if: needs.publish.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+      # Empty on workflow_dispatch, "false" for a normal release.
+      PRERELEASE: ${{ github.event.release.prerelease }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create the manifest list
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('${GITHUB_WORKSPACE}/package.json').version")
+
+          # nullglob so an empty directory yields no refs rather than the
+          # literal "*", which would reach `imagetools create` as a bogus tag.
+          shopt -s nullglob
+          refs=()
+          for digest in *; do
+            refs+=("${IMAGE}@sha256:${digest}")
+          done
+          # Two architectures in, two digests out. Fewer means a matrix leg
+          # failed and fail-fast: false let the rest of the run continue —
+          # publishing a single-architecture image under the release tag is
+          # exactly the silent degradation to refuse.
+          if [ "${#refs[@]}" -ne 2 ]; then
+            echo "::error::Expected 2 per-architecture digests, found ${#refs[@]}. Refusing to tag a partial image."
+            exit 1
+          fi
+
+          tags=(-t "${IMAGE}:${version}")
+          # `latest` must not move backwards onto a pre-release. There are none
+          # today; this costs one line and removes the trap.
+          if [ "${PRERELEASE}" != "true" ]; then
+            tags+=(-t "${IMAGE}:latest")
+          else
+            echo "Pre-release — tagging ${version} only, leaving :latest where it is."
+          fi
+
+          docker buildx imagetools create "${tags[@]}" "${refs[@]}"
+
+      # The tag existing is not the claim being made. The claim is that pulling
+      # it on either architecture gets a working server, so read the published
+      # index back and run what came out of it.
+      - name: Verify the published image
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+
+          docker buildx imagetools inspect "${IMAGE}:${version}" --raw > index.json
+          node -e '
+            const index = require("./index.json");
+            const have = (index.manifests || [])
+              .map((m) => m.platform)
+              .filter((p) => p && p.os === "linux" && p.architecture !== "unknown")
+              .map((p) => p.architecture)
+              .sort();
+            const want = ["amd64", "arm64"];
+            if (JSON.stringify(have) !== JSON.stringify(want)) {
+              console.error("::error::Published index covers " + JSON.stringify(have) +
+                ", expected " + JSON.stringify(want));
+              process.exit(1);
+            }
+            console.log("index covers:", have.join(", "));
+          '
+
+          # Pulls the tag as any user would; on this runner that resolves to the
+          # amd64 manifest. The arm64 half was run on an arm64 runner before it
+          # was ever pushed.
+          docker run --rm "${IMAGE}:${version}" node dist/index.js --help > help.txt
+          grep -q "ccu-mcp" help.txt
+
+      # No `if: always()` here, unlike the npm summary above: this one has
+      # nothing to report but success, and printing a `docker pull` line for a
+      # tag that failed to publish would be worse than printing nothing.
+      - name: Summary
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          {
+            echo "### Container image"
+            echo
+            echo '```sh'
+            echo "docker pull ${IMAGE}:${version}"
+            echo '```'
+            echo
+            echo "- Package: https://github.com/${GITHUB_REPOSITORY}/pkgs/container/$(basename "${GITHUB_REPOSITORY}")"
+            echo "- Platforms: linux/amd64, linux/arm64 — built natively, attested per architecture"
+            echo "- Verify: \`gh attestation verify oci://${IMAGE}:${version} --repo ${GITHUB_REPOSITORY}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,15 @@ jobs:
       - name: Show what would be published
         run: npm pack --dry-run
 
+      - name: Install mcp-publisher
+        uses: ./.github/actions/install-mcp-publisher
+
+      # `validate` needs no authentication, so a malformed server.json fails
+      # here rather than after someone has approved the deployment and npm has
+      # already taken an immutable version.
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
   publish:
     needs: verify
     runs-on: ubuntu-latest
@@ -196,6 +205,57 @@ jobs:
             console.log("provenance present:", JSON.stringify(v.dist.attestations));
           '
 
+      # The MCP registry entry points consumers at the npm package, so npm must
+      # land first. Same job, not a second one, so the release costs ONE
+      # approval rather than two — a gate people click twice per release is a
+      # gate they stop reading.
+      - name: Install mcp-publisher
+        if: steps.publish.outputs.published == 'true'
+        uses: ./.github/actions/install-mcp-publisher
+
+      # Same OIDC token that authenticated npm. The registry authorises the
+      # `io.github.claymore666/*` namespace from the repository owner in the
+      # claim, so there is no registry credential to store either.
+      - name: Authenticate with the MCP registry
+        if: steps.publish.outputs.published == 'true'
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to the MCP registry
+        if: steps.publish.outputs.published == 'true'
+        run: ./mcp-publisher publish
+
+      # A publish that reports success but does not become isLatest leaves
+      # consumers resolving the previous version — the failure mode the release
+      # checklist's fourth target exists to catch.
+      - name: Verify the registry shows this version as latest
+        if: steps.publish.outputs.published == 'true'
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          name=$(node -p "require('./server.json').name")
+          for attempt in 1 2 3 4 5; do
+            if curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=${name}" -o registry.json; then
+              if node -e '
+                const want = process.argv[1];
+                const j = require("./registry.json");
+                const hit = (j.servers || []).find((s) => {
+                  const v = s.version || (s.server && s.server.version);
+                  const meta = s._meta && s._meta["io.modelcontextprotocol.registry/official"];
+                  return v === want && meta && meta.isLatest;
+                });
+                process.exit(hit ? 0 : 1);
+              ' "$version"; then
+                echo "registry reports ${name}@${version} as isLatest"
+                exit 0
+              fi
+            fi
+            echo "attempt ${attempt}: not visible as latest yet, waiting"
+            sleep 15
+          done
+          echo "::error::${name}@${version} did not appear as isLatest on the MCP registry."
+          echo "::error::The registry read path is intermittently flaky — re-check by hand before assuming the publish failed."
+          exit 1
+
       - name: Summary
         if: always()
         env:
@@ -205,9 +265,10 @@ jobs:
           version=$(node -p "require('./package.json').version")
           {
             if [ "$PUBLISHED" = "true" ]; then
-              echo "### Published \`ccu-mcp@${version}\` with provenance"
+              echo "### Published \`ccu-mcp@${version}\`"
               echo
-              echo "https://www.npmjs.com/package/ccu-mcp/v/${version}"
+              echo "- npm, with provenance: https://www.npmjs.com/package/ccu-mcp/v/${version}"
+              echo "- MCP registry: https://registry.modelcontextprotocol.io/v0/servers?search=io.github.claymore666/ccu-mcp"
             else
               echo "### Dry run for \`ccu-mcp@${version}\` — nothing uploaded"
             fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -256,6 +256,59 @@ jobs:
           echo "::error::The registry read path is intermittently flaky — re-check by hand before assuming the publish failed."
           exit 1
 
+      # Smithery last, and it is the odd one out. npm and the MCP registry both
+      # authenticate by OIDC, so neither needs a stored credential. Smithery has
+      # no OIDC path, and its restricted service tokens cap at a 24-hour TTL —
+      # too short to sit in a secret between releases. So this step needs a
+      # long-lived API key, which is the class of credential the other two
+      # deliberately removed.
+      #
+      # Mitigations, in order of how much they matter:
+      #   - The key is an ENVIRONMENT secret on `release`, not a repo secret.
+      #     Only a job that named this environment can read it, and reaching
+      #     this environment requires a human approval.
+      #   - It runs after both real registries. A Smithery failure cannot
+      #     abort an npm or MCP publish that already succeeded.
+      #   - The job does NOT take `contents: write`. Attaching the bundle to
+      #     the Release would be convenient, but granting write to the same job
+      #     that holds a publish credential is a worse trade than a download.
+      - name: Build the MCPB bundle
+        if: steps.publish.outputs.published == 'true'
+        run: npm run build:mcpb
+
+      - name: Publish to Smithery
+        if: steps.publish.outputs.published == 'true'
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SMITHERY_API_KEY:-}" ]; then
+            echo "::error::SMITHERY_API_KEY is not set on the 'release' environment."
+            echo "::error::npm and the MCP registry have already published; only the Smithery listing is missing."
+            exit 1
+          fi
+          version=$(node -p "require('./package.json').version")
+          npx -y @smithery/cli@4.11.1 mcp publish "ccu-mcp-${version}.mcpb" \
+            -n christian-kamien/ccu-mcp
+
+      # Smithery is a thin discovery listing for this project — a stdio bundle
+      # is not hosted, so `tools` stays null however the publish goes. Checking
+      # the qualified name came back is all this can honestly assert.
+      - name: Verify the Smithery listing responds
+        if: steps.publish.outputs.published == 'true'
+        run: |
+          set -euo pipefail
+          curl -fsS "https://registry.smithery.ai/servers/christian-kamien/ccu-mcp" -o smithery.json
+          node -e '
+            const j = require("./smithery.json");
+            if (j.qualifiedName !== "christian-kamien/ccu-mcp") {
+              console.error("::error::unexpected Smithery listing: " + JSON.stringify(j.qualifiedName));
+              process.exit(1);
+            }
+            console.log("Smithery listing OK:", j.qualifiedName,
+              "| connection:", (j.connections || [])[0] && j.connections[0].type);
+          '
+
       - name: Summary
         if: always()
         env:
@@ -269,6 +322,7 @@ jobs:
               echo
               echo "- npm, with provenance: https://www.npmjs.com/package/ccu-mcp/v/${version}"
               echo "- MCP registry: https://registry.modelcontextprotocol.io/v0/servers?search=io.github.claymore666/ccu-mcp"
+              echo "- Smithery: https://smithery.ai/servers/christian-kamien/ccu-mcp"
             else
               echo "### Dry run for \`ccu-mcp@${version}\` — nothing uploaded"
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ occu-issue-*.md
 findings/
 # libFuzzer default artifact location when -artifact_prefix is not passed
 crash-*
+
+# MCPB bundles built by scripts/build-mcpb.sh
+*.mcpb

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ occu-issue-*.md
 findings/
 # libFuzzer default artifact location when -artifact_prefix is not passed
 crash-*
+# Corpus accumulated across runs (FUZZ_CORPUS_DIR). CI keeps this in an
+# actions/cache entry; anything worth keeping permanently gets promoted into
+# fuzz/corpus/ by hand, where it is reviewed like any other committed input.
+.fuzz-corpus/
 
 # MCPB bundles built by scripts/build-mcpb.sh
 *.mcpb

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,79 @@
+{
+  // oxlint is the automated style/correctness gate for this repo (`npm run lint`).
+  //
+  // Why oxlint and not typescript-eslint: this project builds with TypeScript 7,
+  // and typescript-eslint's peer range is `>=4.8.4 <6.1.0`. There is no release
+  // that supports the compiler we ship on. oxlint parses TypeScript natively,
+  // has no TypeScript peer dependency, and is FLOSS (MIT).
+  //
+  // Every entry under "rules" is a deliberate opt-out with the reason recorded
+  // here. A rule silenced with no note is what review should catch — same
+  // discipline as .github/coverage-baseline.txt.
+  "plugins": ["typescript", "unicorn", "oxc", "import", "promise", "node", "vitest"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "error",
+    "perf": "error"
+  },
+  "rules": {
+    // The CCU serialises requests: a burst of parallel calls makes it drop
+    // sessions. Sequential await-in-loop is the deliberate access pattern, not
+    // an oversight. See src/ccu/session.ts and the rate limiter.
+    "no-await-in-loop": "off",
+
+    // CCU JSON-RPC and BidCos paramsets use leading-underscore field names
+    // verbatim. Renaming them would break the wire format.
+    "no-underscore-dangle": "off",
+
+    // Flags `import x from "y"; x.member` where the CJS/ESM interop is correct
+    // here. High false-positive rate against @modelcontextprotocol/sdk.
+    "import/no-named-as-default-member": "off",
+
+    // Purely stylistic: demands an explicit type parameter on every vi.fn().
+    // 118 hits across the suite, no defect-finding value.
+    "vitest/require-mock-type-parameters": "off",
+
+    // The CCU returns several response shapes for the same call, so tests
+    // legitimately branch before asserting. Rewriting them to satisfy the rule
+    // would make them less readable, not more correct.
+    "vitest/no-conditional-expect": "off",
+
+    // Vitest's expect() genuinely accepts a second message argument; this rule
+    // encodes Jest's signature and is a false positive here.
+    "vitest/valid-expect": "off",
+
+    // A bare toThrow() paired with a separate assertion on the error is an
+    // accepted pattern in this suite.
+    "vitest/require-to-throw-message": "off",
+
+    // The e2e suites assert the initialize handshake inside beforeAll, on
+    // purpose: a failed handshake must abort the suite rather than fail every
+    // test in it with the same downstream error.
+    "vitest/no-standalone-expect": "off",
+
+    // Wants .toSorted() over .sort(). The sorts here are on freshly-built local
+    // arrays where mutation is intended and allocation-free.
+    "unicorn/no-array-sort": "off",
+
+    // Stylistic: hoists nested helpers that deliberately close over test state.
+    "unicorn/consistent-function-scoping": "off",
+
+    // The arrays this fires on are process.argv slices and small fixed test
+    // fixtures. Building a Set to replace a linear scan of three elements costs
+    // more than it saves.
+    "unicorn/prefer-set-has": "off",
+
+    // Fires on `transport.onclose = ...`. The MCP SDK's transport is not an
+    // EventTarget — it exposes onclose as a plain callback property, and
+    // addEventListener does not exist on it. False positive.
+    "unicorn/prefer-add-event-listener": "off",
+
+    // Spreading in .map() is exactly how this codebase avoids the prototype-key
+    // defect class fixed in v1.9.1 — object spread uses CreateDataProperty,
+    // while the suggested Object.assign uses [[Set]] and routes __proto__
+    // through Object.prototype's setter. The "inefficient" pattern is the
+    // correct one here. See test/unit/prototype-key-handling.test.ts.
+    "oxc/no-map-spread": "off"
+  },
+  "ignorePatterns": ["dist", "coverage", "node_modules", ".claude", "fuzz/corpus"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,45 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
+## Unreleased
+
+Project documentation and an automated style gate, from a sweep against the
+OpenSSF Best Practices **silver** criteria. No behaviour changes to any tool.
+
+### Added
+
+- **Automated lint gate.** `npm run lint` now runs [oxlint](https://oxc.rs)
+  over `src`, `test`, `scripts` and `fuzz` before `tsc`, with the ruleset and
+  every opt-out recorded in `.oxlintrc.json`. (oxlint rather than
+  typescript-eslint because the latter's peer range stops at TypeScript 6 and
+  this project builds on TypeScript 7.) The gate was mutation-tested before
+  landing.
+- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
+- **`GOVERNANCE.md`** — decision model, roles, and an honest account of the
+  single-maintainer continuity gap.
+- **`ROADMAP.md`** — direction for the next year, and an explicit list of what
+  the project will not do.
+- **`docs/architecture.md`** — components, layers, and the path a tool call
+  takes.
+- **`docs/assurance-case.md`** — threat model, trust boundaries, secure design
+  principles, and the implementation weakness classes countered, each claim
+  pointing at the file or test that backs it.
+- **Security requirements** section in `SECURITY.md`, stating plainly what
+  users can and cannot expect — including that CCU TLS verification is **off by
+  default**.
+- **DCO** — contributions are now signed off (`git commit -s`) under Developer
+  Certificate of Origin 1.1. No CLA, no copyright assignment.
+- Named coding standard (Google TypeScript Style Guide, two documented
+  deviations) in `CONTRIBUTING.md`.
+
+### Fixed
+
+- Two unit tests asserted nothing at all. `RateLimiter` "allows burst up to max"
+  now bounds the elapsed time, and the `ResourcePoller` start/stop test now
+  asserts the pending-timer count — previously both passed even if the
+  behaviour under test was broken. Found by the new lint gate.
+- `readCaCert` now attaches the original error as `cause` when it rethrows.
+
 ## v1.9.1 — 2026-08-01
 
 A supply-chain and verification release. Nothing here changes what the tools do;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,22 @@ behaviour changes to any tool.
   Certificate of Origin 1.1. No CLA, no copyright assignment.
 - Named coding standard (Google TypeScript Style Guide, two documented
   deviations) in `CONTRIBUTING.md`.
+- **Fuzzing corpus now accumulates between nightly runs** (#155), in an
+  `actions/cache` entry rather than in the repository. Each run starts from the
+  committed seeds *plus* everything previous runs discovered, so coverage
+  compounds instead of resetting every night. Every `PASS` line reports how many
+  inputs were carried forward, which is what makes a cache that quietly stopped
+  round-tripping visible instead of silent.
 
 ### Fixed
 
+- **`npm run fuzz` no longer writes into the committed seed corpus.** Given a
+  single corpus directory libFuzzer treats it as writable, so every local run
+  dropped unreviewed mutation output into `fuzz/corpus/` — inputs that then
+  looked like reviewed seeds in the next `git status`. New units now land in
+  `.fuzz-corpus/` (gitignored); promote one into `fuzz/corpus/` by hand when it
+  is worth keeping. The seeds remain load-bearing and a missing seed corpus is
+  still a hard failure, not a clean run.
 - Two unit tests asserted nothing at all. `RateLimiter` "allows burst up to max"
   now bounds the elapsed time, and the `ResourcePoller` start/stop test now
   asserts the pending-timer count — previously both passed even if the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ behaviour changes to any tool.
   compounds instead of resetting every night. Every `PASS` line reports how many
   inputs were carried forward, which is what makes a cache that quietly stopped
   round-tripping visible instead of silent.
+- **CodeQL configuration moved into the repository** (#156). It ran as GitHub's
+  *default setup* — effective, but configured in repository settings, so a
+  file-based survey of the project found no scanner at all. It is now
+  `.github/workflows/codeql.yml`: SHA-pinned like every other action and bumped
+  by Dependabot, least-privilege permissions, an explicit timeout, and the
+  `security-extended` query suite instead of the default one. Default setup was
+  disabled in the same change — the two are mutually exclusive.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,35 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
-Project documentation and an automated style gate, from a sweep against the
-OpenSSF Best Practices **silver** criteria. No behaviour changes to any tool.
+A published container image, plus project documentation and an automated style
+gate from a sweep against the OpenSSF Best Practices **silver** criteria. No
+behaviour changes to any tool.
 
 ### Added
+
+- **Container images on GHCR.** `docker pull ghcr.io/claymore666/ccu-mcp`
+  replaces cloning the repository to build one, for `linux/amd64` and
+  `linux/arm64` — so the image runs on a Raspberry Pi next to the CCU.
+  Published by the release workflow from the same GitHub Release and the same
+  single approval as npm, the MCP registry and Smithery.
+
+  Each architecture is built **natively** on a runner of that architecture (no
+  QEMU), started and exercised before anything is pushed, and carries a
+  [build provenance attestation](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+  verifiable with:
+
+  ```sh
+  gh attestation verify oci://ghcr.io/claymore666/ccu-mcp:latest --repo claymore666/ccu-mcp
+  ```
+
+  `docker-compose.yml` now pulls the published image; swap in `build: .` to run
+  a checkout instead.
+- **Images know what they were built from.** `get_system_info`'s `build` block
+  reported nulls in any container, because `.dockerignore` excludes `.git` and
+  the build had no repository to read. `BUILD_COMMIT` / `BUILD_TAG` build args
+  now carry the commit and tag in, and the release asserts they arrived rather
+  than trusting that they did. A local `docker build` without them behaves as
+  before.
 
 - **Automated lint gate.** `npm run lint` now runs [oxlint](https://oxc.rs)
   over `src`, `test`, `scripts` and `fuzz` before `tsc`, with the ruleset and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
-## Unreleased
+## v1.10.0 — 2026-08-18
 
-A published container image, plus project documentation and an automated style
-gate from a sweep against the OpenSSF Best Practices **silver** criteria. No
-behaviour changes to any tool.
+Container images, and a release that publishes itself.
+`docker pull ghcr.io/claymore666/ccu-mcp` now works — for `linux/amd64` and
+`linux/arm64` — and a single approved GitHub Release publishes every target
+(npm, the MCP registry, Smithery, and the image) instead of four commands run
+by hand. The rest is project documentation and CI hardening from a sweep
+against the OpenSSF Best Practices **silver** criteria.
+
+**No behaviour changes to any tool.** The only change under `src/` is one error
+now carrying its `cause`, so upgrading is optional unless you want the image.
 
 ### Added
 
@@ -35,6 +41,16 @@ behaviour changes to any tool.
   than trusting that they did. A local `docker build` without them behaves as
   before.
 
+- **The MCP registry and Smithery publish from the release workflow** (#160,
+  #161), on the same OIDC identity and the same single approval as npm.
+  `mcp-publisher login github` — the interactive device-code flow — is no
+  longer part of a release; the registry authorises the
+  `io.github.claymore666/*` namespace from the repository in the OIDC claim, so
+  there is no credential to store. Smithery has no OIDC path, so its API key
+  remains as an *environment* secret on `release`, readable only by a job that
+  a human approved. Each publish is verified before the run goes green: npm
+  must report provenance attestations, the registry must report the new version
+  as `isLatest`, and the Smithery listing must answer.
 - **Automated lint gate.** `npm run lint` now runs [oxlint](https://oxc.rs)
   over `src`, `test`, `scripts` and `fuzz` before `tsc`, with the ruleset and
   every opt-out recorded in `.oxlintrc.json`. (oxlint rather than
@@ -86,6 +102,20 @@ behaviour changes to any tool.
   asserts the pending-timer count — previously both passed even if the
   behaviour under test was broken. Found by the new lint gate.
 - `readCaCert` now attaches the original error as `cause` when it rethrows.
+
+### Dependencies
+
+- Container base image moved from `node:24-alpine` to **`node:26-alpine`**
+  (#169). The published image therefore runs Node 26; `package.json` still
+  declares `engines: node >=24`, which is what applies when you run the server
+  from npm rather than from the image. The image was built, started and
+  health-checked on both architectures on the new base before this release.
+- `undici` 8.9.0 → 8.10.0, `ip-address` 10.2.0 → 10.4.0 and the transitive
+  advisories cleared with it (#163, #164, #166); dev-only bumps to `oxlint` and
+  `@types/node` (#165, #167, #170).
+- Dependabot now watches the Dockerfile's base image as well as npm and the
+  pinned GitHub Actions — a stale base is something this project ships now, not
+  something a user picks up on their next local build.
 
 ## v1.9.1 — 2026-08-01
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,142 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+For this project, community spaces are the GitHub repository (issues, pull
+requests, discussions, and code review) and any thread about ccu-mcp that the
+maintainer opens or participates in on the
+[HomeMatic forum](https://homematic-forum.de/). The forum has its own rules,
+set by its operators; this Code of Conduct is in addition to them, not a
+replacement, and it does not give this project any authority over forum
+moderation.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer at <christian.kamien@gmail.com>. All complaints will
+be reviewed and investigated promptly and fairly.
+
+This project is maintained by one person, who is therefore also the person who
+handles reports. If your report concerns the maintainer, and you would rather
+not send it to them directly, please report it to
+[GitHub](https://support.github.com/contact/report-abuse) instead — GitHub's
+Acceptable Use Policies apply to this repository independently of this document.
+
+The maintainer is obligated to respect the privacy and security of the reporter
+of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning, providing clarity around the nature
+of the violation and an explanation of why the behavior was inappropriate. A
+public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,12 +97,68 @@ just records you as the author.
 
 ## Code style
 
-- TypeScript, `strict` mode. `npm run lint` must be clean — warnings are not
-  acceptable in merged code.
+The style guide for this project is the
+[Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html),
+with two deliberate deviations:
+
+- **Line length 120**, not 80.
+- **Double quotes**, matching the existing tree.
+
+Enforcement is automatic. `npm run lint` runs **[oxlint](https://oxc.rs/docs/guide/usage/linter)**
+over `src`, `test`, `scripts` and `fuzz` before `tsc`, and CI runs the same
+command — so a rule violation fails the build, not review.
+
+```sh
+npm run lint          # oxlint + tsc over src AND test
+npx oxlint --fix src  # auto-fix what is safely fixable
+```
+
+The ruleset lives in [`.oxlintrc.json`](.oxlintrc.json): oxlint's
+`correctness`, `suspicious` and `perf` categories, all as errors. Every
+exception is listed in that file **with the reason it is off** — a rule
+silenced with no note is what review should catch. If a rule is wrong for a
+single line rather than for the project, disable it at that line with
+`// oxlint-disable-next-line <rule>` and a comment saying why.
+
+> Why oxlint and not typescript-eslint: this project builds with TypeScript 7,
+> and typescript-eslint's peer range is `>=4.8.4 <6.1.0`. No release of it
+> supports the compiler we ship on. oxlint parses TypeScript natively and is
+> MIT-licensed.
+
+Beyond the mechanical rules:
+
+- TypeScript, `strict` mode. Warnings are not acceptable in merged code.
 - Match the style of the file you're editing.
 - Comments should explain *why*, not restate *what*. The existing codebase
   leans on this heavily; a comment recording a decision or a trap is valuable,
   a comment narrating the next line is noise.
+
+## Certificate of origin (DCO)
+
+Contributions are accepted under the [Developer Certificate of Origin
+1.1](https://developercertificate.org/). It is a short statement that you wrote
+the patch, or otherwise have the right to submit it under the project's MIT
+licence — please read it once.
+
+Sign off each commit:
+
+```sh
+git commit -s -m "fix: ..."
+```
+
+That appends a line naming you:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Use your real name and a working email address. Signing off is an assertion
+about *provenance*, not about code quality, and it is separate from the
+AI-attribution rule above: using an assistant to help write a patch is fine,
+and you still sign off, because you are the one submitting it.
+
+There is no CLA, and no copyright assignment. You keep the copyright in what
+you write.
 
 ## Adding or changing a tool
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,31 @@ RUN npm ci
 COPY tsconfig.json ./
 COPY src/ ./src/
 COPY scripts/ ./scripts/
-# Full build (tsc + build-info stamp). No .git in the build context ⇒ the git
-# fields are null, but dist/build-info.json exists with builtAt, so
-# get_system_info's `build` block works in the image instead of silently
-# reporting nothing. Pass real values by building from a git checkout in CI.
+# Full build (tsc + build-info stamp). `.dockerignore` excludes .git, so the
+# build has no repository to read: without these two the git fields are null and
+# only builtAt survives. The publish workflow passes them, so a released image
+# reports the commit and tag it was built from; a local `docker build` leaves
+# them empty and gets the old null behaviour, which is honest for a build whose
+# source nobody can pin down.
+ARG BUILD_COMMIT=""
+ARG BUILD_TAG=""
+ENV BUILD_COMMIT=${BUILD_COMMIT} \
+    BUILD_TAG=${BUILD_TAG}
 RUN npm run build
 
 FROM node:24-alpine
+# `image.source` is not decoration: GHCR links a package to a repository by this
+# label, and that link is what carries the README, the licence and the "published
+# by" provenance on the package page. Without it the image floats unattached.
+ARG BUILD_COMMIT=""
+ARG BUILD_TAG=""
+LABEL org.opencontainers.image.title="ccu-mcp" \
+      org.opencontainers.image.description="MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API" \
+      org.opencontainers.image.source="https://github.com/claymore666/ccu-mcp" \
+      org.opencontainers.image.documentation="https://github.com/claymore666/ccu-mcp#readme" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.revision="${BUILD_COMMIT}" \
+      org.opencontainers.image.version="${BUILD_TAG}"
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS builder
+FROM node:26-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -17,7 +17,7 @@ ENV BUILD_COMMIT=${BUILD_COMMIT} \
     BUILD_TAG=${BUILD_TAG}
 RUN npm run build
 
-FROM node:24-alpine
+FROM node:26-alpine
 # `image.source` is not decoration: GHCR links a package to a repository by this
 # label, and that link is what carries the README, the licence and the "published
 # by" provenance on the package page. Without it the image floats unattached.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,77 @@
+# Governance
+
+ccu-mcp is a single-maintainer project. This document says who decides what,
+how, and — honestly — where that arrangement is currently thin.
+
+## Model
+
+**Benevolent dictator.** Christian Kamien (GitHub [@claymore666][cm],
+`claymore666` on the [HomeMatic forum][forum]) is the maintainer and makes all
+final decisions: what gets merged, what gets released, and what the project
+does not do.
+
+This is not an aspiration to a larger structure. The project is small, the
+scope is narrow, and a heavier process would cost more than it returns. If the
+contributor base grows, this document changes with it.
+
+Anyone may fork, as with any MIT-licensed project. That is the ultimate check
+on this model and it needs no permission.
+
+[cm]: https://github.com/claymore666
+[forum]: https://homematic-forum.de/
+
+## Roles
+
+| Role | Who | Responsibilities |
+| --- | --- | --- |
+| **Maintainer** | @claymore666 | Reviews and merges PRs; triages issues; decides scope and roadmap; cuts releases (tag, npm, MCP registry, Smithery); holds all signing keys and registry credentials; receives and handles security reports; enforces the [Code of Conduct](CODE_OF_CONDUCT.md). |
+| **Contributor** | anyone who opens a PR | Follows [CONTRIBUTING.md](CONTRIBUTING.md); adds tests for behaviour they add or change; responds to review. Contributors hold no merge rights. |
+| **Reporter** | anyone | Files bugs and feature requests as issues; reports vulnerabilities privately per [SECURITY.md](SECURITY.md). |
+
+There is currently exactly one person in the Maintainer role.
+
+## How decisions are made
+
+- **Ordinary changes** — a PR into `dev`, reviewed and merged by the
+  maintainer. Required CI checks must pass; see [CONTRIBUTING.md](CONTRIBUTING.md).
+- **Scope** — whether a feature belongs in ccu-mcp at all is the maintainer's
+  call, guided by [ROADMAP.md](ROADMAP.md). Ask in an issue before writing a
+  large feature; a rejected 800-line PR wastes your time, not just review time.
+- **Releases** — the maintainer alone. See
+  [docs/release-runbook.md](docs/release-runbook.md).
+- **Disputes** — raise them in the issue or PR thread. The maintainer responds
+  with a decision and a reason. There is no appeal body; there is a fork
+  button.
+
+## Continuity — a known gap
+
+The badge criterion here asks whether the project could keep going, within a
+week, if any one person became unavailable. For ccu-mcp today the honest answer
+is **no**.
+
+One person holds every credential that matters: the GitHub account, the npm
+publish rights, the MCP registry namespace, the Smithery listing, and the
+commit- and tag-signing key. Nobody else can merge a PR, cut a release, or
+publish a fix. The bus factor is 1.
+
+What partially mitigates it:
+
+- Everything needed to *build* the project is public and reproducible — the
+  full history is on GitHub, every release is a signed tag, and the build is
+  `npm ci && npm run build` with no private inputs.
+- The MIT licence lets anyone fork and publish a continuation under a new name
+  without asking.
+
+What that does *not* cover: users who installed `ccu-mcp` from npm would not
+receive a fix, because the name would stay unmaintained.
+
+Closing this properly means a second person with publish rights, or documented
+credential recovery someone else can actually execute. It is tracked on the
+[roadmap](ROADMAP.md) rather than quietly overstated here — a continuity plan
+that exists only on paper is worse than a known gap, because it stops anyone
+from asking again.
+
+## Changing this document
+
+By PR, like anything else. In practice the maintainer decides; the value of it
+being a PR is that the change is visible and dated.

--- a/README.md
+++ b/README.md
@@ -83,11 +83,26 @@ claude mcp add ccu-mcp -- npx ccu-mcp --stdio
 
 Use this if you want the server running independently — for example on a home server, accessible to multiple clients, or when your MCP client supports HTTP remotes.
 
-**1. Start the container:**
+**1. Start the container.** Images are published to GHCR for `linux/amd64` and
+`linux/arm64` (so a Raspberry Pi next to the CCU works), built natively on each
+architecture and attested — `gh attestation verify oci://ghcr.io/claymore666/ccu-mcp:latest --repo claymore666/ccu-mcp`
+proves the image came from this repository's release workflow.
+
+```bash
+docker pull ghcr.io/claymore666/ccu-mcp:latest
+```
+
+Every release also publishes its own `X.Y.Z` tag — pin that instead of `latest`
+if you'd rather upgrade deliberately. To build from source instead:
 
 ```bash
 git clone https://github.com/claymore666/ccu-mcp.git && cd ccu-mcp
-docker build -t ccu-mcp .
+docker build -t ghcr.io/claymore666/ccu-mcp .
+```
+
+Then run it:
+
+```bash
 docker run -d \
   --name ccu-mcp \
   -e CCU_HOST=your-ccu-hostname-or-ip \
@@ -95,7 +110,7 @@ docker run -d \
   -e MCP_ALLOWED_HOSTS=your-server-ip:3000 \
   -v ccu-data:/data \
   -p 3000:3000 \
-  ccu-mcp
+  ghcr.io/claymore666/ccu-mcp:latest
 ```
 
 > **`MCP_ALLOWED_HOSTS` is required for remote clients.** The server's

--- a/README.md
+++ b/README.md
@@ -419,7 +419,21 @@ confirmation, retry semantics) — live in [CHANGELOG.md](CHANGELOG.md).
 - **Found a security problem?** Please don't post it publicly. See
   [SECURITY.md](SECURITY.md) for private reporting.
 - **Want to send a patch?** [CONTRIBUTING.md](CONTRIBUTING.md) covers the setup,
-  the branch to target, and the test policy.
+  the branch to target, the coding standard, and the test policy.
+
+Everyone taking part is expected to follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+### Project documentation
+
+| Document | What's in it |
+| --- | --- |
+| [ROADMAP.md](ROADMAP.md) | Where the project is going — and what it will deliberately never do |
+| [GOVERNANCE.md](GOVERNANCE.md) | Who decides what, and the known continuity gap |
+| [SECURITY.md](SECURITY.md) | Reporting, security requirements, threat model |
+| [docs/architecture.md](docs/architecture.md) | High-level design and request flow |
+| [docs/assurance-case.md](docs/assurance-case.md) | Why the security requirements hold, with evidence |
+| [CHANGELOG.md](CHANGELOG.md) | What changed in each release |
 
 ## Related projects
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,80 @@
+# Roadmap
+
+What ccu-mcp intends to do, and deliberately not do, over roughly the next
+year. Plans are not promises: this is a spare-time project with one maintainer,
+and the point of writing it down is so you can judge whether it is heading
+somewhere useful to you — not to commit to dates.
+
+Last reviewed: 2026-08-02 (v1.9.1).
+
+## Direction
+
+ccu-mcp is a **read-mostly bridge between an MCP client and a HomeMatic CCU on
+your LAN**. It is finished in the sense that matters: the tool surface covers
+devices, rooms, functions, programs, system variables, links and service
+messages, and it works against debmatic, CCU3 and OpenCCU. Effort now goes into
+making it safer and more predictable rather than larger.
+
+## Planned
+
+### Security posture
+
+- **Verify the CCU's TLS certificate by default.** Today `CCU_TLS_VERIFY`
+  defaults to `false`, so an HTTPS connection to a CCU is encrypted but
+  unauthenticated unless you pin a fingerprint or supply a CA. A startup
+  warning says so, which is not the same as being safe by default. Changing the
+  default breaks every stock self-signed CCU, so it needs a major version, a
+  migration note, and a clear error that names the fix. Until then this is a
+  documented gap, not a hidden one — see
+  [docs/assurance-case.md](docs/assurance-case.md).
+- **OpenSSF Scorecard** in CI ([#153](https://github.com/claymore666/ccu-mcp/issues/153)).
+- **CodeQL advanced setup** so the query suite is pinned in the commit rather
+  than tracking GitHub's default ([#156](https://github.com/claymore666/ccu-mcp/issues/156)).
+- **Persist the fuzzing corpus between nightly runs**
+  ([#155](https://github.com/claymore666/ccu-mcp/issues/155)). The corpus is
+  load-bearing — an empty one found nothing in 60s where a seeded one found
+  planted defects in under 20 — so throwing it away each night wastes most of
+  the value of running the fuzzer at all.
+
+### Project continuity
+
+- **Reduce the bus factor from 1.** Either a second maintainer with publish
+  rights, or credential recovery that another person can actually execute. See
+  [GOVERNANCE.md](GOVERNANCE.md#continuity--a-known-gap). This is the single
+  largest risk to anyone depending on the package.
+
+### Maintenance
+
+- Track the MCP specification and SDK as they move.
+- Keep working against current debmatic / OpenCCU / CCU3 firmware.
+- Keep dependencies current and advisories clear.
+
+## Not planned
+
+Saying no is most of what keeps this maintainable.
+
+- **No cloud, no HomeMatic Cloud / Mediola / third-party bridges.** Direct
+  JSON-RPC to a CCU on your network, nothing else.
+- **No addon or XML-API dependency.** The built-in `/api/homematic.cgi`
+  endpoint is the only interface used, and that stays true.
+- **No web UI or dashboard.** The MCP client is the interface.
+- **No multi-user model or per-user permissions.** The server holds one
+  credential per configured CCU and acts as that user. Authorisation belongs to
+  the CCU.
+- **No exposure to the public internet as a supported deployment.** The design
+  target is a trusted LAN; see the out-of-scope list in
+  [SECURITY.md](SECURITY.md#threat-model).
+- **No automation engine.** ccu-mcp reads and writes values and runs programs
+  that already exist on the CCU. Scheduling and rules stay on the CCU, where
+  they keep working when this server is not running.
+- **No support for non-HomeMatic protocols** (Zigbee, Z-Wave, KNX). Other MCP
+  servers exist for those, and one process bridging all of them would be worse
+  at each.
+
+## How to influence this
+
+Open an issue. Concrete use cases move things far more than feature names, and
+"here is what I was trying to do and where it fell down" is the most useful
+report there is. For general HomeMatic discussion the
+[HomeMatic forum](https://homematic-forum.de/) is a better venue than the
+tracker.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,49 @@ branches — older versions exist as tags only.
 ccu-mcp requires Node.js >= 24, and inherits that runtime's own security
 support window.
 
+## Security requirements
+
+What you can and cannot expect from ccu-mcp. The reasoning and the evidence
+behind each of these is in [docs/assurance-case.md](docs/assurance-case.md).
+
+**You can expect that:**
+
+1. Credentials, bearer tokens and CCU session IDs are not written to logs, tool
+   output, error messages, or the on-disk cache in recoverable form. The
+   session cache is written `0600`.
+2. On the HTTP transport, every request is authenticated before it is routed.
+   Cross-origin browser access is denied unless you allowlist an origin, and
+   DNS-rebinding protection is always on.
+3. A CCU marked `READONLY` refuses every write, and one marked `PROTECTED`
+   refuses writes without `confirm: true` — with `run_script` and
+   `delete_system_variable` requiring it on every single call.
+4. Values from the CCU and arguments from the model cannot alter program
+   structure: HM Script is escaped, and caller-supplied keys cannot reach
+   `Object.prototype`.
+5. Configuration that gates safety fails closed. A malformed
+   `CCU_<PROFILE>_PROTECTED` is a startup error, never a silently unprotected
+   CCU.
+6. Releases are signed, published with build provenance, and reproducible from
+   the tagged source.
+
+**You cannot expect that:**
+
+1. **The CCU's TLS certificate is verified by default.** `CCU_TLS_VERIFY`
+   defaults to `false`, because nearly every CCU ships a self-signed
+   certificate. The connection is encrypted but not authenticated unless you
+   pin it with `CCU_TLS_FINGERPRINT` or supply `CCU_CA_CERT`. A warning is
+   logged at startup. **Pin the fingerprint.** Changing this default is on the
+   [roadmap](ROADMAP.md) for a major version.
+2. ccu-mcp adds any authorisation layer above the CCU's own. It acts as the
+   configured CCU user; anything that user may do, a client of this server may
+   do.
+3. The confirmation gate resists a *determined* operator or a model that has
+   been instructed to confirm. It is a guard against accident and confusion,
+   not an authorisation system.
+4. It is safe to expose on the public internet. It is designed for a trusted
+   LAN.
+5. It has had an external security review. It has not.
+
 ## Threat model
 
 ccu-mcp holds credentials for a CCU, and a CCU controls physical devices —

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   ccu-mcp:
-    build: .
+    # Published multi-arch (linux/amd64 + linux/arm64) by the release workflow.
+    # Swap for `build: .` to run this checkout instead of the released image.
+    image: ghcr.io/claymore666/ccu-mcp:latest
     restart: unless-stopped
     volumes:
       - ccu-data:/data

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,163 @@
+# Architecture
+
+High-level design of ccu-mcp: the major components, how a request flows through
+them, and the decisions that shaped them. For *why* the security-relevant ones
+are the way they are, see [assurance-case.md](assurance-case.md).
+
+## What it is
+
+One Node.js process that speaks **MCP** to a client (Claude, Cursor, …) on one
+side and **CCU JSON-RPC** to a HomeMatic CCU on the other. It holds no database
+and owns no state that matters: everything authoritative lives on the CCU. The
+only things written to disk are two caches, both reconstructible by deleting
+them.
+
+```
+┌──────────────┐   MCP over stdio    ┌───────────────────────────┐  JSON-RPC   ┌─────────┐
+│  MCP client  │◄───────────────────►│                           │   (HTTPS)   │         │
+│ (Claude, …)  │   or Streamable     │         ccu-mcp           │◄───────────►│   CCU   │
+└──────────────┘   HTTP + bearer     │                           │ /api/       │         │
+                                     └───────────────────────────┘ homematic.cgi└─────────┘
+                                                   │
+                                            ┌──────┴──────┐
+                                            │  CACHE_DIR  │
+                                            │ session 0600│
+                                            │ device types│
+                                            └─────────────┘
+```
+
+## Layers
+
+Roughly outside-in. Each layer only knows about the one below it.
+
+### 1. Entry point — `src/index.ts`
+
+Parses flags, loads config, builds the shared singletons, and selects a
+transport:
+
+- **stdio** (`--stdio`) — one `StdioServerTransport`, one `McpServer`, one
+  client. The common case: the MCP client spawns the process.
+- **HTTP** (`--http`, the default) — a Node HTTP or HTTPS listener wrapping
+  `StreamableHTTPServerTransport`. **One `McpServer` and one transport per MCP
+  session**, tracked in a bounded map keyed by session ID.
+
+The per-session server is the important structural choice. A stateless
+transport survives a single request, and a *shared* one would let concurrent
+clients see each other's active CCU target and each other's protected-target
+unlocks. Session state that is per-client is therefore held per-server, not in
+a module global.
+
+Also lives here: CORS (default-deny, an allowlisted origin is reflected
+exactly, never `*`), DNS-rebinding protection, bearer-token auth, the health
+endpoint, idle-session reaping, and signal/stdin-EOF shutdown.
+
+### 2. MCP surface — `src/server.ts`, `src/tools/**`, `src/resources/**`, `src/prompts/**`
+
+`createMcpServer(deps)` registers everything the client can see:
+
+- **28 tools**, grouped by intent across `tools/discovery.ts` (find things),
+  `read.ts` (read state), `control.ts` (change state), `diagnostics.ts`,
+  `targets.ts` (multi-CCU) and `meta.ts` (the in-server `help`).
+- **Resources** — `ccu://…` URIs for the list endpoints, device types and
+  system info, with `resources/subscribe` support.
+- **Prompts** — a handful of canned workflows (`check-windows`, `room-status`,
+  `set-heating`, `good-night`, `diagnostics`, `device-info`).
+
+Every tool input is a **zod** schema. That is the allowlist: shapes, enums and
+ranges are declared, and anything else is rejected before a handler runs.
+
+`ServerDeps` exposes `session`, `resolver` and `deviceTypeCache` as **getters**
+that resolve to the session's *active* target. A `use_ccu` switch is therefore
+picked up by the next tool call without any tool needing to know that targets
+exist.
+
+### 3. Middleware — `src/middleware/**`
+
+The path every tool call takes:
+
+| Component | Responsibility |
+| --- | --- |
+| `tool-handler.ts` | `runTool()` — the uniform wrapper: structured log line per call, duration, and crash containment so a handler throwing never kills the transport. |
+| `rate-limiter.ts` | Token bucket with a bounded queue. Protects the CCU, which is a small embedded box, from an enthusiastic LLM. |
+| `retry.ts` | Retries only `TIMEOUT` and `UNREACHABLE`, and never for non-idempotent methods (`Program.execute`, `ReGa.runScript`). Each retry re-acquires a rate-limit token, so a timeout storm cannot double the real request rate. |
+| `resolver.ts` | Turns human-facing arguments (device name, channel, parameter) into CCU addresses, using the device-type cache. |
+| `error-mapper.ts` | Collapses everything that can go wrong into eight categories — `AUTH`, `CCU_ERROR`, `INTERNAL`, `INVALID_INPUT`, `NOT_FOUND`, `TIMEOUT`, `TLS_ERROR`, `UNREACHABLE` — each carrying a `hint` telling the model what to do next. |
+
+The `hint` is deliberate: the consumer is a language model, and a structured
+error it can act on is worth more than a stack trace it will paraphrase.
+
+### 4. CCU layer — `src/ccu/**`
+
+- **`session.ts`** — login, session-ID renewal on a timer, re-login on
+  expiry, logout. Exactly one renewal timer survives a relogin. The session ID
+  is persisted `0600` under `CACHE_DIR` so a restart does not force a new login
+  (and, on a CCU, does not burn a session slot).
+- **`client.ts`** — the HTTP layer, on undici. Owns TLS policy, most specific
+  first: pinned SHA-256 leaf fingerprint → supplied CA/self-signed PEM →
+  system trust store → unverified with a loud warning. Fingerprint pinning
+  disables TLS session resumption, because a resumed handshake returns an empty
+  peer certificate and the pin would silently pass.
+- **`target-registry.ts`** — multiple named CCUs in one process. Each target
+  owns its own session, resolver and device-type cache, with collision-free
+  cache filenames. `TargetSelection` is the per-MCP-session pointer at the
+  active target plus its unlocks; `assertWritable()` is the write gate.
+
+### 5. Support — `src/config.ts`, `src/logger.ts`, `src/cache/**`, `src/auth/**`
+
+- **`config.ts`** — the only place `process.env` is read. Rejects malformed
+  values rather than coercing them: `CCU_PROD_PROTECTED=yes` throws instead of
+  quietly meaning "unprotected". A boolean that fails *open* is a security bug,
+  not a typo.
+- **`logger.ts`** — one JSON object per line to stderr (stdout belongs to the
+  stdio transport), with redaction of credentials, tokens and session IDs.
+- **`cache/device-type-cache.ts`** — paramset descriptions per device type, so
+  the resolver need not re-ask the CCU for structure that never changes.
+- **`auth/token.ts`** — bearer tokens for the HTTP transport, compared as
+  SHA-256 digests through `timingSafeEqual`, with rotation via a previous
+  token and a grace window.
+
+## Request flow
+
+A `set_value` call, end to end:
+
+```
+client → transport → auth (HTTP only) → runTool()
+       → zod validation of arguments
+       → resolveTarget()  — which CCU?
+       → assertWritable() — readonly? protected? confirm:true?
+       → resolver         — name/channel/parameter → CCU address
+       → rate limiter     — acquire a token
+       → withRetry()      — not retried: this one is a write
+       → session.call()   — JSON-RPC over undici, session ID attached
+       → post-write verification read
+       → error-mapper on any failure → category + hint
+       → structured log line
+```
+
+## Write safety
+
+Writes reach real hardware — locks, heating, sockets — so they are gated
+independently of anything the model decides:
+
+- `CCU_<PROFILE>_READONLY` refuses every write on that target outright.
+- `CCU_<PROFILE>_PROTECTED` requires `confirm: true`, which then unlocks writes
+  for the rest of that MCP session…
+- …except `run_script` and `delete_system_variable`, which require `confirm`
+  on **every** call and never unlock the session. Arbitrary ReGa execution and
+  irreversible deletion are not things a single earlier confirmation should
+  license.
+- Unlocks live in `TargetSelection`, per MCP session, so one HTTP client cannot
+  unlock a protected CCU for another.
+
+## Build and test
+
+- `tsc` to `dist/`, ESM, Node ≥ 24, plus a `build-info.json` stamp recording
+  the commit the build came from (surfaced by `get_system_info`).
+- Four test layers: type check (`npm run lint` — oxlint plus `tsc` over both
+  `src` and `test`), unit, e2e against a mocked CCU, and live integration gated
+  on `CCU_HOST`. Coverage is enforced globally *and* per directory by
+  `scripts/coverage-ratchet.mjs`, because a global average hides a directory
+  collapsing to zero.
+- Nightly coverage-guided fuzzing over the parsing and escaping helpers.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for how to run all of it.

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -228,6 +228,10 @@ diverges from the code. Countermeasures:
   the runner treats a missing corpus as a hard failure rather than a clean run.
   Inputs discovered by a run accumulate in a cache alongside those seeds, never
   inside them, so what each night starts from is still a reviewed set.
+- CodeQL analyses both the source and the workflows on every PR and weekly, with
+  its configuration in `.github/workflows/codeql.yml` rather than in repository
+  settings — so what is scanned, and with which query suite, is reviewable in a
+  diff instead of visible only to whoever holds admin.
 
 Where the argument is weakest: it is written and reviewed by one person, and no
 external security review has been performed. Independent review is welcome —

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -226,6 +226,8 @@ diverges from the code. Countermeasures:
   directory's tests cannot hide inside a healthy average.
 - Nightly fuzzing runs against a seeded corpus; the seeds are load-bearing, and
   the runner treats a missing corpus as a hard failure rather than a clean run.
+  Inputs discovered by a run accumulate in a cache alongside those seeds, never
+  inside them, so what each night starts from is still a reviewed set.
 
 Where the argument is weakest: it is written and reviewed by one person, and no
 external security review has been performed. Independent review is welcome —

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -1,0 +1,232 @@
+# Assurance case
+
+An argument, with evidence, that ccu-mcp meets the security requirements stated
+in [SECURITY.md](../SECURITY.md#security-requirements) — and an honest account
+of where it does not.
+
+The structure follows the OpenSSF Best Practices silver criterion
+`assurance_case`: threat model, trust boundaries, secure design principles, and
+common implementation weaknesses countered.
+
+**Top-level claim.** An attacker on the LAN who cannot already authenticate to
+the CCU cannot use ccu-mcp to read or change CCU state; and an MCP client that
+*can* reach ccu-mcp cannot escalate beyond what the configured CCU credential
+already permits, nor write to a protected target without an explicit
+confirmation.
+
+This claim is bounded by two assumptions, both stated up front because the
+argument is worthless without them:
+
+1. **The LAN is trusted-ish, and the deployment is not internet-facing.** See
+   the out-of-scope list in [SECURITY.md](../SECURITY.md#threat-model).
+2. **Whoever holds the CCU credential controls the CCU.** ccu-mcp does not add
+   an authorisation layer on top of the CCU's own, and does not claim to.
+
+## Assets
+
+| Asset | Why it matters |
+| --- | --- |
+| CCU username + password | Full control of the smart home. Long-lived. |
+| CCU session ID | Equivalent to the credential until it expires. |
+| `MCP_AUTH_TOKEN` | Grants a client the use of all of the above. |
+| Physical device state | Locks, heating, sockets. The actual thing being protected. |
+| Cached device topology | Low sensitivity alone; a map of the home in aggregate. |
+
+## Trust boundaries
+
+Four, crossed in this order:
+
+```
+     [ untrusted ]                [ semi-trusted ]           [ trusted ]
+
+  network ──①──► MCP transport ──②──► tool layer ──③──► CCU client ──④──► CCU
+                (auth, CORS,        (zod schemas,      (TLS policy,
+                 rebinding)          write gates)       session)
+```
+
+**① Network → transport.** The widest boundary and the only one an
+unauthenticated party can touch.
+- *stdio*: there is no network boundary. The client spawned the process and
+  already has the privileges of the user running it.
+- *HTTP*: bearer token required on every request (`src/auth/token.ts`); CORS is
+  **default-deny** and an allowlisted origin is reflected exactly, never `*`;
+  DNS-rebinding protection is on unconditionally and checks the `Host` header
+  against an allowlist. The health endpoint answers liveness only before auth,
+  so it cannot be used to probe CCU state.
+
+**② Transport → tool layer.** Everything arriving here is attacker-influenced,
+because the MCP client is a language model and its arguments may be derived
+from device names, room names, or anything else an attacker could have written
+into the CCU.
+- Every tool input is a **zod** schema — a declared allowlist of shape, type,
+  enum and range. Unparseable input is rejected before a handler runs.
+- Write gates (`assertWritable`) apply here, before any CCU call.
+
+**③ Tool layer → CCU client.** Resolved addresses and values.
+- HM Script fragments are escaped (`escapeHmScript`) rather than concatenated
+  raw.
+- Rate limiting and retry policy apply, protecting the CCU from the client.
+
+**④ CCU client → CCU.** The credential and session ID cross here.
+- TLS policy is chosen most-specific-first: pinned SHA-256 leaf fingerprint →
+  supplied CA PEM → system trust store → unverified with a warning.
+
+## Security requirements → argument → evidence
+
+### R1. Credentials never leave the process except to the CCU
+
+*Argument.* Credentials are read once from the environment, held in memory, and
+sent only to the configured CCU host over the configured transport. Every other
+outbound path — logs, tool output, error messages, the persisted cache — is
+either redacted or stores a derived value.
+
+*Evidence.*
+- `src/logger.ts` redacts credential, token and session-ID fields; the redaction
+  is asserted on the emitted log line, not on the redaction function's return
+  value — a distinction that mattered, because an earlier fix to the function
+  alone left the merge site still leaking (v1.9.1).
+- The session cache stores the session ID, not the password, and is written
+  `0600`.
+- The credential *fingerprint* used to detect a credential change is derived
+  with **scrypt** and a random salt (`src/ccu/session.ts`), not a fast hash —
+  so the cache file does not enable an offline guess at the password.
+- `src/config.ts` deliberately does not interpolate the `CCU_CA_CERT` path into
+  its error message.
+
+*Residual.* An operator who sets `LOG_LEVEL=debug` and shares logs is outside
+what the code can control.
+
+### R2. An unauthenticated network party cannot reach CCU functionality
+
+*Argument.* On the HTTP transport every request is authenticated before
+routing; browser-origin and Host-header checks close the cross-origin and
+rebinding paths that would otherwise let a web page in the user's browser drive
+the server.
+
+*Evidence.* `src/auth/token.ts` (SHA-256 digests compared with
+`timingSafeEqual`, fixed width so a length mismatch cannot throw or leak);
+`enableDnsRebindingProtection: true` unconditionally in `src/index.ts`;
+`MCP_ALLOWED_ORIGINS` unset means no cross-origin browser access at all;
+`WWW-Authenticate` sent on 401. Regression tests cover each.
+
+*Residual.* Plain HTTP on a routable address exposes the bearer token in
+transit. The server logs a startup warning; `MCP_ALLOW_PLAINTEXT=true` silences
+the warning and adds no protection. This is a deployment choice, deliberately
+left possible for loopback and container-network use.
+
+### R3. Writes to a protected CCU require explicit confirmation
+
+*Argument.* Write authority is decided before the CCU is contacted, from
+configuration the model cannot influence, and confirmation state is scoped to a
+single MCP session.
+
+*Evidence.* `assertWritable()` in `src/ccu/target-registry.ts`: `readonly`
+refuses unconditionally; `protected` requires `confirm: true`; `run_script` and
+`delete_system_variable` pass `alwaysConfirm` and so require it on **every**
+call and never unlock the session. Unlocks live in `TargetSelection`, one per
+`McpServer`, so in HTTP mode one client cannot de-gate another.
+
+*Residual.* A model that is *told* to pass `confirm: true` will pass it. The
+gate defends against accident and against a confused model, not against a user
+who instructs the model to proceed. That is the intended semantics: it is a
+confirmation, not an authorisation system.
+
+### R4. CCU-supplied and model-supplied data cannot alter program structure
+
+*Argument.* The two places where data becomes code or keys are HM Script
+generation and object indexing; both are handled explicitly.
+
+*Evidence.*
+- `escapeHmScript()` escapes backslashes first, then quotes and newlines —
+  order matters, and the property test asserts round-trip equality against an
+  independent unescape oracle plus odd-backslash quote parity
+  (`test/unit/utils-properties.test.ts`).
+- Prototype-key handling: caller-supplied keys are written with
+  `Object.fromEntries` (which uses `CreateDataProperty`) rather than `obj[k] =
+  v` or `Object.assign` (which use `[[Set]]` and route `__proto__` through
+  `Object.prototype`'s setter), and reads are guarded with `Object.hasOwn`.
+  Fixed across `logger`, `utils`, `device-type-cache` and `resolver` in v1.9.1;
+  regression tests in `test/unit/prototype-key-handling.test.ts`.
+- Cache filenames are derived by slug **plus a SHA-256 hash** of the canonical
+  target name (`fileSuffix`), so a name containing `../` cannot traverse and
+  two names cannot collide.
+
+### R5. The server degrades safely rather than failing open
+
+*Argument.* Every configuration value that gates behaviour fails closed, and
+failures are contained.
+
+*Evidence.* `parseBoolEnv` throws on anything that is not exactly `true`/`false`
+— `CCU_PROD_PROTECTED=yes` is a startup error, not a silently unprotected
+production CCU (issue #120, the concrete failure this replaced). `runTool()`
+contains handler crashes so the transport survives. Retries apply only to
+`TIMEOUT`/`UNREACHABLE` and never to non-idempotent methods, so a retry cannot
+double-execute a program.
+
+## Secure design principles (Saltzer & Schroeder)
+
+| Principle | How it is applied |
+| --- | --- |
+| **Fail-safe defaults** | CORS default-deny; DNS-rebinding protection always on; `readonly`/`protected` fail closed on a malformed value; HTTP transport requires a token. **Exception: CCU TLS verification — see below.** |
+| **Economy of mechanism** | One process, no database, no plugin system, no user model. The tool surface is fixed at build time. |
+| **Complete mediation** | Every tool call goes through `runTool()` → zod → `assertWritable()` → rate limiter. There is no path to `session.call()` that skips them. |
+| **Least privilege** | Documented recommendation to give ccu-mcp its own CCU user at USER level; ADMIN is needed only for ReGa. The container runs as a non-root user. |
+| **Separation of privilege** | Writing to a protected target needs both configuration (the target is writable) and a per-call/per-session confirmation. |
+| **Open design** | MIT, full history public, no security by obscurity. This document is part of that. |
+| **Psychological acceptability** | Errors carry an actionable `hint`; the safety gates explain what to pass and why, rather than refusing opaquely. |
+
+### The known violation of fail-safe defaults
+
+`CCU_TLS_VERIFY` defaults to **false**. An HTTPS connection to a CCU is
+therefore encrypted but **not authenticated** unless the operator pins a
+fingerprint or supplies a CA. A startup warning is logged, naming the three
+ways to fix it.
+
+The reason is that essentially every CCU ships a self-signed certificate, and a
+verify-by-default that refuses to connect to a stock box would push users to
+disable TLS entirely — a worse outcome. That is an explanation, not a
+justification: it is a real gap, it is why the corresponding badge criterion is
+answered **Unmet** rather than argued around, and correcting it is on the
+[roadmap](../ROADMAP.md) for a major version where the migration can be
+handled properly.
+
+Until then, **pin the fingerprint with `CCU_TLS_FINGERPRINT`.** It is the
+strongest option available against a self-signed peer, and it is what the
+maintainer's own deployment uses.
+
+## Common implementation weaknesses countered
+
+Against the classes that actually apply to this program:
+
+| Weakness | Status |
+| --- | --- |
+| **Injection** (CWE-77/78/94) | No shell execution, no `eval`; `no-eval` is enforced by the lint gate. HM Script is escaped, and the escaping is property-tested and fuzzed. |
+| **Prototype pollution** (CWE-1321) | Countered as described in R4; four sites fixed and regression-tested in v1.9.1. |
+| **Broken authentication** (CWE-287/307) | Constant-time token comparison; rotation with a grace window; rate limiting bounds guessing. |
+| **Sensitive data exposure** (CWE-200/532) | Log redaction asserted end-to-end; `0600` session cache; scrypt-derived credential fingerprint. |
+| **Improper certificate validation** (CWE-295) | Pinning and CA paths implemented and tested, including the session-resumption trap that made an earlier pin silently pass. Default-off is the documented gap above. |
+| **ReDoS** (CWE-1333) | Bearer-token parsing was rewritten to a linear pattern after a polynomial one was found; the regexes are property-tested and fuzzed. |
+| **Path traversal** (CWE-22) | Cache filenames are slug + hash of a canonical name; no caller-supplied path segment reaches the filesystem. |
+| **Uncontrolled resource consumption** (CWE-400) | Bounded session map, bounded rate-limiter queue, idle-session reaping, retry budget that re-acquires tokens. |
+| **Vulnerable dependencies** (CWE-1104) | Three production dependencies. Dependabot, a daily `npm audit` of production deps, and a release gate that blocks a release PR on any high/critical advisory. |
+| **Memory safety** (CWE-119 family) | Not applicable: TypeScript on Node, no native code, no FFI. |
+
+## How this argument is kept honest
+
+The weak point of any assurance case is that it is written once and then
+diverges from the code. Countermeasures:
+
+- Every claim above names the file or test that backs it, so a reviewer can
+  check rather than trust.
+- The gates are **mutation-tested** — deliberately broken to confirm they go
+  red — because a guard that has never failed is indistinguishable from
+  decoration. This applies to the coverage ratchet, the AI-attribution check,
+  the actionlint gate and the new lint gate.
+- Coverage is enforced per directory as well as globally, so deleting a
+  directory's tests cannot hide inside a healthy average.
+- Nightly fuzzing runs against a seeded corpus; the seeds are load-bearing, and
+  the runner treats a missing corpus as a hard failure rather than a clean run.
+
+Where the argument is weakest: it is written and reviewed by one person, and no
+external security review has been performed. Independent review is welcome —
+see [SECURITY.md](../SECURITY.md).

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -274,6 +274,35 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    **Nothing here needs `mcp-publisher login github` any more.** The
    interactive device-code flow is only for publishing by hand.
 
+   Finally the same job builds the MCPB bundle (`npm run build:mcpb`) and
+   publishes the Smithery listing. All three registries, one approval.
+
+   **Smithery is the one place a stored credential remains.** npm and the MCP
+   registry authenticate by OIDC; Smithery has no OIDC path, and its restricted
+   service tokens cap at a 24-hour TTL — too short to survive between releases.
+   So `SMITHERY_API_KEY` is stored as an **environment** secret on `release`,
+   not a repo secret: only a job naming that environment can read it, and
+   reaching that environment needs a human approval. Rotate it there
+   (Settings → Environments → release → Secrets), never as a repo secret.
+
+   Smithery runs last on purpose — a failure there cannot abort an npm or MCP
+   publish that has already succeeded. If it does fail, everything else is
+   already live and the fix is a local rerun:
+   ```sh
+   npm run build && npm run build:mcpb
+   SMITHERY_API_KEY=… npx @smithery/cli mcp publish ccu-mcp-X.Y.Z.mcpb -n christian-kamien/ccu-mcp
+   ```
+
+   The bundle manifest is **generated** by `scripts/build-mcpb.sh` from
+   `smithery/manifest.template.json`, with the version injected from
+   `package.json`. The template carries no version deliberately — a committed
+   one would be a fourth place the release version lives, and three already
+   need a sync script and a CI gate to stay honest.
+
+   The `description` shown on Smithery is **not** settable from the bundle;
+   it is a web-dashboard field. Re-publishing appears to blank it, so check
+   the listing after a release.
+
    **Rehearsing it, and the limit of a rehearsal.** `workflow_dispatch` on
    `publish.yml` defaults to `dry_run: true`. That checks the workflow wiring,
    the environment gate and the tarball contents, and uploads nothing.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -104,11 +104,19 @@ The registry listing is published from `server.json` with the
 is authorized via GitHub login (OIDC) — the GitHub account must own the
 `claymore666` namespace.
 
-1. `mcp-publisher login github` (interactive; opens a device-code flow).
+**Releases need no login at all.** `publish.yml` runs
+`mcp-publisher login github-oidc`, which exchanges the workflow's OIDC token —
+the same one npm uses — for registry authorisation. Nothing to store, nothing
+to expire.
+
+Only publishing **by hand** needs the interactive flow:
+
+1. `mcp-publisher login github` (opens a device-code flow).
 2. Authorization persists locally; re-login only when the token expires.
 
 The `io.github.<user>/*` namespace maps to the GitHub user, so no DNS TXT
-record is needed (that path is only for custom-domain namespaces).
+record is needed (that path is only for custom-domain namespaces). It is also
+why OIDC works: the repository owner in the claim *is* the namespace owner.
 
 ### Pre-flight validation (do this every release, costs nothing)
 
@@ -247,14 +255,24 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    present, then **waits for your approval** on the `release` environment
    before publishing. Approve it in the run's UI.
 
-   The workflow refuses to publish when the tag and `package.json` disagree,
-   and fails the run if the uploaded version comes back without provenance
-   attestations. `prepublishOnly` re-runs `lint && test` on top of that.
+   That one approval covers **both** registries. After npm, the same job
+   authenticates to the MCP registry with the same OIDC token
+   (`mcp-publisher login github-oidc`) and publishes `server.json`. There is no
+   registry credential to store either: the registry authorises the
+   `io.github.claymore666/*` namespace from the repository owner in the claim.
 
-   Then the MCP registry, from the tagged `main` checkout:
-   ```sh
-   mcp-publisher publish             # reads server.json
-   ```
+   Deliberately one job and one approval, not two. A gate clicked twice per
+   release is a gate that stops being read.
+
+   The workflow refuses to publish when the tag and `package.json` disagree,
+   fails the run if the npm upload comes back without provenance attestations,
+   and fails if the MCP registry does not report the new version as
+   `isLatest`. `prepublishOnly` re-runs `lint && test` on top of all that.
+   `server.json` is validated in the `verify` job, before anyone is asked to
+   approve anything.
+
+   **Nothing here needs `mcp-publisher login github` any more.** The
+   interactive device-code flow is only for publishing by hand.
 
    **Rehearsing it, and the limit of a rehearsal.** `workflow_dispatch` on
    `publish.yml` defaults to `dry_run: true`. That checks the workflow wiring,

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -2,10 +2,11 @@
 
 How to publish a `vX.Y.Z` of `ccu-mcp`. The release is **manual** —
 there is no release workflow (CI only builds and tests). The publish
-targets are **npm** (`npx ccu-mcp`, the primary install path) and the
-**official MCP registry** (`registry.modelcontextprotocol.io`). The Docker
-image is build-your-own (`docker-compose` builds from source); nothing is
-pushed to a container registry, so there is no image-publish step.
+targets are **npm** (`npx ccu-mcp`, the primary install path), the
+**official MCP registry** (`registry.modelcontextprotocol.io`), **Smithery**,
+and the **container image** on GHCR (`ghcr.io/claymore666/ccu-mcp`,
+`linux/amd64` + `linux/arm64`). All four are published by `publish.yml` from
+the one GitHub Release, behind one approval.
 
 The goal: a release is a tag plus two `publish` commands, with version
 numbers that agree everywhere before any of it happens.
@@ -255,7 +256,7 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    present, then **waits for your approval** on the `release` environment
    before publishing. Approve it in the run's UI.
 
-   That one approval covers **both** registries. After npm, the same job
+   That one approval covers **every** publish target. After npm, the same job
    authenticates to the MCP registry with the same OIDC token
    (`mcp-publisher login github-oidc`) and publishes `server.json`. There is no
    registry credential to store either: the registry authorises the
@@ -275,7 +276,8 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    interactive device-code flow is only for publishing by hand.
 
    Finally the same job builds the MCPB bundle (`npm run build:mcpb`) and
-   publishes the Smithery listing. All three registries, one approval.
+   publishes the Smithery listing. Then the container jobs run. Four targets,
+   one approval.
 
    **Smithery is the one place a stored credential remains.** npm and the MCP
    registry authenticate by OIDC; Smithery has no OIDC path, and its restricted
@@ -302,6 +304,32 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    The `description` shown on Smithery is **not** settable from the bundle;
    it is a web-dashboard field. Re-publishing appears to blank it, so check
    the listing after a release.
+
+   **The container image** publishes from the same run, in the `docker` and
+   `docker-manifest` jobs, and needs nothing from you:
+
+   - One job per architecture on a runner of that architecture (`ubuntu-latest`
+     and `ubuntu-24.04-arm`). No QEMU — emulated builds are slow and can fail
+     for reasons that have nothing to do with the code.
+   - Each architecture is **built, loaded and run** (`--help`, plus an assert
+     that `build-info.json` carries the release commit) *before* it is pushed.
+     A broken image never reaches the registry.
+   - Both are pushed **by digest**; `docker-manifest` then assembles them into
+     the `X.Y.Z` and `latest` tags, refusing to tag at all if fewer than two
+     digests arrived. `latest` is skipped for a GitHub pre-release.
+   - Provenance is attested **per architecture** (`actions/attest-build-provenance`,
+     pushed to the registry as a referrer), because `docker pull` resolves a
+     tag to one platform's manifest and that is the digest a verifier sees.
+
+   These jobs deliberately do **not** name the `release` environment. There is
+   no stored credential to protect — GHCR takes the run's own `GITHUB_TOKEN`,
+   scoped by `permissions: packages: write` — and gating on `needs: publish`
+   already puts your approval upstream of the push. One approval per release.
+
+   No GHCR credential, prerequisite or setting exists to maintain. The package
+   links itself to this repository through the `org.opencontainers.image.source`
+   label in the Dockerfile; if that label is ever dropped, the package page
+   loses its README, licence and repository link.
 
    **Rehearsing it, and the limit of a rehearsal.** `workflow_dispatch` on
    `publish.yml` defaults to `dry_run: true`. That checks the workflow wiring,
@@ -355,6 +383,13 @@ After publishing:
   machine pulls and runs it.
 - The MCP registry shows the new version:
   `curl -s 'https://registry.modelcontextprotocol.io/v0/servers?search=io.github.claymore666/ccu-mcp' | jq '.servers[].version'`.
+- The container image covers both architectures and verifies:
+  ```sh
+  docker buildx imagetools inspect ghcr.io/claymore666/ccu-mcp:X.Y.Z
+  gh attestation verify oci://ghcr.io/claymore666/ccu-mcp:X.Y.Z --repo claymore666/ccu-mcp
+  ```
+  The workflow asserts both of these itself; run them by hand only when
+  something looks wrong.
 - `gh release view vX.Y.Z` shows the notes body.
 - The milestone is closed:
   `gh issue list --milestone vX.Y.Z --state open` — should be empty.
@@ -373,6 +408,9 @@ After publishing:
 | `mcp-publisher publish` rejects the version | `server.json` version ≠ npm package version, or `mcpName` missing in `package.json` | align all three version spots (step 2); ensure `package.json` `mcpName` matches `server.json` `name` |
 | `mcp-publisher` 401 / auth error | publisher login expired | `mcp-publisher login github` again |
 | GitHub Release exists but npm/registry don't | published the release before the `publish` commands | run `npm publish` + `mcp-publisher publish` from the tagged checkout |
+| `docker-manifest` fails with "Expected 2 per-architecture digests" | one matrix leg failed; `fail-fast: false` let the other finish | fix the failing architecture and re-run the job — no tag was written, so nothing is half-published |
+| Image smoke test fails on "does not report commit" | `BUILD_COMMIT` stopped reaching `gen-build-info.mjs` (build-arg renamed, `ARG` dropped from the builder stage) | reconcile `Dockerfile` and the `build-args:` block; the image would otherwise ship with null provenance |
+| GHCR package page has no README or licence | `org.opencontainers.image.source` label missing or not matching the repo URL | restore the label in the Dockerfile's final stage and re-run the release jobs |
 
 ## Backports between `dev` and `main`
 
@@ -389,10 +427,12 @@ When a release-blocking hotfix must land on `main` without going through
 These are in the docker-net-dhcp runbook but don't apply here, noted so their
 absence reads as a decision, not an oversight:
 
-- **Container registry publish (GHCR / Docker Hub), image signing (cosign),
-  SBOM, provenance** — no image is published; the Dockerfile is built locally
-  by `docker-compose`. If a published image is ever added, the GHCR-linking
-  and signing prerequisites from that runbook become relevant.
+- **Docker Hub** — the image publishes to GHCR only. A second registry is a
+  second place a tag can go stale, for an audience GHCR already reaches.
+- **cosign signing, SBOM** — GitHub's build provenance attestation covers what
+  cosign would here (who built it, from which workflow and commit, verifiable
+  with `gh attestation verify`) without a key to hold or rotate. An SBOM is
+  worth adding when something consumes it; nothing does yet.
 - **Versioned docs site (mkdocs / GitHub Pages)** — docs are the README plus
   this `docs/` folder; there's no published site to reconcile.
 - **rc dry-run via the release workflow / coverage ratchet** — there's no

--- a/package-lock.json
+++ b/package-lock.json
@@ -583,9 +583,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.77.0.tgz",
-      "integrity": "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.78.0.tgz",
+      "integrity": "sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw==",
       "cpu": [
         "arm"
       ],
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.77.0.tgz",
-      "integrity": "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.78.0.tgz",
+      "integrity": "sha512-CDfxZgB61B7buRdY2FJoAYYPPXCZ1EoC1LKscnC5dg3kjobdxiconvAvvN1BmHyW4PyFT3jRLDag/BY/roSNBQ==",
       "cpu": [
         "arm64"
       ],
@@ -617,9 +617,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.77.0.tgz",
-      "integrity": "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.78.0.tgz",
+      "integrity": "sha512-2Y2U9Ahrz+OO0Ej88f9SJYq51/jUBp1Mc7iZu0ukrbeeZ3gpRGfzIFnoqfHDY96xr0GEfNrPUBFEy0nN5aD7HA==",
       "cpu": [
         "arm64"
       ],
@@ -634,9 +634,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.77.0.tgz",
-      "integrity": "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.78.0.tgz",
+      "integrity": "sha512-rpych6eJq6m9jDRypTEaPD1xysaEW5h9+xuxhGK/QhOg+/xaqPZrCrTNoIl/f3nEjuJeCEmstNDlrE9rJi/3/g==",
       "cpu": [
         "x64"
       ],
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.77.0.tgz",
-      "integrity": "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.78.0.tgz",
+      "integrity": "sha512-IcMGrQT3QizkOESUJd5et+rOhVqSkNDfNik1cvrKDqIbzqx9KMtRswpFgkCuNTSwylCFLKhGUu8KmqY1ZnC0Dg==",
       "cpu": [
         "x64"
       ],
@@ -668,9 +668,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.77.0.tgz",
-      "integrity": "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.78.0.tgz",
+      "integrity": "sha512-/uLdoJ0IXE6vo/0f0LKjinQAp+re+VMaCWaNT8ENIv2EOCkSsc8SGaflXAuW0Jua2dq5+GLVWm1NQK7P3UFSNQ==",
       "cpu": [
         "arm"
       ],
@@ -685,9 +685,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.77.0.tgz",
-      "integrity": "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.78.0.tgz",
+      "integrity": "sha512-7xi4Wb/O8NRJhLoUXmDJMUVpNYvB5kefdhFU1Jb8rtae4QoXlTiLwI14X4YvAXVZLNZChP8m5qO9SQAlWQTbkQ==",
       "cpu": [
         "arm"
       ],
@@ -702,9 +702,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.77.0.tgz",
-      "integrity": "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.78.0.tgz",
+      "integrity": "sha512-4hFW0+fVXa3OIh1Y4A5SPkmvI4wuuBSrCVKzOyE7PTjhc7yEqZ1pmvEEeS5Lj/MaqvegFxXyF33N+6jkehxdyg==",
       "cpu": [
         "arm64"
       ],
@@ -722,9 +722,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.77.0.tgz",
-      "integrity": "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.78.0.tgz",
+      "integrity": "sha512-oC0mvsgBJjlMijSDEhx9KuvR9zYeHXceA9MjbuXB1F8NSR78Yj2unOBrstEvTVaq+pko+kuue6DajC00eqvTdg==",
       "cpu": [
         "arm64"
       ],
@@ -742,9 +742,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.77.0.tgz",
-      "integrity": "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.78.0.tgz",
+      "integrity": "sha512-XAllT5SUZS+ohjuZ3/5S0cwe0r7eboiuigeStCZ5DXRYx/2KVM2UvQXvAfyzXEimtQjAB7cDQ2YxDe2Zl2WNQQ==",
       "cpu": [
         "ppc64"
       ],
@@ -762,9 +762,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.77.0.tgz",
-      "integrity": "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.78.0.tgz",
+      "integrity": "sha512-trucMER/0QtecoXvc1y/UVqE3kwJipDwrx4oHfj+nNm3dq2zjP44WT0CfHNDPM3G1DXIkx/gY6lAD21NSCZVhA==",
       "cpu": [
         "riscv64"
       ],
@@ -782,9 +782,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.77.0.tgz",
-      "integrity": "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.78.0.tgz",
+      "integrity": "sha512-cm3O4F/HQbdzOUX5mKHqG5KDL6E5w0pnlZ+fbBy2rmLryPOowkuLagFHTopQsEIpjcaZoPOrL+BmmAytAG9HFg==",
       "cpu": [
         "riscv64"
       ],
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.77.0.tgz",
-      "integrity": "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.78.0.tgz",
+      "integrity": "sha512-33wRf6HqGNsybJ3qX4cGaQN2ODPxNmc1rMa0mrTmx3eFq1VzOnvQooi9bIGVYakW8a/wmqVx1mgsUm8R2xfTiw==",
       "cpu": [
         "s390x"
       ],
@@ -822,9 +822,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.77.0.tgz",
-      "integrity": "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.78.0.tgz",
+      "integrity": "sha512-rRdISSYegj6VganMZ9tjRjijowfHJ09IZU01i0toBAqr6n5LEtwHq2IeS4FjW2RoskOHlb6efB26H5izYb3GEQ==",
       "cpu": [
         "x64"
       ],
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.77.0.tgz",
-      "integrity": "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.78.0.tgz",
+      "integrity": "sha512-GmsP4rW0xTL6u5CVdcDsaN5Fbc7hBc382Wmar1kttbnwSEviM+rSINKOMQ+UQ6iH+AGwC+8gaAiwu134Tgh6Lg==",
       "cpu": [
         "x64"
       ],
@@ -862,9 +862,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.77.0.tgz",
-      "integrity": "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.78.0.tgz",
+      "integrity": "sha512-sy9yeYuADc8a+n4TLBayzMCZiHPW78DcIFVpOXTmdKHWQeM9xe5uzkqIIZmi326D5hY9XVwacipEB1p7tQjPAg==",
       "cpu": [
         "arm64"
       ],
@@ -879,9 +879,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.77.0.tgz",
-      "integrity": "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.78.0.tgz",
+      "integrity": "sha512-rjc2hF1KfMi8fZj1X/m3AmnHbdsF3rL0v6KQg0Uc880Yb2khjz+3U14sfdZ7jWTpRnN1m1NQa/TT7uU9lJWPrA==",
       "cpu": [
         "arm64"
       ],
@@ -896,9 +896,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.77.0.tgz",
-      "integrity": "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.78.0.tgz",
+      "integrity": "sha512-zcuXFVrEFHIafRfkCQT8w/Xe41o07ozl/vwHq7p94vB29xVzsB0sZGYORU1jhcYKv3Lr0J3HbJ2T4fHH5rWmvA==",
       "cpu": [
         "ia32"
       ],
@@ -913,9 +913,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.77.0.tgz",
-      "integrity": "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.78.0.tgz",
+      "integrity": "sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA==",
       "cpu": [
         "x64"
       ],
@@ -3490,9 +3490,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.77.0.tgz",
-      "integrity": "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.78.0.tgz",
+      "integrity": "sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3505,25 +3505,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.77.0",
-        "@oxlint/binding-android-arm64": "1.77.0",
-        "@oxlint/binding-darwin-arm64": "1.77.0",
-        "@oxlint/binding-darwin-x64": "1.77.0",
-        "@oxlint/binding-freebsd-x64": "1.77.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.77.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.77.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.77.0",
-        "@oxlint/binding-linux-arm64-musl": "1.77.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.77.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.77.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.77.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.77.0",
-        "@oxlint/binding-linux-x64-gnu": "1.77.0",
-        "@oxlint/binding-linux-x64-musl": "1.77.0",
-        "@oxlint/binding-openharmony-arm64": "1.77.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.77.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.77.0",
-        "@oxlint/binding-win32-x64-msvc": "1.77.0"
+        "@oxlint/binding-android-arm-eabi": "1.78.0",
+        "@oxlint/binding-android-arm64": "1.78.0",
+        "@oxlint/binding-darwin-arm64": "1.78.0",
+        "@oxlint/binding-darwin-x64": "1.78.0",
+        "@oxlint/binding-freebsd-x64": "1.78.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.78.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.78.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.78.0",
+        "@oxlint/binding-linux-arm64-musl": "1.78.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.78.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.78.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.78.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.78.0",
+        "@oxlint/binding-linux-x64-gnu": "1.78.0",
+        "@oxlint/binding-linux-x64-musl": "1.78.0",
+        "@oxlint/binding-openharmony-arm64": "1.78.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.78.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.78.0",
+        "@oxlint/binding-win32-x64-msvc": "1.78.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -583,9 +583,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.76.0.tgz",
-      "integrity": "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.77.0.tgz",
+      "integrity": "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==",
       "cpu": [
         "arm"
       ],
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.76.0.tgz",
-      "integrity": "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.77.0.tgz",
+      "integrity": "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==",
       "cpu": [
         "arm64"
       ],
@@ -617,9 +617,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.76.0.tgz",
-      "integrity": "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.77.0.tgz",
+      "integrity": "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==",
       "cpu": [
         "arm64"
       ],
@@ -634,9 +634,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.76.0.tgz",
-      "integrity": "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.77.0.tgz",
+      "integrity": "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==",
       "cpu": [
         "x64"
       ],
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.76.0.tgz",
-      "integrity": "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.77.0.tgz",
+      "integrity": "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==",
       "cpu": [
         "x64"
       ],
@@ -668,9 +668,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.76.0.tgz",
-      "integrity": "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.77.0.tgz",
+      "integrity": "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==",
       "cpu": [
         "arm"
       ],
@@ -685,9 +685,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.76.0.tgz",
-      "integrity": "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.77.0.tgz",
+      "integrity": "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==",
       "cpu": [
         "arm"
       ],
@@ -702,9 +702,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.76.0.tgz",
-      "integrity": "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.77.0.tgz",
+      "integrity": "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==",
       "cpu": [
         "arm64"
       ],
@@ -722,9 +722,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.76.0.tgz",
-      "integrity": "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.77.0.tgz",
+      "integrity": "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==",
       "cpu": [
         "arm64"
       ],
@@ -742,9 +742,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.76.0.tgz",
-      "integrity": "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.77.0.tgz",
+      "integrity": "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==",
       "cpu": [
         "ppc64"
       ],
@@ -762,9 +762,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.76.0.tgz",
-      "integrity": "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.77.0.tgz",
+      "integrity": "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==",
       "cpu": [
         "riscv64"
       ],
@@ -782,9 +782,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.76.0.tgz",
-      "integrity": "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.77.0.tgz",
+      "integrity": "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==",
       "cpu": [
         "riscv64"
       ],
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.76.0.tgz",
-      "integrity": "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.77.0.tgz",
+      "integrity": "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==",
       "cpu": [
         "s390x"
       ],
@@ -822,9 +822,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.76.0.tgz",
-      "integrity": "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.77.0.tgz",
+      "integrity": "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==",
       "cpu": [
         "x64"
       ],
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.76.0.tgz",
-      "integrity": "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.77.0.tgz",
+      "integrity": "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==",
       "cpu": [
         "x64"
       ],
@@ -862,9 +862,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.76.0.tgz",
-      "integrity": "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.77.0.tgz",
+      "integrity": "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==",
       "cpu": [
         "arm64"
       ],
@@ -879,9 +879,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.76.0.tgz",
-      "integrity": "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.77.0.tgz",
+      "integrity": "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==",
       "cpu": [
         "arm64"
       ],
@@ -896,9 +896,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.76.0.tgz",
-      "integrity": "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.77.0.tgz",
+      "integrity": "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==",
       "cpu": [
         "ia32"
       ],
@@ -913,9 +913,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.76.0.tgz",
-      "integrity": "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.77.0.tgz",
+      "integrity": "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==",
       "cpu": [
         "x64"
       ],
@@ -3490,9 +3490,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.76.0.tgz",
-      "integrity": "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.77.0.tgz",
+      "integrity": "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3505,25 +3505,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.76.0",
-        "@oxlint/binding-android-arm64": "1.76.0",
-        "@oxlint/binding-darwin-arm64": "1.76.0",
-        "@oxlint/binding-darwin-x64": "1.76.0",
-        "@oxlint/binding-freebsd-x64": "1.76.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.76.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.76.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.76.0",
-        "@oxlint/binding-linux-arm64-musl": "1.76.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.76.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.76.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.76.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.76.0",
-        "@oxlint/binding-linux-x64-gnu": "1.76.0",
-        "@oxlint/binding-linux-x64-musl": "1.76.0",
-        "@oxlint/binding-openharmony-arm64": "1.76.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.76.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.76.0",
-        "@oxlint/binding-win32-x64-msvc": "1.76.0"
+        "@oxlint/binding-android-arm-eabi": "1.77.0",
+        "@oxlint/binding-android-arm64": "1.77.0",
+        "@oxlint/binding-darwin-arm64": "1.77.0",
+        "@oxlint/binding-darwin-x64": "1.77.0",
+        "@oxlint/binding-freebsd-x64": "1.77.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.77.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.77.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.77.0",
+        "@oxlint/binding-linux-arm64-musl": "1.77.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.77.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.77.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.77.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.77.0",
+        "@oxlint/binding-linux-x64-gnu": "1.77.0",
+        "@oxlint/binding-linux-x64-musl": "1.77.0",
+        "@oxlint/binding-openharmony-arm64": "1.77.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.77.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.77.0",
+        "@oxlint/binding-win32-x64-msvc": "1.77.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2791,9 +2791,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4264,9 +4264,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
-      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2497,9 +2497,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2726,9 +2726,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^26.1.0",
         "@vitest/coverage-v8": "^4.1.8",
         "fast-check": "^4.9.0",
+        "oxlint": "^1.76.0",
         "typescript": "^7.0.2",
         "vitest": "^4.1.8"
       },
@@ -579,6 +580,353 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.76.0.tgz",
+      "integrity": "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.76.0.tgz",
+      "integrity": "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.76.0.tgz",
+      "integrity": "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.76.0.tgz",
+      "integrity": "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.76.0.tgz",
+      "integrity": "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.76.0.tgz",
+      "integrity": "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.76.0.tgz",
+      "integrity": "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.76.0.tgz",
+      "integrity": "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.76.0.tgz",
+      "integrity": "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.76.0.tgz",
+      "integrity": "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.76.0.tgz",
+      "integrity": "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.76.0.tgz",
+      "integrity": "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.76.0.tgz",
+      "integrity": "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.76.0.tgz",
+      "integrity": "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.76.0.tgz",
+      "integrity": "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.76.0.tgz",
+      "integrity": "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.76.0.tgz",
+      "integrity": "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.76.0.tgz",
+      "integrity": "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.76.0.tgz",
+      "integrity": "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3139,6 +3487,55 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.76.0.tgz",
+      "integrity": "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.76.0",
+        "@oxlint/binding-android-arm64": "1.76.0",
+        "@oxlint/binding-darwin-arm64": "1.76.0",
+        "@oxlint/binding-darwin-x64": "1.76.0",
+        "@oxlint/binding-freebsd-x64": "1.76.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.76.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.76.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.76.0",
+        "@oxlint/binding-linux-arm64-musl": "1.76.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.76.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.76.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.76.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.76.0",
+        "@oxlint/binding-linux-x64-gnu": "1.76.0",
+        "@oxlint/binding-linux-x64-musl": "1.76.0",
+        "@oxlint/binding-openharmony-arm64": "1.76.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.76.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.76.0",
+        "@oxlint/binding-win32-x64-msvc": "1.76.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=7.0.2001",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
       }
     },
     "node_modules/parseurl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1255,9 +1255,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "check:versions": "node scripts/check-version-sync.mjs",
     "version": "node scripts/sync-server-version.mjs && git add server.json",
     "prepublishOnly": "npm run check:versions && npm run lint && npm test",
-    "fuzz": "bash scripts/fuzz.sh"
+    "fuzz": "bash scripts/fuzz.sh",
+    "build:mcpb": "bash scripts/build-mcpb.sh"
   },
   "engines": {
     "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pretest": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit && tsc -p tsconfig.test.json",
+    "lint": "oxlint src test scripts fuzz && tsc --noEmit && tsc -p tsconfig.test.json",
     "check:versions": "node scripts/check-version-sync.mjs",
     "version": "node scripts/sync-server-version.mjs && git add server.json",
     "prepublishOnly": "npm run check:versions && npm run lint && npm test",
@@ -64,6 +64,7 @@
     "@types/node": "^26.1.0",
     "@vitest/coverage-v8": "^4.1.8",
     "fast-check": "^4.9.0",
+    "oxlint": "^1.76.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.8"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Build the MCPB bundle published to Smithery.
+#
+# Used by `npm run build:mcpb` and by .github/workflows/publish.yml, so a
+# release and a local rebuild produce the same artifact.
+#
+# The manifest is GENERATED from smithery/manifest.template.json with the
+# version injected from package.json. The template deliberately has no
+# `version` field: a committed one would be a fourth place the release version
+# lives, and the first three already need a sync script and a CI gate to stay
+# honest. Nothing that cannot drift needs checking.
+#
+# Requires: a built dist/ (run `npm run build` first).
+# Output:   ccu-mcp-<version>.mcpb in the repo root.
+#
+# Deliberately NOT in the bundle: devDependencies (npm ci --omit=dev), the
+# source tree, tests, and .github. `files` in package.json ships dist/ only for
+# the same reason — none of it is needed to run the server.
+set -euo pipefail
+
+MCPB_VERSION="${MCPB_VERSION:-2.1.2}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ ! -d dist ]; then
+    echo "FAIL: dist/ is missing — run 'npm run build' first." >&2
+    exit 2
+fi
+if [ ! -f smithery/manifest.template.json ]; then
+    echo "FAIL: smithery/manifest.template.json is missing." >&2
+    exit 2
+fi
+
+version="$(node -p "require('./package.json').version")"
+out="$ROOT/ccu-mcp-${version}.mcpb"
+stage="$(mktemp -d)"
+trap 'rm -rf "$stage"' EXIT
+
+echo "Building MCPB bundle for ccu-mcp ${version}"
+
+# Mirror the layout the manifest's entry_point expects: server/dist/index.js.
+mkdir -p "$stage/server"
+cp -r dist "$stage/server/dist"
+cp package.json package-lock.json "$stage/server/"
+cp README.md LICENSE "$stage/"
+
+# Production dependencies only. `npm ci` needs the lockfile, which is why it is
+# copied above even though it is not published to npm.
+( cd "$stage/server" && npm ci --omit=dev --no-audit --no-fund >/dev/null )
+
+node -e '
+  const fs = require("fs");
+  const tpl = JSON.parse(fs.readFileSync("smithery/manifest.template.json", "utf8"));
+  const version = require("./package.json").version;
+  if (tpl.version) {
+    console.error("FAIL: the template must not carry a version — that is the drift this avoids.");
+    process.exit(2);
+  }
+  // Rebuild in a fixed key order so the generated manifest is byte-stable
+  // across runs: version goes straight after name, where a reader expects it.
+  const out = {};
+  for (const [k, v] of Object.entries(tpl)) {
+    out[k] = v;
+    if (k === "name") out.version = version;
+  }
+  fs.writeFileSync(process.argv[1] + "/manifest.json", JSON.stringify(out, null, 2) + "\n");
+  console.log("manifest.json generated at version " + version);
+' "$stage"
+
+npx -y "@anthropic-ai/mcpb@${MCPB_VERSION}" validate "$stage/manifest.json"
+
+# Smoke test the thing that will actually run. A bundle that packs cleanly but
+# cannot start is the failure a validated manifest does not catch.
+echo "Smoke test: MCP initialize handshake against the staged server"
+handshake='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"build-mcpb","version":"1"}}}'
+reply="$(printf '%s\n' "$handshake" \
+    | CCU_HOST=127.0.0.1 CCU_USER=smoke CCU_PASSWORD=smoke \
+      timeout 30 node "$stage/server/dist/index.js" --stdio 2>/dev/null | head -1 || true)"
+if ! printf '%s' "$reply" | grep -q '"serverInfo"'; then
+    echo "FAIL: staged server did not complete an MCP initialize handshake." >&2
+    echo "  reply: ${reply:-<empty>}" >&2
+    exit 1
+fi
+if ! printf '%s' "$reply" | grep -q "\"version\":\"${version}\""; then
+    echo "FAIL: staged server reported a different version than ${version}." >&2
+    echo "  reply: ${reply}" >&2
+    exit 1
+fi
+echo "  handshake OK, server reports ${version}"
+
+rm -f "$out"
+npx -y "@anthropic-ai/mcpb@${MCPB_VERSION}" pack "$stage" "$out"
+echo "Bundle: $out"

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -4,8 +4,18 @@
 # Used by `npm run fuzz` and by .github/workflows/fuzz.yml, so both run exactly
 # the same thing. Requires a built dist/ — the targets import from it.
 #
-# FUZZ_SECONDS  per-target time budget (default 60)
-# FINDINGS_DIR  where libFuzzer writes crashing inputs (default ./findings)
+# FUZZ_SECONDS     per-target time budget (default 60)
+# FINDINGS_DIR     where libFuzzer writes crashing inputs (default ./findings)
+# FUZZ_CORPUS_DIR  writable corpus root that outlives a run (default
+#                  ./.fuzz-corpus, gitignored; CI points it at a cache entry).
+#                  <dir>/<target> is passed to libFuzzer FIRST, which is what
+#                  makes new units land there instead of in fuzz/corpus/.
+#
+# Given one corpus directory libFuzzer writes new units into it, so before this
+# split a plain `npm run fuzz` silently added unreviewed mutation output to the
+# committed seeds — they are a reviewed, load-bearing input set, not a scratch
+# directory. Promote something out of .fuzz-corpus into fuzz/corpus/ by hand
+# when it is worth keeping forever.
 #
 # Exit codes, kept distinct on purpose:
 #   0  every target ran to its time limit and found nothing
@@ -20,6 +30,7 @@ set -uo pipefail
 FUZZ_SECONDS="${FUZZ_SECONDS:-60}"
 FINDINGS_DIR="${FINDINGS_DIR:-findings}"
 TARGETS_DIR="$(dirname "$0")/../fuzz"
+FUZZ_CORPUS_DIR="${FUZZ_CORPUS_DIR:-$(dirname "$0")/../.fuzz-corpus}"
 
 if [ ! -d "$(dirname "$0")/../dist" ]; then
     echo "FAIL: dist/ is missing — run 'npm run build' first." >&2
@@ -45,15 +56,24 @@ for target in "$TARGETS_DIR"/*.fuzz.mjs; do
         continue
     fi
 
-    echo "=== $name (${FUZZ_SECONDS}s, $(find "$corpus" -type f | wc -l) seeds) ==="
+    # Order matters: libFuzzer writes newly-discovered units into the FIRST
+    # corpus directory it is given and treats the rest as read-only inputs.
+    # Growable first, committed seeds second.
+    grown="$FUZZ_CORPUS_DIR/$name"
+    mkdir -p "$grown" || { echo "FAIL: cannot create $grown" >&2; broke=1; continue; }
+
+    echo "=== $name (${FUZZ_SECONDS}s, $(find "$corpus" -type f | wc -l) seeds + $(find "$grown" -type f | wc -l) carried over) ==="
     rc=0
-    npx jazzer "$target" "$corpus" --sync -- \
+    npx jazzer "$target" "$grown" "$corpus" --sync -- \
         -max_total_time="$FUZZ_SECONDS" \
         -artifact_prefix="$FINDINGS_DIR/$name-" \
         -print_final_stats=1 || rc=$?
 
     if [ "$rc" -eq 0 ]; then
-        echo "PASS  $name"
+        # Printed because the workflow summary greps PASS lines: a corpus that
+        # never grows across runs is the tell that CI's cache is not actually
+        # round-tripping, which would otherwise fail silently.
+        echo "PASS  $name ($(find "$grown" -type f | wc -l) carried forward)"
         continue
     fi
 

--- a/scripts/gen-build-info.mjs
+++ b/scripts/gen-build-info.mjs
@@ -4,6 +4,14 @@
 // (get_system_info exposes it). Best-effort: outside a git checkout (e.g. an
 // npm tarball or `git archive`), every git field is null — the build still
 // succeeds. Runs after `tsc` (see package.json "build"), so dist/ exists.
+//
+// The container image is the case that made the null path worth fixing rather
+// than merely tolerating: `.dockerignore` excludes `.git`, so a build inside
+// the image has no repository to interrogate and every published image would
+// report nothing about its own provenance. BUILD_COMMIT / BUILD_TAG let the
+// caller supply what git would have answered. Git still wins whenever it is
+// available — the environment is a fallback, never an override, so nothing can
+// stamp a checkout with a commit it was not built from.
 import { execFileSync } from "node:child_process";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -17,21 +25,48 @@ const git = (args) => {
   }
 };
 
+// An unset variable and one set to "" mean the same thing here: nothing was
+// supplied. Docker passes an undeclared --build-arg through as an empty string,
+// so treating "" as a value would stamp empty strings where null belongs.
+const env = (name) => {
+  const value = process.env[name];
+  return value && value.trim() !== "" ? value.trim() : null;
+};
+
 const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]);
 // Tracked modifications only (--untracked-files=no), matching `git describe --dirty`
 // semantics: stray untracked files (drafts, build output) don't change which
 // committed source the build came from, so they must not flip the dirty flag.
 const status = git(["status", "--porcelain", "--untracked-files=no"]);
 
+// All-or-nothing, not field-by-field: the environment is consulted only when
+// git answered nothing at all. Falling back per field would let a stray
+// BUILD_TAG in someone's shell label a real checkout with a tag it is not on,
+// producing a record half-read from the repository and half-asserted by
+// whoever set the variable.
+const gitCommit = git(["rev-parse", "--short", "HEAD"]);
+const noRepository = gitCommit === null;
+
+// CI hands over the full 40-character sha because that is what the OCI
+// `revision` label wants; `git rev-parse --short` answers 7. Truncate so the
+// field has one shape whichever path produced it — a consumer comparing
+// build-info against a release should not have to know how the image was built.
+const envCommit = noRepository ? env("BUILD_COMMIT") : null;
+const commit = gitCommit ?? (envCommit === null ? null : envCommit.slice(0, 7));
+// exact-match returns the tag only when HEAD is *on* a tag, else null
+const tag = noRepository ? env("BUILD_TAG") : git(["describe", "--tags", "--exact-match"]);
+
 const buildInfo = {
   // branch is "HEAD" when detached (e.g. a CI checkout of a tag) — report null
   branch: branch === "HEAD" ? null : branch,
-  commit: git(["rev-parse", "--short", "HEAD"]),
-  // exact-match returns the tag only when HEAD is *on* a tag, else null
-  tag: git(["describe", "--tags", "--exact-match"]),
+  commit,
+  tag,
   // human-readable: <tag>-<n>-g<sha>[-dirty], or just <sha> with no tags
-  describe: git(["describe", "--tags", "--dirty", "--always"]),
-  // null when not a git checkout; true if tracked files have uncommitted changes
+  describe: git(["describe", "--tags", "--dirty", "--always"]) ?? tag ?? commit,
+  // null when not a git checkout; true if tracked files have uncommitted changes.
+  // Stays null on the BUILD_COMMIT path on purpose: the caller asserting a
+  // commit says nothing about whether the tree it built was clean, and
+  // answering `false` there would be a claim this script cannot support.
   dirty: status === null ? null : status.length > 0,
   builtAt: new Date().toISOString(),
 };

--- a/scripts/test-coverage-ratchet.mjs
+++ b/scripts/test-coverage-ratchet.mjs
@@ -6,7 +6,7 @@
 //
 // Run: node scripts/test-coverage-ratchet.mjs   (no deps, no build)
 
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { spawnSync } from "node:child_process";

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.9.1",
+  "version": "1.10.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/smithery/manifest.template.json
+++ b/smithery/manifest.template.json
@@ -1,0 +1,106 @@
+{
+  "manifest_version": "0.2",
+  "name": "ccu-mcp",
+  "display_name": "HomeMatic CCU",
+  "description": "Talk to your HomeMatic smart home from any MCP client.",
+  "long_description": "Connects to a HomeMatic CCU's built-in JSON-RPC API and exposes devices, rooms, programs and system variables as MCP tools. No addons, no XML-API, no cloud — a direct connection to the CCU on your local network. Works with debmatic, a CCU3, or OpenCCU (formerly RaspberryMatic).",
+  "author": {
+    "name": "claymore666",
+    "url": "https://github.com/claymore666"
+  },
+  "homepage": "https://github.com/claymore666/ccu-mcp",
+  "documentation": "https://github.com/claymore666/ccu-mcp#readme",
+  "support": "https://github.com/claymore666/ccu-mcp/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/claymore666/ccu-mcp"
+  },
+  "license": "MIT",
+  "keywords": [
+    "homematic",
+    "homematic-ip",
+    "debmatic",
+    "openccu",
+    "raspberrymatic",
+    "smart-home",
+    "home-automation",
+    "ccu",
+    "iot"
+  ],
+  "server": {
+    "type": "node",
+    "entry_point": "server/dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/server/dist/index.js",
+        "--stdio"
+      ],
+      "env": {
+        "CCU_HOST": "${user_config.ccu_host}",
+        "CCU_PORT": "${user_config.ccu_port}",
+        "CCU_HTTPS": "${user_config.ccu_https}",
+        "CCU_USER": "${user_config.ccu_user}",
+        "CCU_PASSWORD": "${user_config.ccu_password}",
+        "CCU_TLS_VERIFY": "${user_config.ccu_tls_verify}",
+        "CCU_TLS_FINGERPRINT": "${user_config.ccu_tls_fingerprint}"
+      }
+    }
+  },
+  "user_config": {
+    "ccu_host": {
+      "type": "string",
+      "title": "CCU hostname or IP",
+      "description": "Hostname or IP of the CCU on your local network, e.g. debmatic or 192.168.1.10",
+      "required": true,
+      "default": "homematic-ccu"
+    },
+    "ccu_port": {
+      "type": "string",
+      "title": "Port",
+      "description": "443 for HTTPS, 80 for plain HTTP",
+      "required": false,
+      "default": "443"
+    },
+    "ccu_https": {
+      "type": "string",
+      "title": "Use HTTPS",
+      "description": "true or false. Leave true unless the CCU only serves plain HTTP.",
+      "required": false,
+      "default": "true"
+    },
+    "ccu_user": {
+      "type": "string",
+      "title": "CCU username",
+      "description": "A CCU user. USER level is enough for reading; script tools need ADMIN.",
+      "required": true,
+      "default": "Admin"
+    },
+    "ccu_password": {
+      "type": "string",
+      "title": "CCU password",
+      "description": "Password for that CCU user. Stored by your MCP client, never sent anywhere but the CCU.",
+      "sensitive": true,
+      "required": true
+    },
+    "ccu_tls_verify": {
+      "type": "string",
+      "title": "Verify the CCU TLS certificate",
+      "description": "true or false. Most CCUs use a self-signed certificate, so this defaults to false; prefer pinning the fingerprint below instead of disabling verification.",
+      "required": false,
+      "default": "false"
+    },
+    "ccu_tls_fingerprint": {
+      "type": "string",
+      "title": "CCU certificate SHA-256 fingerprint (optional)",
+      "description": "Pin the CCU's certificate. The strongest protection available when the CCU is self-signed. Leave blank to skip pinning.",
+      "required": false,
+      "default": ""
+    }
+  },
+  "compatibility": {
+    "runtimes": {
+      "node": ">=24.0.0"
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -200,7 +200,7 @@ export function loadConfig(): AppConfig {
     try {
       return readFileSync(path, "utf-8");
     } catch (err) {
-      throw new Error(`${envName} could not be read: ${(err as Error).message}`);
+      throw new Error(`${envName} could not be read: ${(err as Error).message}`, { cause: err });
     }
   };
 

--- a/test/unit/rate-limiter.test.ts
+++ b/test/unit/rate-limiter.test.ts
@@ -12,10 +12,16 @@ describe("RateLimiter", () => {
   it("allows burst of requests up to max", async () => {
     limiter = new RateLimiter(5, 10);
 
-    // Should complete immediately — 5 tokens available
+    // 5 tokens available, so all 5 must be granted without waiting for a
+    // refill. Asserting on elapsed time is the point: without it this test
+    // passes even if the limiter blocks on every acquire, because a slow
+    // acquire still resolves eventually. Refill here is 10/s (100ms apart), so
+    // a single queued token would push this well past the bound.
+    const start = Date.now();
     for (let i = 0; i < 5; i++) {
       await limiter.acquire();
     }
+    expect(Date.now() - start).toBeLessThan(50);
   });
 
   it("queues requests when tokens exhausted", async () => {

--- a/test/unit/resource-poller.test.ts
+++ b/test/unit/resource-poller.test.ts
@@ -20,8 +20,12 @@ describe("ResourcePoller", () => {
     const mocks = createMocks();
     const poller = new ResourcePoller(mocks.notify, () => mocks.session, mocks.rateLimiter, logger, 30);
     poller.start();
+    // Under fake timers the pending-timer count is observable, so assert it
+    // rather than trusting "it didn't throw" — a stop() that failed to clear
+    // the interval would leak a timer and this test would still have passed.
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
     poller.stop();
-    // No throw, timer cleaned up
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("does not emit event on first poll (no previous hash)", async () => {
@@ -73,9 +77,7 @@ describe("ResourcePoller", () => {
 
   it("failure in one resource does not stop polling others", async () => {
     const mocks = createMocks();
-    let callIdx = 0;
     mocks.session.call.mockImplementation(async (method: string) => {
-      callIdx++;
       if (method === "Device.listAllDetail") throw new Error("fail");
       return [];
     });

--- a/test/unit/retry.test.ts
+++ b/test/unit/retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { withRetry } from "../../src/middleware/retry.js";
 import { CcuError } from "../../src/middleware/error-mapper.js";
 import { Logger } from "../../src/logger.js";

--- a/test/unit/tools-control.test.ts
+++ b/test/unit/tools-control.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { inferType } from "../../src/tools/control.js";
 import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
 
@@ -174,7 +174,7 @@ describe("set_system_variable handler", () => {
 
   // Last RPC is now the post-write verification, so assert on the setter call itself.
   const lastCallTo = (sessionCall: any, method: string) =>
-    sessionCall.mock.calls.filter((c: unknown[]) => c[0] === method).at(-1);
+    sessionCall.mock.calls.findLast((c: unknown[]) => c[0] === method);
 
   it("uses SysVar.setFloat for enum (LIST) variables and accepts a valid index", async () => {
     const sessionCall = vi.fn().mockImplementation(async (method: string) => {

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { tryParseJson } from "../../src/tools/diagnostics.js";
 import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
 

--- a/test/unit/tools-discovery.test.ts
+++ b/test/unit/tools-discovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
 
 const mockDevices = [

--- a/test/unit/tools-meta.test.ts
+++ b/test/unit/tools-meta.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
 
 describe("help handler", () => {

--- a/test/unit/tools-read.test.ts
+++ b/test/unit/tools-read.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { buildGetValuesScript, tryParseJson } from "../../src/tools/read.js";
 import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
 


### PR DESCRIPTION
Container images, and a release that publishes itself.

`docker pull ghcr.io/claymore666/ccu-mcp` now works for `linux/amd64` and `linux/arm64`, and a single approved GitHub Release publishes every target — npm, the MCP registry, Smithery and the image — instead of four commands run by hand. The rest is project documentation and CI hardening from a sweep against the OpenSSF Best Practices silver criteria.

**No behaviour changes to any tool.** The only change under `src/` in this release is one error now carrying its `cause`.

Full notes: the `v1.10.0` section of [CHANGELOG.md](https://github.com/claymore666/ccu-mcp/blob/dev/CHANGELOG.md), which becomes the GitHub Release body.

## What ships

- **Container images on GHCR** (#168), built natively per architecture — no QEMU — smoke-tested before push, pushed by digest and attested per architecture.
- **npm, MCP registry and Smithery publish from the release workflow** (#157, #160, #161), on one OIDC identity and one approval, each verified before the run goes green.
- **Project documentation** — governance, roadmap, architecture, assurance case — plus an oxlint gate (#162).
- **CI hardening**: CodeQL configuration moved in-tree with `security-extended` (#156), fuzzing corpus now accumulates between nightly runs (#155).
- **Dependencies**: base image `node:24-alpine` → `node:26-alpine` (#169), `undici`, `ip-address` and the transitive advisories with it, plus dev-only bumps.

## Verification beyond CI

The container path was rehearsed twice end-to-end on a throwaway branch, publishing to a scratch package that was deleted afterwards — once on the original base, and again after #169 moved it to Node 26. The second rehearsal asserted more than the release workflow does: that the image reports Node 26 inside, and that the server actually answers `/health` on **each** architecture rather than only printing `--help`. Both green on amd64 and arm64; the published index carried both platforms and the attestations verified.

This matters because nothing in `build-and-test` builds the Dockerfile, so #169 — a major base-image bump merged unattended by Dependabot — would otherwise have had its first real exercise during this release.

## First-release-only, after the tag

The GHCR package is created **private** on first publish; it needs one manual flip to public in the package settings.

Closes #155
Closes #156