### PR TITLE
ci: one Node major everywhere, and run the image before publishing it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,21 @@ updates:
   # The Dockerfile's base image. Now that the image is published rather than
   # built by whoever clones the repo, a stale `node:24-alpine` is something we
   # ship to users rather than something they pick up on their next local build.
+  #
+  # Patches yes, MAJORS no. A Node major is not a dependency bump, it is a
+  # platform decision: it must move together with `engines`, `@types/node` and
+  # every workflow's `node-version` (scripts/check-node-version.mjs enforces
+  # that they agree). #169 auto-merged `node:24-alpine` -> `node:26-alpine`
+  # unattended, and nothing in `build-and-test` builds the Dockerfile, so the
+  # published image would have been the first thing to run that major. Moving
+  # to a new major is one deliberate PR that touches all four places at once.
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: node
+        update-types: ["version-update:semver-major"]
 
   # npm deps: security + version updates against the committed lockfile.
   - package-ecosystem: npm
@@ -21,3 +32,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # Same reasoning as the base image, from the other side: `@types/node`'s
+      # major IS a Node major. Types from a newer major tell `tsc` that APIs
+      # exist which the Node this project supports does not have, and the type
+      # check is the only place that would notice. It moves with the platform
+      # decision, not on its own schedule.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
       - name: Version sync check
         run: npm run check:versions
 
+      # One Node major across the Dockerfile, this file's node-version,
+      # `engines` and `@types/node`. Cheap, and it is the only thing that
+      # notices a base-image bump nothing else here builds.
+      - name: Node version check
+        run: npm run check:node
+
       # oxlint (style/correctness) then tsc over src AND test. Hermetic: every
       # rule and every opt-out is pinned in .oxlintrc.json, in the commit.
       - name: Lint and type check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -422,30 +422,16 @@ jobs:
 
       # Runs the image on its own architecture — the arm64 variant is exercised
       # on an arm64 runner, which is the whole reason for the matrix. The runner
-      # needs no toolchain of its own: node runs inside the image, grep does the
-      # asserting, so this works on any hosted image.
+      # needs no toolchain of its own: node runs inside the image.
+      #
+      # The assertions live in scripts/smoke-image.sh, shared with the
+      # post-publish check in the merge job below (and runnable by hand against
+      # a local `docker build`). Two copies of "is this image any good?" drift;
+      # one does not. It starts the server and waits for the image's own
+      # HEALTHCHECK, so a container that builds but cannot come up fails HERE,
+      # before the push, rather than on a user's first pull.
       - name: Smoke-test the image on its own architecture
-        run: |
-          set -euo pipefail
-          # `docker run <image> --help` does NOT reach the server: node:24-alpine
-          # ships an ENTRYPOINT that turns a leading `-` argument into a `node`
-          # flag, so that prints Node's help and exits 0 — a smoke test that
-          # passes without ever starting this program. Name the command.
-          docker run --rm ccu-mcp:smoke node dist/index.js --help > help.txt
-          grep -q "ccu-mcp" help.txt
-
-          info=$(docker run --rm --entrypoint node ccu-mcp:smoke \
-            -p 'JSON.stringify(require("/app/dist/build-info.json"))')
-          echo "build-info: $info"
-
-          # The failure this catches: a build-arg rename or a .dockerignore
-          # change silently returns the image to reporting nothing about itself,
-          # and nothing else in the release would notice.
-          want="${GITHUB_SHA:0:7}"
-          if ! printf '%s' "$info" | grep -q "\"commit\":\"${want}\""; then
-            echo "::error::Image build-info does not report commit ${want}; BUILD_COMMIT did not reach gen-build-info.mjs."
-            exit 1
-          fi
+        run: EXPECT_COMMIT="${GITHUB_SHA:0:7}" bash scripts/smoke-image.sh ccu-mcp:smoke
 
       # Pushed by digest, not by tag: two architectures pushing to the same tag
       # would race, and the loser's manifest would be the one users pull. The
