### PR TITLE
docs: put both badges on one line above the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
-# ccu-mcp
-
-Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
-
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919/badge)](https://www.bestpractices.dev/projects/13919)
-<!-- Scorecard's own badge endpoint redirects to shields' `ossf-scorecard`
-     route, which reads the LEGACY api.securityscorecards.dev — that host 404s
-     for this repo, so the badge renders "invalid repo path" (with HTTP 200, so
-     a status check does not catch it). The current api.scorecard.dev does
-     serve our result, hence the dynamic/json badge below. Switch back to
+<!-- Both badges stay on ONE source line: a block-level HTML comment between
+     them would end the paragraph and stack them, which is what this used to
+     do. The Scorecard badge reads api.scorecard.dev through shields'
+     dynamic/json route, because Scorecard's own badge endpoint redirects to
+     shields' `ossf-scorecard` route, which reads the LEGACY
+     api.securityscorecards.dev — and that host 404s for this repo, rendering
+     "invalid repo path" (as HTTP 200, so a status check does not catch it).
+     Switch back to
      `https://api.scorecard.dev/projects/github.com/claymore666/ccu-mcp/badge`
      once `curl -sS -o /dev/null -w '%{http_code}'
      https://api.securityscorecards.dev/projects/github.com/claymore666/ccu-mcp`
      returns 200. -->
-[![OpenSSF Scorecard](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fclaymore666%2Fccu-mcp&query=%24.score&label=openssf%20scorecard&suffix=%20%2F%2010)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919/badge)](https://www.bestpractices.dev/projects/13919) [![OpenSSF Scorecard](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fclaymore666%2Fccu-mcp&query=%24.score&label=openssf%20scorecard&suffix=%20%2F%2010)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
+
+# ccu-mcp
+
+Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
 
 <a href="https://glama.ai/mcp/servers/claymore666/ccu-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/claymore666/ccu-mcp/badge" alt="ccu-mcp MCP server" />


### PR DESCRIPTION
The two badges rendered stacked instead of side by side, and now sit above the H1 as a header strip.

**Cause.** The multi-line HTML comment added in #192 sat *between* the two badge lines, and a block-level comment ends the paragraph — so each badge became its own `<p>`. Consecutive badge lines with nothing between them would have joined into one paragraph on their own; the comment is what split them.

**Fix.** Both links on a single source line, with the comment moved above the pair where it splits nothing, and the whole block relocated above `# ccu-mcp`.

**Verification** — rendered through GitHub's own renderer (`POST /markdown`, `mode=gfm`) rather than eyeballed, listing the block order:

```
before:  <h1> ccu-mcp
         <p>  tagline
         <p>  badges: ['OpenSSF Best Practices']
         <p>  badges: ['OpenSSF Scorecard']

after:   <p>  badges: ['OpenSSF Best Practices', 'OpenSSF Scorecard']
         <h1> ccu-mcp
         <p>  tagline
```

One paragraph, both badges, ahead of the title. The glama.ai card is left where it was, below the tagline.