### PR TITLE
ci: add a scheduled OpenSSF Scorecard run

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,72 @@
+name: Scorecard
+
+# OpenSSF Scorecard, scheduled. Non-hermetic by nature — the score moves with
+# upstream check definitions and with repo settings, neither of which is a
+# function of the commit under test. So it belongs here and not in
+# `build-and-test`, and it must never become a required check, for the same
+# reason `npm audit` was taken out of CI in v1.8.1: a verdict that changes with
+# no diff cannot gate a merge.
+#
+# Runs on the default branch (`dev`) — `publish_results` requires that, and it
+# is what makes the score public and feeds the badge.
+#
+# No `repo_token`: Scorecard runs on the workflow's own GITHUB_TOKEN, which is
+# upstream's recommended default. The one thing that costs us is
+# Branch-Protection fidelity. GITHUB_TOKEN cannot read *classic* branch
+# protection (that needs an admin token), and the non-admin fallback upstream
+# provides reads Repository *Rules*, which this repo does not use. So that
+# single check scores on thin evidence: it can see that `main` is protected,
+# not that six status checks are required. Closing that gap means either a
+# fine-grained PAT with `Administration: Read-only` as secret SCORECARD_TOKEN —
+# a long-lived credential that expires yearly — or moving `main` to rulesets.
+# Deliberately deferred; see ROADMAP.md.
+
+on:
+  schedule:
+    # Mondays, 04:31 UTC. Off the hour: scheduled runs cluster there and GitHub
+    # drops them under load.
+    - cron: '31 4 * * 1'
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # Upload the SARIF to code scanning, alongside CodeQL's own results.
+      security-events: write
+      # OIDC token, which is how the published result is proven authentic.
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Keep the raw SARIF for 5 days: code scanning shows the findings but not
+      # the per-check scores, and a scheduled job has no other artifact.
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          sarif_file: results.sarif

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,16 @@ making it safer and more predictable rather than larger.
   migration note, and a clear error that names the fix. Until then this is a
   documented gap, not a hidden one — see
   [docs/assurance-case.md](docs/assurance-case.md).
-- **OpenSSF Scorecard** in CI ([#153](https://github.com/claymore666/ccu-mcp/issues/153)).
+- **Give OpenSSF Scorecard a real Branch-Protection reading.** Scorecard now
+  runs weekly ([#153](https://github.com/claymore666/ccu-mcp/issues/153)) on
+  the workflow's own `GITHUB_TOKEN`, which cannot read classic branch
+  protection — so that one check scores on thin evidence while the rest of the
+  report is accurate. Two ways to close it: a fine-grained PAT with
+  `Administration: Read-only` as secret `SCORECARD_TOKEN`, which is a
+  long-lived credential plus a yearly rotation when it expires; or move
+  `main`'s protection to rulesets, which non-admin tokens can read and which
+  would need its six required checks and the deliberate `enforce_admins: false`
+  bypass rebuilt as bypass actors.
 
 Delivered in v1.10.0, kept here because the reasoning is still the record:
 CodeQL moved off GitHub's default setup into a workflow file, so the query


### PR DESCRIPTION
Closes #153.

**The blocker in the issue is stale.** #153 held this back on a `SCORECARD_TOKEN`, on the grounds that Branch-Protection scores -1 without one. Upstream now says the opposite: *"Scorecard can run successfully with the workflow's default `GITHUB_TOKEN`, which is our recommended approach"*, and for Branch-Protection, *"if the provided token does not have admin access, the check will query the branch settings accessible to non-admins and provide results based only on these settings."*

**What the missing token still costs.** That non-admin fallback reads the Repository *Rules* API. This repo protects `main` with classic branch protection — `gh api repos/claymore666/ccu-mcp/rulesets` returns `0` — which needs an admin token to read. So Branch-Protection will see that `main` is protected, but not that six status checks are required or that `enforce_admins` is deliberately off. Every other check is unaffected. Closing that gap means either a fine-grained PAT (`Administration: Read-only`, secret `SCORECARD_TOKEN`) or moving `main` to rulesets; the choice is recorded on the roadmap rather than left blocking a report that is accurate about everything else.

**Placement.** Non-hermetic — the score moves with upstream check definitions and repo settings, neither a function of the commit — so it is scheduled weekly and never becomes a required check. Same reasoning that took `npm audit` out of `build-and-test` in v1.8.1.

**Details**
- `ossf/scorecard-action` pinned to `2d1146689b8cda280b9bc96326124645441f03bc` (v2.4.4 — the annotated tag dereferenced to its commit). Checkout, upload-artifact and upload-sarif reuse SHAs already pinned elsewhere in the repo.
- `publish_results: true` makes the score public and feeds the badge; it requires the run to be on the default branch, which is why the push trigger is `dev`.
- Job permissions are `security-events: write` (SARIF into code scanning, alongside CodeQL), `id-token: write` (OIDC, proves the published result authentic) and `contents: read`, under a top-level `permissions: read-all`.
- Cron is at `:31` rather than the hour, where scheduled runs cluster and GitHub sheds them.

**Verification** — pinned `actionlint` v1.7.12 passes clean on the new file, and `scripts/test-actionlint.sh` still flags its known-bad fixture. The score itself is only observable once this is on `dev` and the first run happens; expect **Contributors** to score low (it counts distinct organizations) and **Fuzzing** not to credit `fuzz.yml` (it detects known harnesses like OSS-Fuzz, not a custom one).