@@ -593,9 +579,10 @@ jobs:
 
           # Pulls the tag as any user would; on this runner that resolves to the
           # amd64 manifest. The arm64 half was run on an arm64 runner before it
-          # was ever pushed.
-          docker run --rm "${IMAGE}:${version}" node dist/index.js --help > help.txt
-          grep -q "ccu-mcp" help.txt
+          # was ever pushed. Same script as the pre-push smoke test, so what is
+          # asserted about the published tag is what was asserted about the
+          # build — including that the server comes up and /health answers.
+          EXPECT_COMMIT="${GITHUB_SHA:0:7}" bash scripts/smoke-image.sh "${IMAGE}:${version}"
 
       # No `if: always()` here, unlike the npm summary above: this one has
       # nothing to report but success, and printing a `docker pull` line for a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,23 @@ now carrying its `cause`, so upgrading is optional unless you want the image.
   now carry the commit and tag in, and the release asserts they arrived rather
   than trusting that they did. A local `docker build` without them behaves as
   before.
+- **A release starts the image and waits for it to report healthy** — on each
+  architecture before the push, and once more against the published tag
+  afterwards. The image's own `HEALTHCHECK` has to go green and `/health` has
+  to answer on the *published* port, which is the part an in-container probe
+  cannot vouch for. `scripts/smoke-image.sh` holds the assertions, so the
+  pre-push and post-publish checks cannot drift apart and you can run the same
+  ones against a local build:
+
+  ```sh
+  docker build -t ccu-mcp:local . && bash scripts/smoke-image.sh ccu-mcp:local
+  ```
+- **One Node major, enforced.** `npm run check:node` fails the build when the
+  Dockerfile, the workflows' `node-version`, `engines` and `@types/node` stop
+  naming the same major. The Node version lives in four files that no single
+  change touches and nothing in `build-and-test` builds the Dockerfile, so a
+  base-image bump could reach the published image having never run a test —
+  which is exactly what #169 did.
 
 - **The MCP registry and Smithery publish from the release workflow** (#160,
   #161), on the same OIDC identity and the same single approval as npm.
@@ -105,17 +122,19 @@ now carrying its `cause`, so upgrading is optional unless you want the image.
 
 ### Dependencies
 
-- Container base image moved from `node:24-alpine` to **`node:26-alpine`**
-  (#169). The published image therefore runs Node 26; `package.json` still
-  declares `engines: node >=24`, which is what applies when you run the server
-  from npm rather than from the image. The image was built, started and
-  health-checked on both architectures on the new base before this release.
+- **The container image runs Node 24**, the Active LTS line, matching
+  `engines: node >=24` and the version CI runs the tests on. A Dependabot PR
+  briefly moved the base to `node:26-alpine` (#169) and was reverted: 26 does
+  not reach LTS until October 2026, and nothing in this project had ever
+  executed a test on it. Moving Node majors is now one deliberate PR that
+  changes all four places together (see *Added*, above).
 - `undici` 8.9.0 → 8.10.0, `ip-address` 10.2.0 → 10.4.0 and the transitive
-  advisories cleared with it (#163, #164, #166); dev-only bumps to `oxlint` and
-  `@types/node` (#165, #167, #170).
+  advisories cleared with it (#163, #164, #166); dev-only bumps to `oxlint`
+  (#165, #170). `@types/node` stays on the 24 line for the reason above.
 - Dependabot now watches the Dockerfile's base image as well as npm and the
   pinned GitHub Actions — a stale base is something this project ships now, not
-  something a user picks up on their next local build.
+  something a user picks up on their next local build. It is configured **not**
+  to propose a `node` or `@types/node` major on its own.
 
 ## v1.9.1 — 2026-08-01
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM node:26-alpine AS builder
+# Node 24, not the newest tag. This project runs ONE Node major everywhere —
+# `engines`, `@types/node`, every workflow's `node-version` and both stages
+# here — and 24 is the one under Active LTS support (26 becomes LTS in October
+# 2026). It is also the only major the test suite ever executes on, so a base
+# image ahead of it would ship users a configuration nothing here has run.
+# scripts/check-node-version.mjs fails the build if these four drift apart.
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -17,7 +23,7 @@ ENV BUILD_COMMIT=${BUILD_COMMIT} \
     BUILD_TAG=${BUILD_TAG}
 RUN npm run build
 
-FROM node:26-alpine
+FROM node:24-alpine
 # `image.source` is not decoration: GHCR links a package to a repository by this
 # label, and that link is what carries the README, the licence and the "published
 # by" provenance on the package page. Without it the image floats unattached.

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -228,6 +228,16 @@ diverges from the code. Countermeasures:
   the runner treats a missing corpus as a hard failure rather than a clean run.
   Inputs discovered by a run accumulate in a cache alongside those seeds, never
   inside them, so what each night starts from is still a reviewed set.
+- The published container image is *run* before it is published, not merely
+  built: on each architecture the release starts it, waits for the image's own
+  `HEALTHCHECK` to report healthy and asks `/health` from outside the container
+  (`scripts/smoke-image.sh`), then repeats that against the published tag. A
+  build that succeeds and a server that comes up are different claims.
+- The platform the image runs on is pinned to the one the tests run on:
+  `scripts/check-node-version.mjs` fails the build if the Dockerfile,
+  `node-version`, `engines` and `@types/node` stop naming the same Node major,
+  and Dependabot is configured not to propose either major unattended. Without
+  it a base-image bump reaches users having executed no test at all.
 - CodeQL analyses both the source and the workflows on every PR and weekly, with
   its configuration in `.github/workflows/codeql.yml` rather than in repository
   settings — so what is scanned, and with which query suite, is reviewable in a

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -311,9 +311,14 @@ milestone — it's the source of the `Closes #N` list in the release PR.
    - One job per architecture on a runner of that architecture (`ubuntu-latest`
      and `ubuntu-24.04-arm`). No QEMU — emulated builds are slow and can fail
      for reasons that have nothing to do with the code.
-   - Each architecture is **built, loaded and run** (`--help`, plus an assert
-     that `build-info.json` carries the release commit) *before* it is pushed.
-     A broken image never reaches the registry.
+   - Each architecture is **built, loaded and run** *before* it is pushed:
+     `scripts/smoke-image.sh` asserts `--help` reaches this program, that
+     `build-info.json` carries the release commit, that the image's own
+     `HEALTHCHECK` reports healthy, and that `/health` answers on the published
+     port. A broken image never reaches the registry. The same script runs
+     again against the published tag, so the pre-push and post-publish checks
+     cannot drift; run it yourself against a local `docker build` with
+     `bash scripts/smoke-image.sh <image>`.
    - Both are pushed **by digest**; `docker-manifest` then assembles them into
      the `X.Y.Z` and `latest` tags, refusing to tag at all if fewer than two
      digests arrived. `latest` is skipped for a GitHub pre-release.
@@ -410,6 +415,8 @@ After publishing:
 | GitHub Release exists but npm/registry don't | published the release before the `publish` commands | run `npm publish` + `mcp-publisher publish` from the tagged checkout |
 | `docker-manifest` fails with "Expected 2 per-architecture digests" | one matrix leg failed; `fail-fast: false` let the other finish | fix the failing architecture and re-run the job — no tag was written, so nothing is half-published |
 | Image smoke test fails on "does not report commit" | `BUILD_COMMIT` stopped reaching `gen-build-info.mjs` (build-arg renamed, `ARG` dropped from the builder stage) | reconcile `Dockerfile` and the `build-args:` block; the image would otherwise ship with null provenance |
+| Image smoke test fails on "never reported healthy" | the server inside the image does not come up — the container logs are printed right below the error | reproduce locally with `bash scripts/smoke-image.sh <image>`; nothing was pushed |
+| `build-and-test` fails on "Node version drift" | the Dockerfile, a workflow's `node-version`, `engines` or `@types/node` disagree on the Node major | move all four in one PR — Dependabot is configured not to propose either major alone |
 | GHCR package page has no README or licence | `org.opencontainers.image.source` label missing or not matching the repo URL | restore the label in the Dockerfile's final stage and re-run the release jobs |
 
 ## Backports between `dev` and `main`

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@jazzer.js/core": "^4.0.0",
-        "@types/node": "^26.1.0",
+        "@types/node": "^24.13.3",
         "@vitest/coverage-v8": "^4.1.8",
         "fast-check": "^4.9.0",
         "oxlint": "^1.76.0",
@@ -1255,13 +1255,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -4273,9 +4273,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "test:watch": "vitest",
     "lint": "oxlint src test scripts fuzz && tsc --noEmit && tsc -p tsconfig.test.json",
     "check:versions": "node scripts/check-version-sync.mjs",
+    "check:node": "node scripts/check-node-version.mjs",
     "version": "node scripts/sync-server-version.mjs && git add server.json",
-    "prepublishOnly": "npm run check:versions && npm run lint && npm test",
+    "prepublishOnly": "npm run check:versions && npm run check:node && npm run lint && npm test",
     "fuzz": "bash scripts/fuzz.sh",
     "build:mcpb": "bash scripts/build-mcpb.sh"
   },
@@ -61,7 +62,7 @@
   },
   "devDependencies": {
     "@jazzer.js/core": "^4.0.0",
-    "@types/node": "^26.1.0",
+    "@types/node": "^24.13.3",
     "@vitest/coverage-v8": "^4.1.8",
     "fast-check": "^4.9.0",
     "oxlint": "^1.76.0",

--- a/scripts/check-node-version.mjs
+++ b/scripts/check-node-version.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Failsafe gate: ONE Node major, everywhere. Exits non-zero (with a
+// remediation hint) when the four places that pick a Node version disagree.
+//
+// Why this exists: the Node major lives in four files that no single change
+// touches, and nothing here builds the Dockerfile before a release. When
+// Dependabot auto-merged `node:24-alpine` -> `node:26-alpine` (#169), every
+// check stayed green — the published container would have been the first thing
+// to run that major, on a base the test suite had never executed on. An
+// average of green checks hid it; this reads the four numbers and compares.
+//
+// Checks (package.json `engines.node` is the reference — it is the floor the
+// package publicly claims, and the number consumers actually depend on):
+//   1. Dockerfile   FROM node:<major>-…    == engines major, every stage
+//   2. workflows    node-version: "<major>" == engines major, every occurrence
+//   3. package.json @types/node ^<major>   == engines major
+//
+// A source that matches NOTHING is a failure, not a pass: a Dockerfile with no
+// `FROM node:` line, or a workflow directory with no `node-version:` anywhere,
+// means this gate has quietly stopped checking the thing it was written for.
+//
+// Usage:
+//   node scripts/check-node-version.mjs      # exit 0 in sync, 1 on drift
+//
+// Test seam: PKG_FILE / DOCKERFILE / WORKFLOW_DIR point the check at synthetic
+// fixtures (see test/unit/node-version-sync.test.ts).
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const PKG = process.env.PKG_FILE ?? "package.json";
+const DOCKERFILE = process.env.DOCKERFILE ?? "Dockerfile";
+const WORKFLOW_DIR = process.env.WORKFLOW_DIR ?? ".github/workflows";
+
+const problems = [];
+const rows = [];
+
+const pkg = JSON.parse(readFileSync(PKG, "utf8"));
+
+// The reference. `>=24`, `^24.1.0`, `24.x` — take the first number in the
+// range, which is the major every form of it starts with.
+const enginesRange = pkg.engines?.node ?? "";
+const reference = /(\d+)/.exec(enginesRange)?.[1] ?? null;
+rows.push([`${PKG} engines.node`, enginesRange || "(missing)"]);
+if (reference === null) {
+  console.error(`::error::${PKG} engines.node "${enginesRange}" has no major version to read.`);
+  process.exit(1);
+}
+
+const expect = (label, found, where) => {
+  rows.push([label, where]);
+  if (found !== reference) {
+    problems.push(`${label} is Node ${found}, but ${PKG} engines.node is ">=${reference}"`);
+  }
+};
+
+// 1. Dockerfile — every stage. Multi-stage builds have caught this before:
+// bumping the runtime stage and forgetting the builder compiles on one major
+// and runs on another.
+const dockerfile = readFileSync(DOCKERFILE, "utf8");
+const fromLines = [...dockerfile.matchAll(/^FROM\s+node:(\d+)(\S*)/gm)];
+if (fromLines.length === 0) {
+  problems.push(`${DOCKERFILE} has no \`FROM node:<major>\` line — this gate has nothing to check`);
+}
+fromLines.forEach((m, i) => {
+  expect(`${DOCKERFILE} FROM[${i}]`, m[1], `node:${m[1]}${m[2]}`);
+});
+
+// 2. Workflows — every `node-version:`, quoted or not. setup-node's version is
+// what CI executes the tests on; it is the claim `engines` makes, tested.
+let workflowHits = 0;
+const workflows = readdirSync(WORKFLOW_DIR)
+  .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+  .sort();
+for (const file of workflows) {
+  const text = readFileSync(join(WORKFLOW_DIR, file), "utf8");
+  for (const m of text.matchAll(/node-version:\s*["']?(\d+)/g)) {
+    workflowHits += 1;
+    expect(`${file} node-version`, m[1], m[1]);
+  }
+}
+if (workflowHits === 0) {
+  problems.push(`no \`node-version:\` found in ${WORKFLOW_DIR} — this gate has nothing to check`);
+}
+
+// 3. @types/node — types from a newer major describe APIs the supported Node
+// does not have, and `tsc` is the only thing that would ever notice.
+const typesRange = pkg.devDependencies?.["@types/node"];
+if (typesRange === undefined) {
+  problems.push(`${PKG} has no @types/node devDependency — the type check has no Node types to pin`);
+} else {
+  const typesMajor = /(\d+)/.exec(typesRange)?.[1] ?? null;
+  if (typesMajor === null) {
+    problems.push(`${PKG} @types/node "${typesRange}" has no major version to read`);
+  } else {
+    expect(`${PKG} @types/node`, typesMajor, typesRange);
+  }
+}
+
+const width = Math.max(...rows.map(([label]) => label.length));
+for (const [label, value] of rows) {
+  console.log(`  ${label.padEnd(width)}  ${value}`);
+}
+console.log();
+
+if (problems.length > 0) {
+  console.error("Node version drift:");
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error();
+  console.error("Fix: move all four together, in one PR — Dockerfile (both stages),");
+  console.error("every workflow's node-version, package.json engines and @types/node.");
+  console.error("Dependabot is configured NOT to propose either major on its own.");
+  process.exit(1);
+}
+
+console.log(`Node ${reference} everywhere.`);

--- a/scripts/smoke-image.sh
+++ b/scripts/smoke-image.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Smoke-test a ccu-mcp container image: does it run, does it know what it was
+# built from, and does the server inside it actually answer?
+#
+# Used by BOTH container jobs in .github/workflows/publish.yml — the
+# per-architecture build (before anything is pushed) and the published
+# manifest list afterwards — so the pre-push and post-push checks cannot drift
+# apart, and so the same assertions can be run by hand against a local build:
+#
+#   docker build -t ccu-mcp:local . && bash scripts/smoke-image.sh ccu-mcp:local
+#
+# EXPECT_COMMIT  seven-character commit the image must report in build-info
+#                (the release passes it; a local build has nothing to compare
+#                against, so it is optional)
+# SMOKE_PORT     host port for the external health probe (default 3000)
+set -euo pipefail
+
+image="${1:-}"
+if [ -z "$image" ]; then
+  echo "usage: $0 <image-ref>" >&2
+  exit 2
+fi
+port="${SMOKE_PORT:-3000}"
+container="ccu-mcp-smoke-$$"
+
+cleanup() { docker rm -f "$container" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# 1. The program starts and identifies itself.
+#
+# `docker run <image> --help` does NOT reach the server: node:24-alpine ships
+# an ENTRYPOINT that turns a leading `-` argument into a `node` flag, so that
+# prints Node's help and exits 0 — a smoke test that passes without ever
+# starting this program. Name the command.
+docker run --rm "$image" node dist/index.js --help > "${TMPDIR:-/tmp}/ccu-help.$$"
+grep -q "ccu-mcp" "${TMPDIR:-/tmp}/ccu-help.$$"
+rm -f "${TMPDIR:-/tmp}/ccu-help.$$"
+
+# 2. The image knows its own provenance. `.dockerignore` excludes .git, so
+# BUILD_COMMIT/BUILD_TAG build args are the only way the commit reaches
+# get_system_info; a build-arg rename or a .dockerignore change silently
+# returns every published image to reporting nulls about itself, and nothing
+# else in a release would notice.
+info=$(docker run --rm --entrypoint node "$image" \
+  -p 'JSON.stringify(require("/app/dist/build-info.json"))')
+echo "build-info: $info"
+if [ -n "${EXPECT_COMMIT:-}" ]; then
+  if ! printf '%s' "$info" | grep -q "\"commit\":\"${EXPECT_COMMIT}\""; then
+    echo "::error::Image build-info does not report commit ${EXPECT_COMMIT}; BUILD_COMMIT did not reach gen-build-info.mjs."
+    exit 1
+  fi
+fi
+
+# 3. The claim a release actually makes: pull this and you get a server that
+# comes up. Everything above is satisfied by an image whose listener never
+# binds — a bad config default, a missing dist/ file on a path `--help` does
+# not touch, a native dependency that only fails at listen() time.
+#
+# Dummy CCU coordinates because the server refuses to boot without them. It
+# does not dial the box until a tool is called, and unauthenticated /health is
+# liveness only (it deliberately reports nothing about the session), so this
+# needs neither a CCU nor real credentials.
+#
+# The --health-* flags override the Dockerfile's production intervals (30s
+# between probes, 15s start period) without replacing the probe itself: what is
+# being exercised is still the HEALTHCHECK shipped in the image, which is what
+# a user's orchestrator reads to decide whether this container is up.
+docker run -d --name "$container" \
+  -p "127.0.0.1:${port}:3000" \
+  -e CCU_HOST=127.0.0.1 \
+  -e CCU_PASSWORD=smoke \
+  --health-interval=2s \
+  --health-start-period=1s \
+  --health-retries=3 \
+  "$image" > /dev/null
+
+status=starting
+for _ in $(seq 1 45); do
+  if [ "$(docker inspect --format '{{.State.Running}}' "$container")" != "true" ]; then
+    status=exited
+    break
+  fi
+  status=$(docker inspect --format '{{.State.Health.Status}}' "$container")
+  if [ "$status" = "healthy" ] || [ "$status" = "unhealthy" ]; then
+    break
+  fi
+  sleep 1
+done
+
+if [ "$status" != "healthy" ]; then
+  echo "::error::Image never reported healthy (last status: ${status})."
+  docker logs "$container" || true
+  exit 1
+fi
+echo "HEALTHCHECK: healthy"
+
+# The healthcheck above probes loopback INSIDE the container, and would pass
+# just as happily if the listener bound to 127.0.0.1 only — in which case
+# `docker run -p` publishes a port that answers nothing and every user's first
+# request fails. Ask from outside, the way a user does.
+body=$(curl -fsS --max-time 5 "http://127.0.0.1:${port}/health")
+echo "GET /health: $body"
+if ! printf '%s' "$body" | grep -q '"status":"ok"'; then
+  echo "::error::/health did not report ok on the published port."
+  docker logs "$container" || true
+  exit 1
+fi
+
+echo "Smoke test passed: ${image}"

--- a/test/unit/node-version-sync.test.ts
+++ b/test/unit/node-version-sync.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+const CHECK = join(root, "scripts/check-node-version.mjs");
+
+const PKG = (engines = ">=24", types = "^24.1.0") =>
+  JSON.stringify({ name: "y", version: "1.0.0", engines: { node: engines }, devDependencies: { "@types/node": types } });
+
+const DOCKERFILE = (builder = 24, runtime = builder) =>
+  `FROM node:${builder}-alpine AS builder\nRUN npm ci\n\nFROM node:${runtime}-alpine\nCMD ["node", "dist/index.js"]\n`;
+
+const WORKFLOW = (version = 24) =>
+  `name: CI\njobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v6\n        with:\n          node-version: "${version}"\n`;
+
+describe("check-node-version gate", () => {
+  let dir: string;
+  let pkgFile: string;
+  let dockerfile: string;
+  let workflowDir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nodever-"));
+    pkgFile = join(dir, "package.json");
+    dockerfile = join(dir, "Dockerfile");
+    workflowDir = join(dir, "workflows");
+    mkdirSync(workflowDir);
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const runCheck = (): { code: number; out: string } => {
+    try {
+      const out = execFileSync("node", [CHECK], {
+        env: { ...process.env, PKG_FILE: pkgFile, DOCKERFILE: dockerfile, WORKFLOW_DIR: workflowDir },
+        encoding: "utf8",
+      });
+      return { code: 0, out };
+    } catch (e: any) {
+      return { code: e.status ?? 1, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+    }
+  };
+
+  const write = ({ pkg = PKG(), docker = DOCKERFILE(), workflow = WORKFLOW() } = {}) => {
+    writeFileSync(pkgFile, pkg);
+    writeFileSync(dockerfile, docker);
+    writeFileSync(join(workflowDir, "ci.yml"), workflow);
+  };
+
+  it("passes (exit 0) when all four places name the same major", () => {
+    write();
+    const { code, out } = runCheck();
+    expect(code).toBe(0);
+    expect(out).toContain("Node 24 everywhere.");
+  });
+
+  // The exact failure this gate was written for: Dependabot bumping the base
+  // image alone (#169), with every other check still green.
+  it("fails (exit 1) when the base image is ahead of engines", () => {
+    write({ docker: DOCKERFILE(26) });
+    const { code, out } = runCheck();
+    expect(code).toBe(1);
+    expect(out).toContain("Node version drift");
+  });
+
+  it("fails (exit 1) when only one build stage moved", () => {
+    write({ docker: DOCKERFILE(26, 24) });
+    expect(runCheck().code).toBe(1);
+  });
+
+  it("fails (exit 1) when a workflow runs a different major than the image", () => {
+    write({ workflow: WORKFLOW(26) });
+    expect(runCheck().code).toBe(1);
+  });
+
+  it("fails (exit 1) when @types/node is a major ahead of the supported Node", () => {
+    write({ pkg: PKG(">=24", "^26.1.0") });
+    const { code, out } = runCheck();
+    expect(code).toBe(1);
+    expect(out).toContain("@types/node");
+  });
+
+  // A gate that silently checks nothing is worse than no gate: it reports
+  // success for a file it never found.
+  it("fails (exit 1) when the Dockerfile has no FROM node: line", () => {
+    write({ docker: "FROM alpine:3.20\nCMD [\"true\"]\n" });
+    const { code, out } = runCheck();
+    expect(code).toBe(1);
+    expect(out).toContain("nothing to check");
+  });
+
+  it("fails (exit 1) when no workflow declares a node-version", () => {
+    write({ workflow: "name: CI\njobs:\n  build:\n    steps:\n      - run: true\n" });
+    const { code, out } = runCheck();
+    expect(code).toBe(1);
+    expect(out).toContain("nothing to check");
+  });
+
+  it("accepts an unquoted node-version, as YAML allows", () => {
+    write({ workflow: "name: CI\njobs:\n  build:\n    steps:\n      - with:\n          node-version: 24\n" });
+    expect(runCheck().code).toBe(0);
+  });
+});
+
+describe("live repo", () => {
+  it("Dockerfile, workflows, engines and @types/node all name one Node major", () => {
+    // Belt-and-suspenders, as with the version-sync gate: `npm test` goes red
+    // on real drift, not only the dedicated CI step.
+    const code = (() => {
+      try {
+        execFileSync("node", [CHECK], { cwd: root, encoding: "utf8" });
+        return 0;
+      } catch (e: any) {
+        return e.status ?? 1;
+      }
+    })();
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes the two gaps the container work left open, both rooted in the same
thing: nothing in `build-and-test` builds the Dockerfile, so the published
image is the first thing to run whatever base is in the tree.

## Pin, and harmonize

The Node major lives in four files that no single change touches: the
Dockerfile (twice), every workflow's `node-version`, `engines` and
`@types/node`. #169 auto-merged `node:24-alpine` → `node:26-alpine` with every
check green — that base would have reached users having executed no test.

- **Back to `node:24-alpine`.** 24 is the Active LTS line (26 reaches LTS in
  October 2026), the floor `engines: node >=24` claims, and the only major CI
  runs the suite on. `@types/node` moves back to the 24 line for the same
  reason: types from a newer major tell `tsc` that APIs exist which the
  supported Node does not have, and the type check is the only thing that would
  ever notice.
- **`scripts/check-node-version.mjs`** compares all four and fails on drift.
  Wired into `build-and-test`, into `prepublishOnly`, and — as with the
  version-sync gate — into a unit test, so plain `npm test` goes red on real
  drift as well. A source it finds no match in (a Dockerfile with no
  `FROM node:`, a workflow dir with no `node-version:`) is a **failure**, not a
  pass: a gate that has silently stopped checking is worse than no gate.
- **Dependabot no longer proposes either major on its own** — `node` and
  `@types/node` majors are `ignore`d, with the reason recorded in the file.
  Patches and minors still flow. Moving Node is one deliberate PR touching all
  four places, which is what the gate then verifies.

Moving to 26 in October is that one PR.

## Promote the health check

The release built each image and ran `--help`. An image whose listener never
binds passes that. It now:

- starts the container and waits for **the image's own `HEALTHCHECK`** to
  report healthy (the probe a user's orchestrator reads, exercised as shipped —
  only the intervals are overridden), and
- asks `/health` **from outside the container**. The in-container probe cannot
  distinguish a listener on `0.0.0.0` from one on loopback, and the second
  publishes a port that answers nothing.

Both live in `scripts/smoke-image.sh`, called by the pre-push per-architecture
job *and* by the post-publish check against the released tag — so what is
asserted about the published image is what was asserted about the build, and
you can run the same thing locally:

```sh
docker build -t ccu-mcp:local . && bash scripts/smoke-image.sh ccu-mcp:local
```

## Verification

- Image built on the 24 base; smoke script green — HEALTHCHECK healthy,
  `GET /health` → `{"status":"ok"}`, build-info commit asserted.
- **Mutation-checked**: with boot deliberately broken the script exits 1 and
  prints the container logs. The gate script was mutation-checked through its
  unit tests (base image ahead, one stage moved, workflow ahead, types ahead,
  and both "nothing to check" paths).
- `shellcheck` and `actionlint` clean; `npm run lint` and 478 tests pass.

Note for the release: `main` currently carries the v1.10.0 commit with the 26
base, and the tag has not been cut. The CHANGELOG entry for v1.10.0 is updated
here rather than opening a new version, so the release PR into `main` should be
refreshed from `dev` before tagging.