### PR TITLE
Release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,21 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
-## v1.10.0 — 2026-08-18
+## v1.10.0 — 2026-08-19
 
-Container images, and a release that publishes itself.
+Container images, a release that publishes itself, and a pass over the MCP
+surface.
 `docker pull ghcr.io/claymore666/ccu-mcp` now works — for `linux/amd64` and
 `linux/arm64` — and a single approved GitHub Release publishes every target
 (npm, the MCP registry, Smithery, and the image) instead of four commands run
 by hand. The rest is project documentation and CI hardening from a sweep
 against the OpenSSF Best Practices **silver** criteria.
 
-**No behaviour changes to any tool.** The only change under `src/` is one error
-now carrying its `cause`, so upgrading is optional unless you want the image.
+**No behaviour changes to any tool** — every tool takes the same arguments and
+returns the same results. What changed around them is what a client sees on
+connect: the server now ships instructions, identifies itself with a display
+title, describes its resources in the listing, and can autocomplete prompt
+arguments from the live CCU.
 
 ### Added
 
@@ -74,6 +78,24 @@ now carrying its `cause`, so upgrading is optional unless you want the image.
   typescript-eslint because the latter's peer range stops at TypeScript 6 and
   this project builds on TypeScript 7.) The gate was mutation-tested before
   landing.
+- **Server instructions.** The `initialize` result now carries a short brief:
+  names resolve to addresses for you, reads are safe, writes reach real
+  hardware and a protected CCU needs `confirm: true`. It is the only guidance
+  that reaches the model without it choosing to call `help` first.
+- **Prompt arguments autocomplete** (`completions` capability). The `room`
+  arguments of `room-status` / `set-heating` and `device-info`'s `device` are
+  answered from the live CCU, so a client offers the rooms and devices this
+  installation actually has instead of asking the user to remember how one was
+  spelled in the WebUI. The lists are cached for 60 seconds — a burst of typing
+  is one CCU call, not one per keystroke — and any CCU failure yields no
+  suggestions rather than a failed completion.
+- **The server identifies itself.** `serverInfo` gained `title`
+  ("HomeMatic CCU"), `websiteUrl` and a `description` that mirrors
+  `server.json`, so the registry entry and the live handshake cannot say
+  different things. Prompts gained display titles, and resources now declare a
+  title and `application/json` on the *registration*, which is what puts them
+  in `resources/list` — a client can tell what it is about to fetch without
+  fetching it.
 - **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
 - **`GOVERNANCE.md`** — decision model, roles, and an honest account of the
   single-maintainer continuity gap.
@@ -119,6 +141,28 @@ now carrying its `cause`, so upgrading is optional unless you want the image.
   asserts the pending-timer count — previously both passed even if the
   behaviour under test was broken. Found by the new lint gate.
 - `readCaCert` now attaches the original error as `cause` when it rethrows.
+- **Two CodeQL findings closed at the source.** The `/health` branch ran its
+  own token verification *inside* a block guarded by the request path, so an
+  attacker-controlled value decided whether credentials were checked at all
+  (`js/user-controlled-bypass`). Verification now happens before path routing
+  and one verdict serves both the health endpoint and the auth gate —
+  behaviour unchanged, one `verify()` where there were two. The HTTPS e2e test
+  no longer reads its throwaway certificate back off disk to trust it
+  (`js/file-access-to-http`).
+- **`resources/subscribe` errors are no longer doubled.** An unknown URI came
+  back as `MCP error -32602: MCP error -32602: Unknown resource…`, because
+  `McpError` builds that prefix into its message and the client adds it again
+  on receipt.
+- **Documentation drift.** `docs/architecture.md` called the resource URIs
+  `ccu://…` (they are `homematic://…`); the README's `--version` example still
+  printed 1.8.1; `ROADMAP.md` listed the CodeQL and fuzzing-corpus work as
+  planned after it had shipped. The README now also states which MCP revisions
+  the server implements, and `SECURITY.md` records the static bearer token as
+  a considered deviation from the specification's OAuth flow rather than
+  leaving it unexplained.
+- **The MCPB bundle's smoke test pinned `2025-06-18`.** It passed only because
+  the server negotiates down, so it never exercised the revision actually
+  shipped; it now handshakes at `2025-11-25`.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ installed copy actually is, e.g. after updating:
 
 ```console
 $ npx ccu-mcp@latest --version
-1.8.1
+1.10.0
 ```
 
 Note that a bare `npx ccu-mcp` reuses the copy cached in `~/.npm/_npx` without
@@ -387,6 +387,21 @@ It also ships MCP **prompts** — ready-made workflows you can invoke from clien
 - `good-night` — prepare the house for night
 - `diagnostics` — check for device issues
 - `device-info` — detailed info about a device's capabilities and parameters
+
+The `room` and `device` arguments autocomplete: clients that support
+`completion/complete` offer the rooms and device names this CCU actually has,
+so there's no need to remember how a room was spelled in the WebUI.
+
+### MCP protocol revisions
+
+The server implements revision **`2025-11-25`** and negotiates down for older
+clients (`2025-06-18`, `2025-03-26`, `2024-11-05` are all accepted) — you do
+not need a particular client version. It advertises `tools`, `resources`
+(with `subscribe`), `prompts`, `completions` and `logging`.
+
+Revision `2026-07-28` — per-request protocol version, `server/discover` — is
+not implemented yet: the TypeScript SDK this server is built on does not
+support it at the time of writing, and this server follows the SDK.
 
 ## How it works
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@ year. Plans are not promises: this is a spare-time project with one maintainer,
 and the point of writing it down is so you can judge whether it is heading
 somewhere useful to you — not to commit to dates.
 
