### PR TITLE
build: pin the base image by digest as well as tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,14 @@
 # 2026). It is also the only major the test suite ever executes on, so a base
 # image ahead of it would ship users a configuration nothing here has run.
 # scripts/check-node-version.mjs fails the build if these four drift apart.
-FROM node:24-alpine AS builder
+#
+# Pinned by digest as well as tag, the same contract the SHA-pinned actions get:
+# `node:24-alpine` is a moving target, so without this a rebuild of an old
+# commit is not the image that commit produced. The digest is the OCI *index*,
+# not a per-arch manifest, so the multi-arch build in publish.yml still resolves
+# linux/amd64 and linux/arm64 from it. Dependabot bumps digest and tag together
+# (majors are held back — see .github/dependabot.yml), so the pin will not rot.
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -23,7 +30,7 @@ ENV BUILD_COMMIT=${BUILD_COMMIT} \
     BUILD_TAG=${BUILD_TAG}
 RUN npm run build
 
-FROM node:24-alpine
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43
 # `image.source` is not decoration: GHCR links a package to a repository by this
 # label, and that link is what carries the README, the licence and the "published
 # by" provenance on the package page. Without it the image floats unattached.


### PR DESCRIPTION
Scorecard's `Pinned-Dependencies` scores **9**, and the details name the only two unpinned dependencies left in the repo:

```
Warn: containerImage not pinned by hash: Dockerfile:7
Warn: containerImage not pinned by hash: Dockerfile:26
Info:  31 out of  31 GitHub-owned GitHubAction dependencies pinned
Info:   7 out of   7 third-party GitHubAction dependencies pinned
Info:   0 out of   2 containerImage dependencies pinned
Info:   7 out of   7 npmCommand dependencies pinned
Info:   1 out of   1 goCommand dependencies pinned
```

Both are `FROM node:24-alpine`, now `node:24-alpine@sha256:d32cdf61…`. The tag stays for readability; the digest is what makes the build reproducible, the same contract the SHA-pinned actions already have — without it, rebuilding an old commit does not produce the image that commit produced.

**Multi-arch is safe.** I resolved the digest myself rather than taking Scorecard's suggested value on trust, and confirmed it is the OCI *index*, not a per-arch manifest:

```
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43
  Platform: linux/amd64 · linux/arm64/v8 · linux/s390x
```

`publish.yml` builds `linux/amd64` and `linux/arm64`, both of which resolve from that index.

**The pin will not rot.** `.github/dependabot.yml` already tracks the docker ecosystem weekly and bumps digest and tag together, with node majors deliberately ignored so a platform decision stays one attended PR across `engines`, `@types/node`, the workflows and this file.

**Verification** — built the image locally and ran it: builds clean, the container reports Node v24.19.0, and the `org.opencontainers.image.source` label survives. Nothing in `build-and-test` builds the Dockerfile, so this local build is the check.

**Expected effect:** `Pinned-Dependencies` 9 → 10. On the weighted mean that reproduces the current score, that is 787.5/90 = 8.75, so expect the aggregate to read 8.7 or 8.8 depending on how it rounds — a real but small move. The run triggered by merging this will say which.