### PR TITLE
docs: show the OpenSSF Scorecard badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919/badge)](https://www.bestpractices.dev/projects/13919)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/claymore666/ccu-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
 
 <a href="https://glama.ai/mcp/servers/claymore666/ccu-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/claymore666/ccu-mcp/badge" alt="ccu-mcp MCP server" />


### PR DESCRIPTION
Adds one line under the existing Best Practices badge:

```markdown
[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/claymore666/ccu-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
```

**Dynamic, not a hardcoded number.** The scheduled workflow publishes results, so `api.scorecard.dev` serves a live score for this repo — it currently returns `"score":8.7` for commit `8721ef6`. Writing "8.7/10" into the README would be stale the first time `Maintained` decays or a check flips; the badge tracks the measurement instead.

Both endpoints verified to return 200: the badge (which resolves to shields.io) and the viewer link.

**It links to the full report on purpose.** Anyone clicking through sees every check, including `Code-Review 0` and `Branch-Protection -1`. `GOVERNANCE.md` and `docs/assurance-case.md` already state those gaps plainly, so a badge that links to honest detail is more consistent with this repo than one that only shows the headline.