### PR TITLE
docs: make the Scorecard badge actually render

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,16 @@
 Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919/badge)](https://www.bestpractices.dev/projects/13919)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/claymore666/ccu-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
+<!-- Scorecard's own badge endpoint redirects to shields' `ossf-scorecard`
+     route, which reads the LEGACY api.securityscorecards.dev — that host 404s
+     for this repo, so the badge renders "invalid repo path" (with HTTP 200, so
+     a status check does not catch it). The current api.scorecard.dev does
+     serve our result, hence the dynamic/json badge below. Switch back to
+     `https://api.scorecard.dev/projects/github.com/claymore666/ccu-mcp/badge`
+     once `curl -sS -o /dev/null -w '%{http_code}'
+     https://api.securityscorecards.dev/projects/github.com/claymore666/ccu-mcp`
+     returns 200. -->
+[![OpenSSF Scorecard](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fclaymore666%2Fccu-mcp&query=%24.score&label=openssf%20scorecard&suffix=%20%2F%2010)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
 
 <a href="https://glama.ai/mcp/servers/claymore666/ccu-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/claymore666/ccu-mcp/badge" alt="ccu-mcp MCP server" />


### PR DESCRIPTION
The badge added in #191 renders **"invalid repo path"**. Fixes that.

**Cause.** `api.scorecard.dev/.../badge` 302-redirects to shields' `ossf-scorecard` route, and that route reads the *legacy* host:

```
api.securityscorecards.dev/projects/github.com/claymore666/ccu-mcp  ->  404
api.scorecard.dev/projects/github.com/claymore666/ccu-mcp           ->  200  {"score":8.8}
```

The same shields route works for `ossf/scorecard` (renders `score: 9`), and the legacy host returns 200 for it — so this is our repo missing from the old dataset, not a malformed URL. Self-published results land on the new host; the legacy one appears to pick projects up later.

**Why I didn't catch it.** I verified the badge with `curl -o /dev/null -w '%{http_code}'`, and shields serves its error as **HTTP 200 with an error SVG**. The fetch succeeded; the badge was broken. Status codes are not a rendering check.

**Fix.** Read the same live score from the working host via shields' `dynamic/json` badge — no hardcoded number, same viewer link. A comment above the badge records the one-line switch back to the official endpoint, with the `curl` that tells you when the legacy host is ready.

**Verification** — this time the check parses every badge out of `README.md`, fetches the image, and asserts the rendered `<title>` contains no error text:

```
OK   OpenSSF Best Practices: rendered='openssf best practices: passing'  link_http=200
OK   OpenSSF Scorecard: rendered='openssf scorecard: 8.8 / 10'  link_http=200
```

Also confirms the aggregate is now **8.8** — `Pinned-Dependencies` reads *"all dependencies are pinned"* and `Token-Permissions` *"follow principle of least privilege"*, so #189 and #190 both landed as intended and 8.75 rounds up.