-Last reviewed: 2026-08-02 (v1.9.1).
+Last reviewed: 2026-08-19 (v1.10.0).
 
 ## Direction
 
@@ -28,13 +28,15 @@ making it safer and more predictable rather than larger.
   documented gap, not a hidden one — see
   [docs/assurance-case.md](docs/assurance-case.md).
 - **OpenSSF Scorecard** in CI ([#153](https://github.com/claymore666/ccu-mcp/issues/153)).
-- **CodeQL advanced setup** so the query suite is pinned in the commit rather
-  than tracking GitHub's default ([#156](https://github.com/claymore666/ccu-mcp/issues/156)).
-- **Persist the fuzzing corpus between nightly runs**
-  ([#155](https://github.com/claymore666/ccu-mcp/issues/155)). The corpus is
-  load-bearing — an empty one found nothing in 60s where a seeded one found
-  planted defects in under 20 — so throwing it away each night wastes most of
-  the value of running the fuzzer at all.
+
+Delivered in v1.10.0, kept here because the reasoning is still the record:
+CodeQL moved off GitHub's default setup into a workflow file, so the query
+suite is pinned in the commit and reviewable in a PR
+([#156](https://github.com/claymore666/ccu-mcp/issues/156)); and the fuzzing
+corpus now carries between nightly runs
+([#155](https://github.com/claymore666/ccu-mcp/issues/155)) — an empty corpus
+found nothing in 60s where a seeded one found planted defects in under 20, so
+discarding it each night wasted most of the value of running the fuzzer.
 
 ### Project continuity
 
@@ -45,7 +47,10 @@ making it safer and more predictable rather than larger.
 
 ### Maintenance
 
-- Track the MCP specification and SDK as they move.
+- Track the MCP specification and SDK as they move. The server implements
+  revision `2025-11-25` (negotiating down to `2024-11-05`), which is what the
+  TypeScript SDK currently tops out at; revision `2026-07-28` — per-request
+  protocol version, `server/discover` — lands here when the SDK supports it.
 - Keep working against current debmatic / OpenCCU / CCU3 firmware.
 - Keep dependencies current and advisories clear.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,7 +85,20 @@ behind each of these is in [docs/assurance-case.md](docs/assurance-case.md).
    not an authorisation system.
 4. It is safe to expose on the public internet. It is designed for a trusted
    LAN.
-5. It has had an external security review. It has not.
+5. **The HTTP transport speaks OAuth.** The MCP specification makes
+   authorization optional ("Implementations using an HTTP-based transport
+   **SHOULD** conform"), and describes an OAuth 2.1 flow with RFC 9728
+   protected-resource metadata and an authorization server. ccu-mcp
+   deliberately does not implement it: a LAN appliance bridging to one CCU
+   credential has no authorization server to point at, and one would add a
+   moving part without adding a decision — there is a single principal, and it
+   is the CCU user in the config. What it does implement is the token half —
+   `Authorization: Bearer` on every request, timing-safe comparison, rotation
+   with an overlap window, optional expiry, and an RFC 6750 `WWW-Authenticate`
+   challenge on 401. If you need per-user authorization in front of the
+   server, put a reverse proxy that does OAuth in front of it. This is a
+   considered deviation, not an oversight.
+6. It has had an external security review. It has not.
 
 ## Threat model
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,10 +58,18 @@ endpoint, idle-session reaping, and signal/stdin-EOF shutdown.
 - **28 tools**, grouped by intent across `tools/discovery.ts` (find things),
   `read.ts` (read state), `control.ts` (change state), `diagnostics.ts`,
   `targets.ts` (multi-CCU) and `meta.ts` (the in-server `help`).
-- **Resources** — `ccu://…` URIs for the list endpoints, device types and
-  system info, with `resources/subscribe` support.
+- **Resources** — `homematic://…` URIs for the list endpoints, device types and
+  system info, with `resources/subscribe` support. Each registration carries a
+  display title and `application/json`, so `resources/list` describes them
+  without a read.
 - **Prompts** — a handful of canned workflows (`check-windows`, `room-status`,
-  `set-heating`, `good-night`, `diagnostics`, `device-info`).
+  `set-heating`, `good-night`, `diagnostics`, `device-info`). Their `room` and
+  `device` arguments are completable: `completion/complete` answers from the
+  live CCU (`src/prompts/completions.ts`, 60-second cache, empty list on any
+  failure), which is what turns the `completions` capability on.
+- **Instructions** — the `initialize` result carries a short brief (names
+  resolve, writes are gated). It is the only guidance that reaches the model
+  without it deciding to call `help`.
 
 Every tool input is a **zod** schema. That is the allowlist: shapes, enums and
 ranges are declared, and anything else is rejected before a handler runs.

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -72,7 +72,10 @@ npx -y "@anthropic-ai/mcpb@${MCPB_VERSION}" validate "$stage/manifest.json"
 # Smoke test the thing that will actually run. A bundle that packs cleanly but
 # cannot start is the failure a validated manifest does not catch.
 echo "Smoke test: MCP initialize handshake against the staged server"
-handshake='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"build-mcpb","version":"1"}}}'
+# The revision this server actually implements. Pinning an older one still
+# passes — the server negotiates down — which is exactly why it would not test
+# what we ship. Bump this with the SDK.
+handshake='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"build-mcpb","version":"1"}}}'
 reply="$(printf '%s\n' "$handshake" \
     | CCU_HOST=127.0.0.1 CCU_USER=smoke CCU_PASSWORD=smoke \
       timeout 30 node "$stage/server/dist/index.js" --stdio 2>/dev/null | head -1 || true)"

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,18 @@ async function main(): Promise<void> {
           return;
         }
 
+        // Verify the bearer token BEFORE any path routing, so the request path
+        // — attacker-controlled — never decides whether credentials are checked
+        // at all; it only decides what an already-known-good/bad verdict means.
+        // (CodeQL js/user-controlled-bypass flagged the previous shape, where
+        // the /health branch ran its own verify() inside a path-guarded block.)
+        // Token parsing tolerates the case-insensitive scheme (RFC 7235);
+        // verify() is timing-safe across all currently-valid tokens (it hashes
+        // both sides and checks every entry without early return) and enforces
+        // expiry live (issue #52). One call now serves both consumers below.
+        const presented = extractBearerToken(req.headers.authorization ?? "");
+        const headerValid = authTokens.verify(presented);
+
         // Path routing: MCP is served on the root path only (README points
         // clients at the bare URL; "/mcp" accepted as a common convention).
         // Without this, the full protocol answered on ANY path, and a typo'd
@@ -270,19 +282,16 @@ async function main(): Promise<void> {
         const path = (req.url ?? "/").split("?")[0];
 
         // Health check endpoint (tolerate cache-busting query strings that
-        // uptime monitors append)
+        // uptime monitors append). Deliberately reachable without a token —
+        // uptime monitors need it — but a valid token unlocks the detailed
+        // body, which is why the verdict above is passed through rather than
+        // recomputed here.
         if (path === "/health" && req.method === "GET") {
-          const detailed = authTokens.verify(extractBearerToken(req.headers.authorization ?? ""));
-          handleHealthRequest(req, res, { session: targets.default.session, deviceTypeCache: targets.default.deviceTypeCache }, detailed);
+          handleHealthRequest(req, res, { session: targets.default.session, deviceTypeCache: targets.default.deviceTypeCache }, headerValid);
           return;
         }
 
-        // Auth check for MCP endpoints. Token parsing tolerates the
-        // case-insensitive scheme (RFC 7235); verify() is timing-safe across all
-        // currently-valid tokens (it hashes both sides and checks every entry
-        // without early return) and enforces expiry live (issue #52).
-        const presented = extractBearerToken(req.headers.authorization ?? "");
-        const headerValid = authTokens.verify(presented);
+        // Auth gate for the MCP endpoints (health has already returned above).
         if (!headerValid) {
           // Structured, greppable failure line so an external tool (fail2ban et
           // al.) can ban brute-force sources at the firewall — the server

--- a/src/prompts/completions.ts
+++ b/src/prompts/completions.ts
@@ -1,0 +1,79 @@
+import type { ServerDeps } from "../server.js";
+import type { CcuDevice } from "../ccu/types.js";
+import { withRetry } from "../middleware/retry.js";
+import { expectArray } from "../utils.js";
+
+/**
+ * Completion sources for prompt arguments (`completion/complete`).
+ *
+ * A completion request fires while the user is still typing, so it must be
+ * cheap and it must never fail loudly: an empty list is a fine answer, an
+ * exception in the middle of an autocomplete is not. Every fetch is therefore
+ * wrapped — any CCU failure yields no suggestions and the argument stays free
+ * text.
+ *
+ * The lists are cached for CACHE_MS. Without that, one keystroke would be one
+ * `Device.listAllDetail` against a small embedded box; with it, a burst of
+ * typing costs a single call. The TTL is short because rooms and device names
+ * change in the CCU WebUI while this server runs, and a name that autocompletes
+ * to something that no longer exists is worse than no suggestion.
+ */
+const CACHE_MS = 60_000;
+
+type Entry = { at: number; values: Promise<string[]> };
+
+export class CompletionSource {
+  private readonly cache = new Map<string, Entry>();
+
+  constructor(private readonly deps: ServerDeps) {}
+
+  /** Room names, filtered by what the user has typed so far. */
+  rooms = (typed: string): Promise<string[]> =>
+    this.filtered("Room.getAll", typed, (rows) =>
+      rows.map((r) => (r as { name?: unknown }).name).filter((n): n is string => typeof n === "string"),
+    );
+
+  /** Device names (not channels — a prompt argument names a device). */
+  devices = (typed: string): Promise<string[]> =>
+    this.filtered("Device.listAllDetail", typed, (rows) =>
+      (rows as CcuDevice[]).map((d) => d.name).filter((n): n is string => typeof n === "string"),
+    );
+
+  private async filtered(
+    method: string,
+    typed: string,
+    extract: (rows: unknown[]) => string[],
+  ): Promise<string[]> {
+    const all = await this.load(method, extract);
+    // Substring, case-insensitive: CCU names are commonly "OG Bad Heizung",
+    // so a user typing "bad" means the middle of the name at least as often as
+    // its start. An empty value asks for everything (the SDK caps at 100).
+    const needle = typed.toLowerCase();
+    return needle ? all.filter((v) => v.toLowerCase().includes(needle)) : all;
+  }
+
+  private load(method: string, extract: (rows: unknown[]) => string[]): Promise<string[]> {
+    const hit = this.cache.get(method);
+    if (hit && Date.now() - hit.at < CACHE_MS) return hit.values;
+
+    const { rateLimiter, logger } = this.deps;
+    const values = (async () => {
+      try {
+        await rateLimiter.acquire();
+        const rows = expectArray(
+          await withRetry(() => this.deps.session.call(method), method, logger, { rateLimiter }),
+          method,
+        );
+        return extract(rows);
+      } catch {
+        // No suggestions rather than a failed completion. Do not cache the
+        // failure for the full TTL — drop it so the next keystroke retries.
+        this.cache.delete(method);
+        return [];
+      }
+    })();
+
+    this.cache.set(method, { at: Date.now(), values });
+    return values;
+  }
+}

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -1,8 +1,25 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { completable } from "@modelcontextprotocol/sdk/server/completable.js";
+import type { ServerDeps } from "../server.js";
+import { CompletionSource } from "./completions.js";
 
-export function registerPrompts(server: McpServer): void {
-  server.registerPrompt("check-windows", { description: "Check all window/door sensors and report which are open" }, async () => ({
+/**
+ * Prompts carry a `title` as well as a `description`: the title is what a
+ * client puts in a slash-command menu, and "Room status" reads better there
+ * than the sentence explaining what it does.
+ *
+ * The `room` / `device` arguments are `completable()`, which is what makes the
+ * server advertise the `completions` capability at all — the SDK enables it the
+ * moment a prompt argument has a completer. Suggestions come from the live CCU
+ * (see completions.ts), so a client offers the rooms this installation actually
+ * has instead of asking the user to remember how a room was spelled.
+ */
+export function registerPrompts(server: McpServer, deps: ServerDeps): void {
+  const suggest = new CompletionSource(deps);
+  const roomArg = completable(z.string().describe("Room name"), (typed) => suggest.rooms(typed));
+
+  server.registerPrompt("check-windows", { title: "Check windows", description: "Check all window/door sensors and report which are open" }, async () => ({
     messages: [{ role: "user" as const, content: { type: "text" as const, text:
       "Check all window and door sensors: call list_devices (no type filter — the type arg is EXACT-match), " +
       "keep the devices whose type contains 'SWDO' or 'SCI' (e.g. HmIP-SWDO-I), then read them with get_values. " +
@@ -11,8 +28,9 @@ export function registerPrompts(server: McpServer): void {
   }));
 
   server.registerPrompt("room-status", {
+    title: "Room status",
     description: "Show current status of all devices in a room",
-    argsSchema: { room: z.string().describe("Room name") },
+    argsSchema: { room: roomArg },
   }, async ({ room }) => ({
     messages: [{ role: "user" as const, content: { type: "text" as const, text:
       `Show the current status of all devices in the room "${room}". ` +
@@ -22,9 +40,10 @@ export function registerPrompts(server: McpServer): void {
   }));
 
   server.registerPrompt("set-heating", {
+    title: "Set heating",
     description: "Set heating temperature in a room",
     argsSchema: {
-      room: z.string().describe("Room name"),
+      room: roomArg,
       temperature: z.string().describe("Target temperature in °C"),
     },
   }, async ({ room, temperature }) => ({
@@ -36,7 +55,7 @@ export function registerPrompts(server: McpServer): void {
     }}],
   }));
 
-  server.registerPrompt("good-night", { description: "Prepare the house for night" }, async () => ({
+  server.registerPrompt("good-night", { title: "Good night", description: "Prepare the house for night" }, async () => ({
     messages: [{ role: "user" as const, content: { type: "text" as const, text:
       "Prepare the house for night:\n" +
       "1. Check all window/door sensors and report any that are open\n" +
@@ -46,7 +65,7 @@ export function registerPrompts(server: McpServer): void {
     }}],
   }));
 
-  server.registerPrompt("diagnostics", { description: "Check for device issues" }, async () => ({
+  server.registerPrompt("diagnostics", { title: "Diagnostics", description: "Check for device issues" }, async () => ({
     messages: [{ role: "user" as const, content: { type: "text" as const, text:
       "Run a diagnostic check on the HomeMatic system:\n" +
       "1. Use get_service_messages to find active issues (low battery, unreachable devices)\n" +
@@ -59,8 +78,11 @@ export function registerPrompts(server: McpServer): void {
   }));
 
   server.registerPrompt("device-info", {
+    title: "Device info",
     description: "Show detailed info about a device",
-    argsSchema: { device: z.string().describe("Device name or address") },
+    argsSchema: {
+      device: completable(z.string().describe("Device name or address"), (typed) => suggest.devices(typed)),
+    },
   }, async ({ device }) => ({
     messages: [{ role: "user" as const, content: { type: "text" as const, text:
       `Show detailed information about the device "${device}". ` +

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -6,13 +6,21 @@ import { VERSION, expectArray } from "../utils.js";
 // CCU-backed list resources: one JSON-RPC method each; polled for change
 // notifications (see poller.ts POLLABLE).
 const CCU_LIST_RESOURCES = [
-  { name: "devices", uri: "homematic://devices", description: "All devices with channels", method: "Device.listAllDetail" },
-  { name: "rooms", uri: "homematic://rooms", description: "All rooms with channel assignments", method: "Room.getAll" },
-  { name: "functions", uri: "homematic://functions", description: "All function groups", method: "Subsection.getAll" },
-  { name: "programs", uri: "homematic://programs", description: "All automation programs", method: "Program.getAll" },
-  { name: "sysvars", uri: "homematic://sysvars", description: "All system variables with values", method: "SysVar.getAll" },
-  { name: "interfaces", uri: "homematic://interfaces", description: "Available communication interfaces", method: "Interface.listInterfaces" },
+  { name: "devices", title: "Devices", uri: "homematic://devices", description: "All devices with channels", method: "Device.listAllDetail" },
+  { name: "rooms", title: "Rooms", uri: "homematic://rooms", description: "All rooms with channel assignments", method: "Room.getAll" },
+  { name: "functions", title: "Functions", uri: "homematic://functions", description: "All function groups", method: "Subsection.getAll" },
+  { name: "programs", title: "Programs", uri: "homematic://programs", description: "All automation programs", method: "Program.getAll" },
+  { name: "sysvars", title: "System variables", uri: "homematic://sysvars", description: "All system variables with values", method: "SysVar.getAll" },
+  { name: "interfaces", title: "Interfaces", uri: "homematic://interfaces", description: "Available communication interfaces", method: "Interface.listInterfaces" },
 ] as const;
+
+/**
+ * Every resource here serves `application/json`. Declaring it on the
+ * REGISTRATION (not only on the contents returned by a read) is what puts it in
+ * `resources/list`, so a client can tell what it is about to fetch without
+ * fetching it — same reason each one carries a display `title`.
+ */
+const JSON_MIME = "application/json";
 
 const DEVICE_TYPES_URI = "homematic://device-types";
 const SYSTEM_URI = "homematic://system";
@@ -39,26 +47,26 @@ export function registerResources(server: McpServer, deps: ServerDeps): void {
   };
 
   for (const r of CCU_LIST_RESOURCES) {
-    server.registerResource(r.name, r.uri, { description: r.description }, async () => {
+    server.registerResource(r.name, r.uri, { title: r.title, description: r.description, mimeType: JSON_MIME }, async () => {
       // Guard like the sibling list_* tools: a malformed CCU/proxy result
       // (result:null) must surface as an error, not be handed to a subscriber
       // as the literal text "null" indistinguishable from an empty payload.
       const list = expectArray(await ccuRead(r.method), r.method);
-      return { contents: [{ uri: r.uri, text: JSON.stringify(list, null, 2), mimeType: "application/json" }] };
+      return { contents: [{ uri: r.uri, text: JSON.stringify(list, null, 2), mimeType: JSON_MIME }] };
     });
   }
 
   // The two non-polled resources: subscriptions are accepted but change
   // notifications are not emitted for them (locally-derived / near-static).
-  server.registerResource("device-types", DEVICE_TYPES_URI, { description: "Cached device type schemas (not change-notified)" }, async () => ({
-    contents: [{ uri: DEVICE_TYPES_URI, text: JSON.stringify(deps.deviceTypeCache.getAll(), null, 2), mimeType: "application/json" }],
+  server.registerResource("device-types", DEVICE_TYPES_URI, { title: "Device types", description: "Cached device type schemas (not change-notified)", mimeType: JSON_MIME }, async () => ({
+    contents: [{ uri: DEVICE_TYPES_URI, text: JSON.stringify(deps.deviceTypeCache.getAll(), null, 2), mimeType: JSON_MIME }],
   }));
 
-  server.registerResource("system", SYSTEM_URI, { description: "CCU system info (not change-notified)" }, async () => {
+  server.registerResource("system", SYSTEM_URI, { title: "System info", description: "CCU system info (not change-notified)", mimeType: JSON_MIME }, async () => {
     const info: Record<string, unknown> = { serverVersion: VERSION };
     for (const [key, method] of [["version", "CCU.getVersion"], ["serial", "CCU.getSerial"]] as const) {
       try { info[key] = await ccuRead(method); } catch { info[key] = null; }
     }
-    return { contents: [{ uri: SYSTEM_URI, text: JSON.stringify(info, null, 2), mimeType: "application/json" }] };
+    return { contents: [{ uri: SYSTEM_URI, text: JSON.stringify(info, null, 2), mimeType: JSON_MIME }] };
   });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,13 +48,61 @@ export interface ServerDeps {
  */
 export const serverSubscriptions = new WeakMap<McpServer, Set<string>>();
 
+/**
+ * Sent to the client in the `initialize` result and, in most clients, put in
+ * front of the model before it calls anything. It is the one piece of guidance
+ * that arrives without the model choosing to ask for it — `help` only helps a
+ * client that decides to call it — so it carries the two things that change
+ * whether a first call succeeds: names are resolved for you, and writes to a
+ * protected CCU need `confirm: true`.
+ */
+const INSTRUCTIONS = `Controls a HomeMatic CCU (debmatic, CCU3 or OpenCCU) over its JSON-RPC API.
+
+Start with list_devices / list_rooms to discover what exists; addresses look like \
+"000EDBE9A1B4F4:1" (device:channel). Most tools accept a device or channel NAME as \
+well as an address and resolve it for you, so there is no need to look an address up \
+first unless the name is ambiguous.
+
+Reads (get_*, list_*) are always safe. Writes (set_*, put_paramset, execute_program, \
+create/delete system variable, assign/unassign channel, run_script) reach real \
+hardware — heating, locks, sockets. A CCU configured as protected refuses them unless \
+called with confirm: true, and run_script plus delete_system_variable require it on \
+every single call.
+
+Call help for the full tool list, the argument conventions and worked examples. With \
+several CCUs configured, list_ccu_targets shows them, get_connection_info reports the \
+active one, use_ccu switches it, and read tools take an optional target for a \
+single-call read elsewhere.`;
+
+/**
+ * `new McpError(code, msg)` builds its `message` as "MCP error <code>: <msg>",
+ * and that whole string is what goes on the wire — where the client prefixes it
+ * a second time, so the user reads
+ * "MCP error -32602: MCP error -32602: Unknown resource…". Reset `message` to
+ * the bare text after construction: `code` still travels in the JSON-RPC error
+ * object, so nothing is lost and the client renders one prefix.
+ */
+function invalidParams(message: string): McpError {
+  const err = new McpError(ErrorCode.InvalidParams, message);
+  err.message = message;
+  return err;
+}
+
 export function createMcpServer(deps: ServerDeps): McpServer {
   const server = new McpServer(
     {
       name: "ccu-mcp",
+      // title/description/websiteUrl are the human-facing half of
+      // `Implementation`: a client listing servers shows these rather than the
+      // package name. `description` mirrors server.json's, so the registry
+      // entry and the live handshake say the same thing.
+      title: "HomeMatic CCU",
+      description: "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
+      websiteUrl: "https://github.com/claymore666/ccu-mcp",
       version: VERSION,
     },
     {
+      instructions: INSTRUCTIONS,
       capabilities: {
         tools: {},
         // subscribe is backed by the handlers registered below; the poller
@@ -74,7 +122,7 @@ export function createMcpServer(deps: ServerDeps): McpServer {
   registerMetaTools(server, deps);
   registerTargetTools(server, deps);
   registerResources(server, deps);
-  registerPrompts(server);
+  registerPrompts(server, deps);
 
   // resources/subscribe support: the SDK's McpServer registers no handler for
   // it, so back the advertised capability ourselves.
@@ -84,8 +132,7 @@ export function createMcpServer(deps: ServerDeps): McpServer {
     // Reject unknown URIs: silently accepting a typo would leave the client
     // waiting forever for notifications that can never come.
     if (!RESOURCE_URIS.includes(req.params.uri)) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
+      throw invalidParams(
         `Unknown resource: ${req.params.uri}. Valid URIs: ${RESOURCE_URIS.join(", ")}`,
       );
     }

--- a/test/e2e/http-transport.test.ts
+++ b/test/e2e/http-transport.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createServer, request, type Server, type IncomingHttpHeaders } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { AddressInfo } from "node:net";
@@ -631,14 +631,21 @@ describe.skipIf(distMissing || !HAVE_OPENSSL)("HTTPS transport e2e (native TLS, 
     // so a CN-only cert would fail verification against the loopback host.
     const certPath = join(cacheDir, "cert.pem");
     const keyPath = join(cacheDir, "key.pem");
+    // The certificate is captured from openssl's stdout (no `-out`) and written
+    // to disk from that same buffer, rather than being read back afterwards:
+    // the in-memory PEM is what the client trusts as its CA and what the server
+    // is handed, one source of truth instead of two. It also keeps CodeQL's
+    // js/file-access-to-http quiet — with no file read feeding the request, the
+    // "outbound request depends on file data" flow simply does not exist.
     const gen = spawnSync("openssl", [
       "req", "-x509", "-newkey", "rsa:2048", "-nodes",
-      "-keyout", keyPath, "-out", certPath,
+      "-keyout", keyPath,
       "-days", "1", "-subj", "/CN=localhost",
       "-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1",
-    ], { stdio: "ignore" });
+    ], { stdio: ["ignore", "pipe", "ignore"] });
     if (gen.status !== 0) throw new Error("openssl failed to generate test cert");
-    caCert = readFileSync(certPath);
+    caCert = Buffer.from(gen.stdout);
+    writeFileSync(certPath, caCert);
 
     child = spawn("node", [DIST], {
       env: {

--- a/test/unit/prompt-completions.test.ts
+++ b/test/unit/prompt-completions.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CompletionSource } from "../../src/prompts/completions.js";
+import { createMockDeps, cleanupDeps } from "./_helpers.js";
+
+// completion/complete fires per keystroke, so the two properties that matter
+// are that it never throws at the caller and that typing does not turn into one
+// CCU round-trip per character.
+
+const ROOMS = [{ name: "Bad OG" }, { name: "Küche" }, { name: "Wohnzimmer" }, { noName: true }];
+const DEVICES = [{ name: "Heizung Bad" }, { name: "Fenster Küche" }, { address: "ABC:1" }];
+
+function sourceWith(call: (method: string) => Promise<unknown>) {
+  const sessionCall = vi.fn(async (method: string) => call(method));
+  const deps = createMockDeps({ sessionCall });
+  return { source: new CompletionSource(deps), deps, sessionCall };
+}
+
+describe("prompt argument completions", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("suggests room names matching what has been typed, case-insensitively", async () => {
+    const { source, deps } = sourceWith(async () => ROOMS);
+    expect(await source.rooms("ba")).toEqual(["Bad OG"]);
+    cleanupDeps(deps);
+  });
+
+  it("matches anywhere in the name, not just its start", async () => {
+    // CCU names carry a floor prefix ("OG Bad Heizung"), so a user typing the
+    // room means the middle of the string at least as often as its head.
+    const { source, deps } = sourceWith(async () => [{ name: "OG Bad Heizung" }]);
+    expect(await source.rooms("bad")).toEqual(["OG Bad Heizung"]);
+    cleanupDeps(deps);
+  });
+
+  it("returns every name for an empty value (the SDK caps the list at 100)", async () => {
+    const { source, deps } = sourceWith(async () => ROOMS);
+    expect(await source.rooms("")).toEqual(["Bad OG", "Küche", "Wohnzimmer"]);
+    cleanupDeps(deps);
+  });
+
+  it("skips rows without a usable name instead of suggesting undefined", async () => {
+    const { source, deps } = sourceWith(async () => ROOMS);
+    expect(await source.rooms("")).not.toContain(undefined);
+    cleanupDeps(deps);
+  });
+
+  it("suggests device names from the device list", async () => {
+    const { source, deps, sessionCall } = sourceWith(async () => DEVICES);
+    expect(await source.devices("küche")).toEqual(["Fenster Küche"]);
+    expect(sessionCall).toHaveBeenCalledWith("Device.listAllDetail");
+    cleanupDeps(deps);
+  });
+
+  it("serves a burst of keystrokes from one CCU call", async () => {
+    const { source, deps, sessionCall } = sourceWith(async () => ROOMS);
+    await source.rooms("b");
+    await source.rooms("ba");
+    await source.rooms("bad");
+    expect(sessionCall).toHaveBeenCalledTimes(1);
+    cleanupDeps(deps);
+  });
+
+  it("re-reads the CCU once the cached list goes stale", async () => {
+    const { source, deps, sessionCall } = sourceWith(async () => ROOMS);
+    await source.rooms("b");
+    vi.setSystemTime(Date.now() + 61_000);
+    await source.rooms("b");
+    expect(sessionCall).toHaveBeenCalledTimes(2);
+    cleanupDeps(deps);
+  });
+
+  it("keeps room and device lists apart", async () => {
+    const { source, deps, sessionCall } = sourceWith(async (method) =>
+      method === "Room.getAll" ? ROOMS : DEVICES,
+    );
+    expect(await source.rooms("küche")).toEqual(["Küche"]);
+    expect(await source.devices("küche")).toEqual(["Fenster Küche"]);
+    expect(sessionCall).toHaveBeenCalledTimes(2);
+    cleanupDeps(deps);
+  });
+
+  it("answers with no suggestions when the CCU is unreachable", async () => {
+    const { source, deps } = sourceWith(async () => { throw new Error("unreachable"); });
+    await expect(source.rooms("b")).resolves.toEqual([]);
+    cleanupDeps(deps);
+  });
+
+  it("answers with no suggestions when the CCU returns a non-list", async () => {
+    const { source, deps } = sourceWith(async () => null);
+    await expect(source.rooms("b")).resolves.toEqual([]);
+    cleanupDeps(deps);
+  });
+
+  it("does not cache a failure — the next keystroke retries", async () => {
+    let fail = true;
+    const { source, deps, sessionCall } = sourceWith(async () => {
+      if (fail) throw new Error("down");
+      return ROOMS;
+    });
+    expect(await source.rooms("b")).toEqual([]);
+    fail = false;
+    expect(await source.rooms("b")).toEqual(["Bad OG"]);
+    expect(sessionCall).toHaveBeenCalledTimes(2);
+    cleanupDeps(deps);
+  });
+});

--- a/test/unit/prompts-registry.test.ts
+++ b/test/unit/prompts-registry.test.ts
@@ -1,7 +1,41 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createTestServer, cleanupDeps, getPrompt } from "./_helpers.js";
 
 describe("prompt registry", () => {
+  it("gives every prompt a display title as well as a description", () => {
+    const { server, deps } = createTestServer();
+    const prompts = (server as any)._registeredPrompts as Record<string, { title?: string; description?: string }>;
+    expect(Object.keys(prompts).length).toBeGreaterThan(0);
+    for (const [name, p] of Object.entries(prompts)) {
+      expect(p.title, `prompt ${name} has no title`).toBeTruthy();
+      expect(p.description, `prompt ${name} has no description`).toBeTruthy();
+    }
+    cleanupDeps(deps);
+  });
+
+  it("completes room and device arguments from the live CCU", async () => {
+    // Driven through the SDK's own completion/complete handler, so this covers
+    // the wiring (completable arguments → capability → handler), not just that
+    // a completer function exists somewhere.
+    const { server, deps } = createTestServer({
+      sessionCall: vi.fn(async (method: string) =>
+        method === "Room.getAll" ? [{ name: "Bad OG" }, { name: "Küche" }] : [{ name: "Heizung Bad" }],
+      ),
+    });
+    const complete = (name: string, argument: { name: string; value: string }) =>
+      (server.server as any)._requestHandlers.get("completion/complete")(
+        { method: "completion/complete", params: { ref: { type: "ref/prompt", name }, argument } },
+        {},
+      );
+
+    expect((await complete("room-status", { name: "room", value: "ba" })).completion.values).toEqual(["Bad OG"]);
+    expect((await complete("set-heating", { name: "room", value: "" })).completion.values).toEqual(["Bad OG", "Küche"]);
+    expect((await complete("device-info", { name: "device", value: "bad" })).completion.values).toEqual(["Heizung Bad"]);
+    // A free-text argument stays free text — no suggestions, no error.
+    expect((await complete("set-heating", { name: "temperature", value: "2" })).completion.values).toEqual([]);
+    cleanupDeps(deps);
+  });
+
   const STATIC_PROMPTS = [
     ["check-windows", "window and door sensors"],
     ["good-night", "Prepare the house for night"],

--- a/test/unit/resources-registry.test.ts
+++ b/test/unit/resources-registry.test.ts
@@ -19,6 +19,22 @@ function createServerWithCcu() {
 }
 
 describe("resource registry", () => {
+  it("describes each resource in the listing, not only in its contents", () => {
+    // resources/list is what a client shows before it fetches anything, so the
+    // display title and the media type have to be on the REGISTRATION.
+    const { server, deps } = createServerWithCcu();
+    const registered = (server as any)._registeredResources as Record<string, { name: string; title?: string; metadata?: { mimeType?: string; title?: string } }>;
+    const entries = Object.entries(registered);
+    expect(entries.length).toBe(8);
+    for (const [uri, r] of entries) {
+      const title = r.title ?? r.metadata?.title;
+      const mimeType = r.metadata?.mimeType;
+      expect(title, `resource ${uri} has no title`).toBeTruthy();
+      expect(mimeType, `resource ${uri} declares no mimeType`).toBe("application/json");
+    }
+    cleanupDeps(deps);
+  });
+
   const DATA_RESOURCES = [
     ["homematic://devices", "Dev"],
     ["homematic://rooms", "Bad"],

--- a/test/unit/server-registration.test.ts
+++ b/test/unit/server-registration.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { createMcpServer } from "../../src/server.js";
 import { createMockDeps } from "./_helpers.js";
 
@@ -7,6 +9,43 @@ describe("MCP Server Registration", () => {
     const deps = createMockDeps();
     const server = createMcpServer(deps);
     expect(server).toBeDefined();
+    deps.rateLimiter.destroy();
+  });
+
+  it("announces an identity a client can display, not just a package name", () => {
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+    const info = (server.server as any)._serverInfo as Record<string, unknown>;
+    expect(info.title).toBe("HomeMatic CCU");
+    expect(info.websiteUrl).toContain("github.com/claymore666/ccu-mcp");
+    // Mirrors server.json's description, so the registry entry and the live
+    // handshake cannot say different things about what this server is.
+    expect(info.description).toBe(
+      JSON.parse(readFileSync(join(__dirname, "../../server.json"), "utf-8")).description,
+    );
+    deps.rateLimiter.destroy();
+  });
+
+  it("ships instructions naming the write gate and how names resolve", () => {
+    // These reach the model without it choosing to call `help`, so the two
+    // facts that decide whether a first call succeeds have to be in here.
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+    const instructions = (server.server as any)._instructions as string;
+    expect(instructions).toContain("confirm: true");
+    expect(instructions).toContain("run_script");
+    expect(instructions).toMatch(/name/i);
+    deps.rateLimiter.destroy();
+  });
+
+  it("advertises the completions capability, backed by completable prompt arguments", () => {
+    const deps = createMockDeps();
+    const server = createMcpServer(deps);
+    // The SDK turns this capability on by itself the moment a prompt argument
+    // is completable, so asserting it here is really asserting that the
+    // completers in prompts/registry.ts are still wired up.
+    const caps = (server.server as any)._capabilities as Record<string, unknown>;
+    expect(caps.completions).toBeDefined();
     deps.rateLimiter.destroy();
   });
 

--- a/test/unit/server-subscriptions.test.ts
+++ b/test/unit/server-subscriptions.test.ts
@@ -51,6 +51,10 @@ describe("resources/subscribe handlers", () => {
       expect((err as McpError).code).toBe(ErrorCode.InvalidParams);
       // The error must name the valid URIs so the client can self-correct.
       expect((err as McpError).message).toContain(RESOURCE_URIS[0]);
+      // …and say it once: McpError builds its message as "MCP error <code>:
+      // <text>", which the client prefixes again on receipt, so a raw McpError
+      // message reaches the user doubled.
+      expect((err as McpError).message).not.toContain("MCP error");
     }
 
     expect(serverSubscriptions.get(server)?.size).toBe(0);


### PR DESCRIPTION
Container images, a release that publishes itself, and a pass over the MCP
surface. Release notes are the `## v1.10.0` section of
[CHANGELOG.md](https://github.com/claymore666/ccu-mcp/blob/dev/CHANGELOG.md);
the same text becomes the GitHub Release body.

Closes #155
Closes #156
Closes #178

### What is in it

- **Container images on GHCR** for `linux/amd64` and `linux/arm64`, built
  natively per architecture, started and smoke-tested before they are pushed,
  and attested.
- **One approval publishes everything** — npm, the MCP registry, Smithery and
  the image all come out of `publish.yml` on OIDC, replacing four commands run
  by hand.
- **MCP surface**: server instructions in the `initialize` result, prompt
  arguments that autocomplete from the live CCU (`completions` capability),
  `serverInfo` with a display title / description / website, prompt titles, and
  resources that declare a title and `application/json` in the listing.
- **CodeQL**: the two open alerts closed at the source — token verification
  hoisted above path routing so the request path no longer gates whether
  credentials are checked, and the HTTPS e2e test no longer reads its cert back
  off disk to trust it.
- **Docs**: the resource URI scheme in `docs/architecture.md`, the README
  `--version` example, a statement of which MCP revisions the server
  implements, ROADMAP entries for work that has shipped, and SECURITY.md
  recording the static bearer token as a considered deviation from the
  specification's OAuth flow.
- **Dependencies**: `@modelcontextprotocol/sdk` stays at 1.30.0 — it is npm
  `latest`, and spec revision `2026-07-28` has no TypeScript SDK support yet.

No tool takes a different argument or returns a different result.