### PR TITLE
ci: grant auto-merge's write permissions at job level

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -37,15 +37,24 @@ on:
   pull_request_target:
     branches: [dev]
 
+# Read-only at the top, writes granted to the one job that needs them. The
+# effective token is identical either way — but Scorecard's Token-Permissions
+# check scores `contents: write` at *top* level as 0 for the whole repo
+# (checks/evaluation/permissions.go applies its -10 `reduceBy` only to
+# top-level findings; a job-level write is logged and not deducted, as long as
+# the top level is declared and not itself write). This one line was the
+# repo's entire Token-Permissions score.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write        # merge the PR
+      pull-requests: write   # arm auto-merge, post the fallback comment
     steps:
       - name: Enable auto-merge
         env:


### PR DESCRIPTION
The first Scorecard run (aggregate **7.9**) scored `Token-Permissions` **0** on exactly one warning:

```
Warn: topLevel 'contents' permission set to 'write': .github/workflows/dependabot-auto-merge.yml:41
Info: no jobLevel write permissions found
```

That check is weighted High (7.5), so this single line was costing roughly 0.8 of the aggregate.

**Why moving it works.** Scorecard deducts for `contents: write` only at *top* level. In `checks/evaluation/permissions.go`, the top-level branch calls `reduceBy()`, which returns `checker.MaxResultScore` (-10, i.e. straight to 0) for `contents`, `packages` and `actions`. The job-level branch never calls `reduceBy` — it logs a warning and only deducts 0.5 when the top level is *undeclared*, or drops to 0 when the top level is itself write:

```go
case jobLevelPermissions.Probe:
        ...
        dl.Warn(&checker.LogMessage{Finding: f})
        hasWritePermissions["jobLevel"][fPath] = true
        if hasWritePermissions["topLevel"][fPath] { score = checker.MinResultScore; break }
        if undeclaredPermissions["topLevel"][fPath] { score -= 0.5 }
```

So `contents: read` at the top plus the writes on the one job that needs them clears the check. **The effective token is bit-for-bit identical** — job-level permissions override the top level, and no other job exists in this workflow.

**Expected result:** `Token-Permissions` 0 → 10, aggregate 7.9 → **8.7**. That arithmetic is the same weighted mean that reproduces the current 7.9 exactly (707.5/90 = 7.86 over the 16 conclusive checks; inconclusive `-1` checks are excluded, not counted as zero). The next scheduled run — or the push to `dev` that merging this creates — will confirm it.

**Verification:** pinned `actionlint` v1.7.12 passes; the parsed YAML shows top level `{contents: read}` and job level `{contents: write, pull-requests: write}`, with the `pull_request_target` trigger unchanged.