### PR TITLE
feat: ccu-mcp init / doctor — interactive setup wizard

### DIFF
--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -47,6 +47,10 @@ src 96.3 94.8
 src/auth 96.8 94.0
 src/cache 99.2 97.7
 src/ccu 91.6 87.1
+# src/cli (init-wizard PR): seeded at measured (89.7/77.3). Interactive CLI
+# code; the uncovered remainder is TTY-only paths (raw-mode echo suppression,
+# SIGINT) that a piped test harness cannot reach.
+src/cli 89.7 77.3
 src/health 100.0 100.0
 src/http 100.0 100.0
 # src/middleware 99.2/92.2 -> 99.2/95.2 (prototype-key PR): branches RAISED,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
+## Unreleased
+
+- **`ccu-mcp init`** — interactive setup wizard (#195): probes the CCU
+  (auto-detecting HTTPS/port), shows the TLS certificate and pins its SHA-256
+  fingerprint on confirmation, tests the login, reports the detected privilege
+  level (USER-level accounts get a warning that script-based tools need
+  ADMIN), and writes a mode-0600 env file — flat vars for one target,
+  `CCU_PROFILES` for several. Ends with a ready-to-paste MCP client snippet.
+  Re-running preserves every non-CCU line of an existing file and asks before
+  replacing the CCU settings.
+- **`ccu-mcp doctor`** — validates an env file end-to-end without starting the
+  server: configuration errors, reachability, pinned-fingerprint match
+  (interactive runs are offered a refresh after a legitimate certificate
+  rotation), login, privilege level. Exits non-zero when a check fails.
+- **`--env <path>`** server flag — loads a dotenv file before configuration,
+  so an MCP client entry can reference the file `init` wrote instead of
+  inlining credentials (`npx ccu-mcp --stdio --env /path/to/.env`).
+  Already-set environment variables win, matching node's `--env-file`
+  precedence. (Named `--env` because node's own CLI intercepts an
+  `--env-file` argument even after the script path and refuses to start when
+  the file does not exist yet — exactly the state `init` begins in.)
+
 ## v1.10.0 — 2026-08-19
 
 Container images, a release that publishes itself, and a pass over the MCP

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ npx ccu-mcp --stdio
 
 If it prints `server_ready` to stderr, it's working. Press Ctrl+C to stop. Now set it up in your MCP client — see below.
 
+Prefer a guided setup? `npx ccu-mcp init` probes your CCU, pins its TLS
+certificate, tests the login, writes a ready-to-use `.env` file, and prints the
+matching MCP client config — see [Command-line flags](#command-line-flags).
+
 ## Installation
 
 There are two ways to run this: **stdio** (the server runs as a subprocess of your MCP client) or **HTTP** (the server runs standalone in Docker and clients connect over the network). Pick one.
@@ -213,6 +217,11 @@ The server accepts self-signed certificates automatically — certificate verifi
 
 `CCU_TLS_FINGERPRINT` takes precedence over `CCU_CA_CERT`, which takes precedence over `CCU_TLS_VERIFY`.
 
+`ccu-mcp init` does the pinning for you: it shows the certificate the CCU
+presents and writes the fingerprint into the env file on confirmation, and
+`ccu-mcp doctor` re-checks the pin later (offering a refresh after a
+legitimate certificate rotation).
+
 ## Configuration
 
 All configuration is via environment variables:
@@ -254,11 +263,25 @@ below.
 ### Command-line flags
 
 ```sh
+ccu-mcp init           # interactive setup: probe the CCU, pin its TLS cert,
+                       #   test the login, write an env file (default ./.env)
+ccu-mcp doctor         # validate an env file end-to-end: reachability,
+                       #   certificate pin, login, privilege level
 ccu-mcp --stdio        # serve over stdin/stdout (overrides MCP_TRANSPORT)
 ccu-mcp --http         # serve over HTTP (default)
+ccu-mcp --env <path>   # load configuration from a dotenv file (already-set
+                       #   environment variables win); also accepted by
+                       #   init/doctor to pick the file they write/check
 ccu-mcp --version      # print the installed version and exit
 ccu-mcp --help         # print usage and exit
 ```
+
+`ccu-mcp init` walks through one or more CCU targets ([profiles](#multiple-ccu-targets-profiles)),
+detects whether the configured user is ADMIN- or USER-level (script-based
+tools need ADMIN), and ends with a ready-to-paste MCP client snippet. It
+needs no pre-existing configuration. `ccu-mcp doctor` exits non-zero when any
+check fails, so it also works in scripts; run it interactively to be offered
+a pin refresh when the CCU's certificate legitimately rotated.
 
 `--version` and `--help` need no configuration — use them to check what an
 installed copy actually is, e.g. after updating:
@@ -280,19 +303,24 @@ variables**. Provide them in whichever of these you prefer — you need just one
 - **Inline in `.mcp.json`** — the `env` block shown in [Option A](#option-a-stdio-direct-simplest)
   above. Simplest; self-contained.
 - **Shell `export`** — as in [Quick start](#quick-start) above.
-- **A `.env` file** — keeps secrets out of `.mcp.json`. The server does not read
-  `.env` on its own, so load it with Node's built-in flag (Node ≥ 20.6):
+- **A `.env` file** — keeps secrets out of `.mcp.json`. Pass it with the
+  server's own `--env` flag (this is also what `ccu-mcp init` writes and the
+  snippet it prints):
 
   ```json
   {
     "mcpServers": {
       "ccu-mcp": {
-        "command": "node",
-        "args": ["--env-file=/path/to/.env", "/path/to/ccu-mcp/dist/index.js", "--stdio"]
+        "command": "npx",
+        "args": ["ccu-mcp", "--stdio", "--env", "/path/to/.env"]
       }
     }
   }
   ```
+
+  (Node's own `--env-file=` flag before the script path works too, but node
+  refuses to start when that file doesn't exist yet, and it needs the full
+  path to `dist/index.js`.)
 
   Copy [`.env.example`](.env.example) to `.env` and fill it in (it documents every
   variable). Docker users can pass the same file with `docker run --env-file .env`
@@ -342,7 +370,9 @@ without switching.
 ### Configuration errors
 
 Some mistakes stop the server at startup instead of being ignored. Each of these
-would otherwise fail *silently* and much later, so the exit is deliberate:
+would otherwise fail *silently* and much later, so the exit is deliberate.
+`ccu-mcp doctor` reports the same errors against an env file without starting
+the server, alongside its live checks (reachability, certificate pin, login):
 
 | Message | Cause and why it's fatal |
 |---|---|

--- a/src/ccu/client.ts
+++ b/src/ccu/client.ts
@@ -5,7 +5,7 @@ import { CcuError, mapCcuError, mapNetworkError } from "../middleware/error-mapp
 import type { Logger } from "../logger.js";
 
 /** Normalize a SHA-256 fingerprint for comparison: drop colons, lowercase. */
-function normalizeFingerprint(fp: string): string {
+export function normalizeFingerprint(fp: string): string {
   return fp.replace(/:/g, "").toLowerCase();
 }
 

--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { parseEnv } from "node:util";
+
+/**
+ * Value of `--env <path>` in argv, defaulting to ./.env. Deliberately NOT
+ * named `--env-file`: node's own CLI intercepts that flag even when it
+ * appears after the script path and aborts when the file does not exist —
+ * which is precisely the state `ccu-mcp init` starts from.
+ */
+export function envFileArg(argv: string[], def = ".env"): string {
+  const i = argv.indexOf("--env");
+  if (i !== -1) {
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error("--env requires a path argument");
+    }
+    return value;
+  }
+  return def;
+}
+
+/** Parse a dotenv file into key/value pairs. Throws when unreadable. */
+export function loadEnvFile(path: string): Record<string, string> {
+  const content = readFileSync(path, "utf-8");
+  return parseEnv(content) as Record<string, string>;
+}
+
+/**
+ * Apply parsed env-file vars to process.env with the same precedence as
+ * node's own `--env-file`: variables already present in the environment win.
+ */
+export function applyEnvVars(vars: Record<string, string>): void {
+  for (const [key, value] of Object.entries(vars)) {
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
+}
+
+/** Display form of a SHA-256 fingerprint: colon-separated uppercase pairs. */
+export function displayFingerprint(fp: string): string {
+  const bare = fp.replace(/:/g, "").toUpperCase();
+  return bare.match(/.{1,2}/g)?.join(":") ?? bare;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,142 @@
+import { resolve } from "node:path";
+import { Prompter, type PromptIo } from "./prompt.js";
+import { envFileArg, applyEnvVars, loadEnvFile, displayFingerprint } from "./common.js";
+import { readEnvFile, replaceEnvKey, writeEnvFile } from "./env-writer.js";
+import { probeApi, fetchCert, fingerprintMatches, testLogin } from "./probe.js";
+import { loadConfig, envPrefix } from "../config.js";
+import type { CcuProfile } from "../ccu/types.js";
+
+interface Report {
+  say: (text: string) => void;
+  failures: number;
+}
+
+function pass(r: Report, text: string): void {
+  r.say(`  ✓ ${text}`);
+}
+
+function fail(r: Report, text: string): void {
+  r.failures++;
+  r.say(`  ✗ ${text}`);
+}
+
+/** The env key holding this profile's pin, for the refresh offer. */
+function fingerprintKey(p: CcuProfile): string {
+  return p.isFlat ? "CCU_TLS_FINGERPRINT" : `CCU_${envPrefix(p.name)}_TLS_FINGERPRINT`;
+}
+
+/** Returns false when the login test can't succeed anyway (pin mismatch / cert unreadable). */
+async function checkPin(
+  r: Report,
+  p: CcuProfile,
+  envPath: string,
+  ui: Prompter | undefined,
+): Promise<boolean> {
+  if (!p.ccu.https) return true;
+  if (!p.ccu.tlsFingerprint) {
+    r.say("  - no TLS fingerprint pinned (connection is encrypted but unverified)");
+    return true;
+  }
+  let presented: string;
+  try {
+    presented = (await fetchCert(p.ccu.host, p.ccu.port)).fingerprint256;
+  } catch (err) {
+    fail(r, `could not read the TLS certificate: ${(err as Error).message}`);
+    return false;
+  }
+  if (fingerprintMatches(p.ccu.tlsFingerprint, presented)) {
+    pass(r, "pinned TLS fingerprint matches the presented certificate");
+    return true;
+  }
+  fail(r, "pinned TLS fingerprint does NOT match the presented certificate");
+  r.say(`      pinned:    ${displayFingerprint(p.ccu.tlsFingerprint)}`);
+  r.say(`      presented: ${displayFingerprint(presented)}`);
+  r.say("      If the CCU's certificate was legitimately renewed, refresh the pin;");
+  r.say("      if not, this could be an interception attempt — investigate first.");
+  if (ui && (await ui.askYesNo(`    Update ${fingerprintKey(p)} in ${envPath} to the presented one?`, false))) {
+    const existing = readEnvFile(envPath);
+    if (existing === undefined) {
+      r.say(`    Could not re-read ${envPath} — pin left unchanged.`);
+      return false;
+    }
+    writeEnvFile(envPath, replaceEnvKey(existing, fingerprintKey(p), presented));
+    r.say("    Pin updated. Re-run doctor to verify.");
+  }
+  return false;
+}
+
+async function checkProfile(r: Report, p: CcuProfile, envPath: string, ui: Prompter | undefined): Promise<void> {
+  r.say(`Target "${p.name}" — ${p.ccu.host}:${p.ccu.port} (${p.ccu.https ? "HTTPS" : "HTTP"})`);
+  const outcome = await probeApi(p.ccu);
+  if (outcome.kind !== "ccu") {
+    fail(r, `CCU API not reachable: ${outcome.detail}`);
+    return;
+  }
+  pass(r, "CCU API reachable");
+  if (!(await checkPin(r, p, envPath, ui))) {
+    r.say("  - skipping the login test until the certificate check passes");
+    return;
+  }
+  const login = await testLogin(p.ccu);
+  if (!login.ok) {
+    fail(r, `login failed: ${login.error.message}`);
+    if (login.error.hint) r.say(`      ${login.error.hint}`);
+    return;
+  }
+  const version = login.version ? ` (CCU ${login.version})` : "";
+  pass(r, `login OK as "${p.ccu.user}"${version} — privilege level ${login.role}`);
+  if (login.role === "USER") {
+    r.say("      Note: script-based tools (run_script, create_system_variable,");
+    r.say("      acknowledge_service_messages) need an ADMIN-level CCU user.");
+  }
+}
+
+/** Entry point for `ccu-mcp doctor`. Returns the process exit code. */
+export async function run(argv: string[], io?: PromptIo): Promise<number> {
+  const out = io?.output ?? process.stdout;
+  const r: Report = { say: (text) => out.write(text + "\n"), failures: 0 };
+  let envPath: string;
+  try {
+    envPath = envFileArg(argv);
+    r.say(`ccu-mcp doctor — checking ${resolve(envPath)}`);
+    applyEnvVars(loadEnvFile(envPath));
+  } catch (err) {
+    r.say(`  ✗ ${(err as Error).message}`);
+    return 1;
+  }
+
+  let config;
+  try {
+    config = loadConfig();
+  } catch (err) {
+    r.say(`  ✗ configuration invalid: ${(err as Error).message}`);
+    r.say("    (See README → Configuration errors for what each message means.)");
+    return 1;
+  }
+  r.say(
+    `  ✓ configuration loads: ${config.profiles.length} target(s), default "${config.defaultProfile}"`,
+  );
+
+  // The interactive pin-refresh offer needs someone at a terminal; with piped
+  // stdin (CI, scripts) doctor only reports. Tests opt in by stamping
+  // isTTY=true on their injected input stream.
+  const input = io?.input ?? process.stdin;
+  const ui =
+    input.isTTY === true ? new Prompter(io ?? { input: process.stdin, output: process.stdout }) : undefined;
+  try {
+    for (const p of config.profiles) {
+      r.say("");
+      await checkProfile(r, p, envPath, ui);
+    }
+  } finally {
+    ui?.close();
+  }
+
+  r.say("");
+  if (r.failures > 0) {
+    r.say(`${r.failures} check(s) failed.`);
+    return 1;
+  }
+  r.say("All checks passed.");
+  return 0;
+}

--- a/src/cli/env-writer.ts
+++ b/src/cli/env-writer.ts
@@ -1,0 +1,125 @@
+import { readFileSync, writeFileSync, renameSync } from "node:fs";
+import { envPrefix } from "../config.js";
+
+/** What the wizard collects per CCU target. */
+export interface WizardProfile {
+  name: string;
+  host: string;
+  port: number;
+  https: boolean;
+  tlsFingerprint?: string;
+  user: string;
+  password: string;
+  protected: boolean;
+  readonly: boolean;
+}
+
+// The connection-defining keys the wizard owns inside the .env file — flat,
+// profile-scoped (ANY prefix, so a removed profile's leftovers don't linger and
+// break the next load), plus the profile roster itself. Everything else in the
+// file (MCP_*, LOG_LEVEL, rate limits, timeouts) belongs to the operator and
+// survives a rewrite — same contract as the auth-token persistence.
+const MANAGED_SUFFIXES = "HOST|PORT|HTTPS|USER|PASSWORD|TLS_FINGERPRINT|TLS_VERIFY|CA_CERT|PROTECTED|READONLY";
+export const MANAGED_KEY_RE = new RegExp(
+  `^CCU_(PROFILES|DEFAULT_PROFILE|(${MANAGED_SUFFIXES})|[A-Z0-9_]+_(${MANAGED_SUFFIXES}))=`,
+);
+
+/**
+ * Quote a value if the dotenv format needs it. Node's env-file parser (and
+ * util.parseEnv, which doctor uses to read the file back) treats an unquoted
+ * `#` as a comment start and trims whitespace — and it does NOT process
+ * escape sequences inside quotes, so the only way to represent a value is to
+ * pick a quote character (", ', or `) that the value itself doesn't contain.
+ */
+export function quoteEnvValue(value: string): string {
+  if (value !== "" && !/[\s#"'`]/.test(value)) return value;
+  for (const q of ['"', "'", "`"]) {
+    if (!value.includes(q)) return `${q}${value}${q}`;
+  }
+  throw new Error(
+    'value contains all three quote characters (", \' and `) and cannot be stored in a dotenv file',
+  );
+}
+
+/** Render the managed block: flat vars for one target, CCU_PROFILES for more. */
+export function buildEnvContent(profiles: WizardProfile[], defaultProfile: string): string {
+  const lines: string[] = [
+    "# Written by `ccu-mcp init` — https://github.com/claymore666/ccu-mcp#configuration",
+  ];
+  const emit = (prefix: string, p: WizardProfile): void => {
+    lines.push(`CCU_${prefix}HOST=${quoteEnvValue(p.host)}`);
+    lines.push(`CCU_${prefix}PORT=${p.port}`);
+    lines.push(`CCU_${prefix}HTTPS=${p.https}`);
+    lines.push(`CCU_${prefix}USER=${quoteEnvValue(p.user)}`);
+    lines.push(`CCU_${prefix}PASSWORD=${quoteEnvValue(p.password)}`);
+    if (p.tlsFingerprint) lines.push(`CCU_${prefix}TLS_FINGERPRINT=${p.tlsFingerprint}`);
+    if (p.protected) lines.push(`CCU_${prefix}PROTECTED=true`);
+    if (p.readonly) lines.push(`CCU_${prefix}READONLY=true`);
+  };
+  if (profiles.length === 1) {
+    emit("", profiles[0]);
+  } else {
+    lines.push(`CCU_PROFILES=${profiles.map((p) => p.name).join(",")}`);
+    lines.push(`CCU_DEFAULT_PROFILE=${defaultProfile}`);
+    for (const p of profiles) {
+      lines.push("");
+      lines.push(`# --- target: ${p.name} ---`);
+      emit(`${envPrefix(p.name)}_`, p);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Merge the managed block into an existing file's content: managed keys are
+ * replaced, everything else (operator vars, comments) is preserved verbatim.
+ * Returns the keys that were replaced so the wizard can ask before clobbering.
+ */
+export function mergeEnvContent(existing: string, managed: string): { content: string; replaced: string[] } {
+  const foreign: string[] = [];
+  const replaced: string[] = [];
+  for (const line of existing.split(/\r?\n/)) {
+    if (MANAGED_KEY_RE.test(line)) {
+      replaced.push(line.slice(0, line.indexOf("=")));
+      continue;
+    }
+    if (line.trim() === "") continue;
+    foreign.push(line);
+  }
+  const content = managed + (foreign.length > 0 ? "\n" + foreign.join("\n") + "\n" : "");
+  return { content, replaced };
+}
+
+/** Replace (or append) one KEY=value line in existing file content. */
+export function replaceEnvKey(content: string, key: string, value: string): string {
+  const lines = content.split(/\r?\n/);
+  let done = false;
+  const out = lines.map((line) => {
+    if (!done && line.startsWith(`${key}=`)) {
+      done = true;
+      return `${key}=${value}`;
+    }
+    return line;
+  });
+  if (!done) {
+    while (out.length > 0 && out[out.length - 1] === "") out.pop();
+    out.push(`${key}=${value}`, "");
+  }
+  return out.join("\n");
+}
+
+/** Read an existing env file; undefined when it doesn't exist. */
+export function readEnvFile(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+/** Write mode 0600 via tmp+rename: the file holds the CCU password. */
+export function writeEnvFile(path: string, content: string): void {
+  const tmpPath = path + ".tmp";
+  writeFileSync(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
+  renameSync(tmpPath, path);
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,262 @@
+import { resolve } from "node:path";
+import { Prompter, type PromptIo } from "./prompt.js";
+import { envFileArg, displayFingerprint } from "./common.js";
+import {
+  buildEnvContent,
+  mergeEnvContent,
+  readEnvFile,
+  writeEnvFile,
+  type WizardProfile,
+} from "./env-writer.js";
+import { probeApi, probeConfig, fetchCert, testLogin, type CertInfo } from "./probe.js";
+import { envPrefix } from "../config.js";
+import type { CcuConfig } from "../ccu/types.js";
+
+const DETECT_TIMEOUT = 3_000;
+
+interface Detected {
+  port: number;
+  https: boolean;
+}
+
+/** Try the two stock CCU ports to pre-fill defaults. Never asks anything. */
+async function detectEndpoint(host: string): Promise<Detected | undefined> {
+  for (const candidate of [
+    { port: 443, https: true },
+    { port: 80, https: false },
+  ]) {
+    const outcome = await probeApi(probeConfig(host, candidate.port, candidate.https, DETECT_TIMEOUT));
+    if (outcome.kind === "ccu") return candidate;
+  }
+  return undefined;
+}
+
+function toCcuConfig(p: WizardProfile): CcuConfig {
+  return {
+    host: p.host,
+    port: p.port,
+    https: p.https,
+    tlsVerify: false,
+    tlsFingerprint: p.tlsFingerprint,
+    user: p.user,
+    password: p.password,
+    timeout: 10_000,
+    scriptTimeout: 30_000,
+  };
+}
+
+function describeCert(cert: CertInfo): string[] {
+  const lines: string[] = [];
+  if (cert.subjectCN) lines.push(`  Subject: ${cert.subjectCN}`);
+  if (cert.issuerCN) lines.push(`  Issuer:  ${cert.issuerCN}`);
+  if (cert.validFrom && cert.validTo) lines.push(`  Valid:   ${cert.validFrom} — ${cert.validTo}`);
+  lines.push(`  SHA-256: ${displayFingerprint(cert.fingerprint256)}`);
+  return lines;
+}
+
+/** Host/port/HTTPS for one target, looping until reachable or accepted as-is. */
+async function askEndpoint(ui: Prompter): Promise<{ host: string; port: number; https: boolean }> {
+  for (;;) {
+    const host = await ui.ask("CCU hostname or IP", {
+      validate: (v) => (v === "" ? "A hostname or IP is required." : null),
+    });
+    ui.say(`Probing ${host} ...`);
+    const detected = await detectEndpoint(host);
+    if (detected) {
+      ui.say(`  Found the CCU API on port ${detected.port} (${detected.https ? "HTTPS" : "HTTP"}).`);
+    } else {
+      ui.say("  No CCU API on the standard ports (443/80) — enter the port manually.");
+    }
+    const https = await ui.askYesNo("Use HTTPS?", detected ? detected.https : true);
+    const port = Number(
+      await ui.ask("Port", {
+        def: detected && detected.https === https ? String(detected.port) : https ? "443" : "80",
+        validate: (v) =>
+          /^\d+$/.test(v) && Number(v) >= 1 && Number(v) <= 65535 ? null : "Port must be 1-65535.",
+      }),
+    );
+    if (detected && detected.port === port && detected.https === https) {
+      return { host, port, https };
+    }
+    const outcome = await probeApi(probeConfig(host, port, https, DETECT_TIMEOUT));
+    if (outcome.kind === "ccu") {
+      ui.say("  CCU API found.");
+      return { host, port, https };
+    }
+    ui.say(`  No CCU API there: ${outcome.detail}`);
+    if (await ui.askYesNo("Continue with these settings anyway?", false)) {
+      return { host, port, https };
+    }
+  }
+}
+
+/** Credentials + test-login loop for one target. Returns null on abort. */
+async function askCredentials(
+  ui: Prompter,
+  base: Omit<WizardProfile, "user" | "password">,
+): Promise<{ user: string; password: string } | null> {
+  for (;;) {
+    const user = await ui.ask("CCU user", { def: "Admin" });
+    const password = await ui.askHidden("CCU password (input hidden)");
+    ui.say("Testing login ...");
+    const result = await testLogin(toCcuConfig({ ...base, user, password }));
+    if (result.ok) {
+      const version = result.version ? ` (CCU ${result.version})` : "";
+      if (result.role === "ADMIN") {
+        ui.say(`  Login OK${version} — privilege level ADMIN: all tools available.`);
+      } else if (result.role === "USER") {
+        ui.say(`  Login OK${version} — privilege level USER.`);
+        ui.say(
+          "  Note: script-based tools (run_script, create_system_variable, " +
+            "acknowledge_service_messages) need an ADMIN-level CCU user and will fail for this one.",
+        );
+      } else {
+        ui.say(`  Login OK${version} — privilege level could not be determined.`);
+      }
+      return { user, password };
+    }
+    ui.say(`  Login failed: ${result.error.message}`);
+    if (result.error.hint) ui.say(`  ${result.error.hint}`);
+    if (await ui.askYesNo("Re-enter user/password?", true)) continue;
+    if (await ui.askYesNo("Save this target with untested credentials anyway?", false)) {
+      return { user, password };
+    }
+    return null;
+  }
+}
+
+async function runWizard(ui: Prompter, envPath: string): Promise<number> {
+  ui.say("ccu-mcp setup — probes your CCU, pins its TLS certificate, tests the");
+  ui.say(`login, and writes the result to ${envPath}.`);
+  ui.say("");
+
+  const multi = await ui.askYesNo("Set up multiple CCU targets (e.g. prod/dev)?", false);
+  const profiles: WizardProfile[] = [];
+
+  for (;;) {
+    let name = "default";
+    if (multi) {
+      name = await ui.ask("Profile name", {
+        def: profiles.length === 0 ? "prod" : undefined,
+        validate: (v) => {
+          if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(v)) {
+            return "Use letters, digits, dot, dash or underscore.";
+          }
+          if (profiles.some((p) => envPrefix(p.name) === envPrefix(v))) {
+            return `Collides with already-configured "${profiles.find((p) => envPrefix(p.name) === envPrefix(v))?.name}".`;
+          }
+          return null;
+        },
+      });
+    }
+
+    const endpoint = await askEndpoint(ui);
+
+    let tlsFingerprint: string | undefined;
+    if (endpoint.https) {
+      try {
+        const cert = await fetchCert(endpoint.host, endpoint.port);
+        ui.say("The CCU presents this TLS certificate:");
+        for (const line of describeCert(cert)) ui.say(line);
+        if (await ui.askYesNo("Pin this certificate's fingerprint (recommended)?", true)) {
+          tlsFingerprint = cert.fingerprint256;
+        } else {
+          ui.say("  Not pinned — the connection will be encrypted but UNVERIFIED (MITM-exposed).");
+        }
+      } catch (err) {
+        ui.say(`  Could not read the certificate: ${(err as Error).message}`);
+        ui.say("  Continuing without a pin — the connection will be unverified.");
+      }
+    }
+
+    const base: Omit<WizardProfile, "user" | "password"> = {
+      name,
+      host: endpoint.host,
+      port: endpoint.port,
+      https: endpoint.https,
+      tlsFingerprint,
+      protected: false,
+      readonly: false,
+    };
+    const creds = await askCredentials(ui, base);
+    if (creds === null) {
+      ui.say("Aborted — nothing written.");
+      return 1;
+    }
+
+    let prot = false;
+    let ro = false;
+    if (multi) {
+      prot = await ui.askYesNo("Protect this target (write tools then require confirm:true)?", false);
+      ro = await ui.askYesNo("Make this target read-only (write tools refused entirely)?", false);
+    }
+    profiles.push({ ...base, ...creds, protected: prot, readonly: ro });
+
+    if (!multi || !(await ui.askYesNo("Add another CCU target?", false))) break;
+  }
+
+  let defaultProfile = profiles[0].name;
+  if (profiles.length > 1) {
+    const names = profiles.map((p) => p.name);
+    defaultProfile = await ui.askChoice("Default target", names, names[0]);
+  }
+
+  const managed = buildEnvContent(profiles, defaultProfile);
+  const existing = readEnvFile(envPath);
+  let content = managed;
+  if (existing !== undefined) {
+    const merged = mergeEnvContent(existing, managed);
+    if (merged.replaced.length > 0) {
+      ui.say(`${envPath} already configures a CCU (${[...new Set(merged.replaced)].join(", ")}).`);
+      if (!(await ui.askYesNo("Replace those settings? Everything else in the file is kept.", true))) {
+        ui.say("Nothing written.");
+        return 1;
+      }
+    }
+    content = merged.content;
+  }
+  writeEnvFile(envPath, content);
+  const absPath = resolve(envPath);
+  ui.say("");
+  ui.say(`Wrote ${absPath} (mode 0600).`);
+
+  ui.say("");
+  ui.say("Add the server to an MCP client — .mcp.json (Claude Code) or");
+  ui.say("claude_desktop_config.json (Claude Desktop):");
+  ui.say("");
+  ui.say(
+    JSON.stringify(
+      {
+        mcpServers: {
+          "ccu-mcp": { command: "npx", args: ["ccu-mcp", "--stdio", "--env", absPath] },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  ui.say("");
+  ui.say("Or via the Claude Code CLI:");
+  ui.say(`  claude mcp add ccu-mcp -- npx ccu-mcp --stdio --env ${absPath}`);
+  ui.say("");
+  ui.say(`Re-check this configuration anytime with: ccu-mcp doctor --env ${absPath}`);
+  return 0;
+}
+
+/** Entry point for `ccu-mcp init`. Returns the process exit code. */
+export async function run(argv: string[], io?: PromptIo): Promise<number> {
+  const envPath = envFileArg(argv);
+  const ui = new Prompter(io ?? { input: process.stdin, output: process.stdout });
+  try {
+    return await runWizard(ui, envPath);
+  } catch (err) {
+    if ((err as Error).message === "input closed") {
+      process.stderr.write("ccu-mcp init: input closed — nothing written.\n");
+      return 130;
+    }
+    process.stderr.write(`ccu-mcp init: ${(err as Error).message}\n`);
+    return 1;
+  } finally {
+    ui.close();
+  }
+}

--- a/src/cli/probe.ts
+++ b/src/cli/probe.ts
@@ -1,0 +1,170 @@
+import { connect as tlsConnect } from "node:tls";
+import { isIP } from "node:net";
+import { tmpdir } from "node:os";
+import { CcuClient, normalizeFingerprint } from "../ccu/client.js";
+import { SessionManager } from "../ccu/session.js";
+import { CcuError } from "../middleware/error-mapper.js";
+import type { CcuConfig, StructuredError } from "../ccu/types.js";
+import { Logger } from "../logger.js";
+
+/**
+ * The wizard talks to the user on stdout itself; the structured JSON logger
+ * the client/session classes expect would only interleave noise. Expected
+ * failures (unreachable probe, wrong password) are reported by the wizard.
+ */
+class SilentLogger extends Logger {
+  override error(): void {}
+  override warn(): void {}
+  override info(): void {}
+  override debug(): void {}
+}
+
+export const silentLogger: Logger = new SilentLogger();
+
+/** A CcuConfig for probing: no TLS verification, short timeout. */
+export function probeConfig(host: string, port: number, https: boolean, timeout = 5000): CcuConfig {
+  return {
+    host,
+    port,
+    https,
+    tlsVerify: false,
+    user: "",
+    password: "",
+    timeout,
+    scriptTimeout: 30_000,
+  };
+}
+
+export type ProbeKind = "ccu" | "not-ccu" | "tls" | "timeout" | "unreachable";
+
+export interface ProbeOutcome {
+  kind: ProbeKind;
+  detail: string;
+}
+
+/**
+ * Classify what answers at ${host}:${port}/api/homematic.cgi. Sends a bogus
+ * JSON-RPC method: a CCU replies with a JSON-RPC error envelope (proof of the
+ * API without needing credentials); anything else is classified by how it
+ * fails. TLS settings on `ccu` are ignored — reachability is the question
+ * here, pin verification is the doctor's separate check.
+ */
+export async function probeApi(ccu: CcuConfig): Promise<ProbeOutcome> {
+  const client = new CcuClient(
+    { ...ccu, tlsFingerprint: undefined, caCert: undefined, tlsVerify: false },
+    silentLogger,
+  );
+  try {
+    await client.call("CCU.probe", {}, ccu.timeout);
+    return { kind: "ccu", detail: "JSON-RPC endpoint answered" };
+  } catch (err) {
+    if (!(err instanceof CcuError)) throw err;
+    const s = err.structured;
+    if (s.error === "TIMEOUT") return { kind: "timeout", detail: s.message };
+    if (s.error === "TLS_ERROR") return { kind: "tls", detail: s.message };
+    if (s.error === "UNREACHABLE") return { kind: "unreachable", detail: s.message };
+    if (s.message.includes("Invalid JSON response") || s.message.includes("no JSON-RPC error in body")) {
+      return { kind: "not-ccu", detail: s.message };
+    }
+    // The endpoint answered with a JSON-RPC error envelope — it IS a CCU API.
+    return { kind: "ccu", detail: s.message };
+  }
+}
+
+export interface CertInfo {
+  /** SHA-256 fingerprint as Node reports it: colon-separated uppercase hex. */
+  fingerprint256: string;
+  subjectCN?: string;
+  issuerCN?: string;
+  validFrom?: string;
+  validTo?: string;
+}
+
+/**
+ * Fetch the peer certificate without verifying it — the whole point is to
+ * show the operator what the CCU presents so they can decide to pin it.
+ */
+export function fetchCert(host: string, port: number, timeoutMs = 5000): Promise<CertInfo> {
+  return new Promise((resolve, reject) => {
+    const socket = tlsConnect({
+      host,
+      port,
+      rejectUnauthorized: false,
+      // SNI must be a hostname; tls.connect throws on an IP literal.
+      ...(isIP(host) === 0 ? { servername: host } : {}),
+    });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`TLS handshake timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    socket.once("secureConnect", () => {
+      clearTimeout(timer);
+      const cert = socket.getPeerCertificate();
+      socket.destroy();
+      if (!cert || !cert.fingerprint256) {
+        reject(new Error("Peer presented no certificate"));
+        return;
+      }
+      // subject/issuer CN can be a string array for multi-valued RDNs.
+      const first = (v: string | string[] | undefined): string | undefined =>
+        Array.isArray(v) ? v[0] : v;
+      resolve({
+        fingerprint256: cert.fingerprint256,
+        subjectCN: first(cert.subject?.CN),
+        issuerCN: first(cert.issuer?.CN),
+        validFrom: cert.valid_from,
+        validTo: cert.valid_to,
+      });
+    });
+    socket.once("error", (err) => {
+      clearTimeout(timer);
+      socket.destroy();
+      reject(err);
+    });
+  });
+}
+
+/** True when the presented fingerprint matches the pinned one (colon/case-insensitive). */
+export function fingerprintMatches(pinned: string, presented: string): boolean {
+  return normalizeFingerprint(pinned) === normalizeFingerprint(presented);
+}
+
+export type CcuRole = "ADMIN" | "USER" | "UNKNOWN";
+
+export type LoginResult =
+  | { ok: true; role: CcuRole; version?: string }
+  | { ok: false; error: StructuredError };
+
+/**
+ * Log in with the profile's real TLS settings, detect the privilege level,
+ * log out again. Role detection is the same capability probe get_system_info
+ * uses: `CCU.getVersion` is ADMIN-only per the OCCU method table, so a result
+ * means ADMIN and an access denial means USER.
+ */
+export async function testLogin(ccu: CcuConfig): Promise<LoginResult> {
+  // Unique throwaway session file: never touch (or restore) the running
+  // server's persisted session, and leave nothing behind — logout clears it.
+  const sessionFile = `ccu-mcp-cli-${process.pid}-${Date.now()}.json`;
+  const session = new SessionManager(ccu, silentLogger, tmpdir(), sessionFile);
+  try {
+    await session.login();
+  } catch (err) {
+    if (err instanceof CcuError) return { ok: false, error: err.structured };
+    throw err;
+  }
+  try {
+    const version = await session.call("CCU.getVersion");
+    if (typeof version === "string" && version !== "") {
+      return { ok: true, role: "ADMIN", version };
+    }
+    return { ok: true, role: "USER" };
+  } catch (err) {
+    if (err instanceof CcuError && err.structured.error === "AUTH") {
+      return { ok: true, role: "USER" };
+    }
+    // Login itself worked; the role probe failed for some other reason.
+    return { ok: true, role: "UNKNOWN" };
+  } finally {
+    await session.logout();
+  }
+}

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,0 +1,132 @@
+import { createInterface, type Interface } from "node:readline";
+
+export interface PromptIo {
+  input: NodeJS.ReadableStream & { isTTY?: boolean };
+  output: NodeJS.WritableStream;
+}
+
+/**
+ * Minimal interactive prompter over injected streams, so tests can script a
+ * whole wizard run through a PassThrough. One persistent readline interface
+ * for the prompter's lifetime: a fresh interface per question would buffer a
+ * piped multi-line answer chunk internally and discard the rest on close.
+ */
+export class Prompter {
+  private readonly rl: Interface;
+  private readonly output: NodeJS.WritableStream;
+  private muted = false;
+  private closed = false;
+  // Piped input can deliver many answers in one chunk; readline emits them as
+  // `line` events whether or not a question is pending, so unconsumed lines
+  // must be queued — rl.question() would silently drop them between prompts.
+  private readonly lines: string[] = [];
+  private waiter: { resolve: (line: string) => void; reject: (err: Error) => void } | null = null;
+
+  constructor(io: PromptIo) {
+    this.output = io.output;
+    this.rl = createInterface({
+      input: io.input,
+      output: io.output,
+      terminal: io.input.isTTY === true,
+    });
+    // Echo suppression for askHidden(): in terminal mode readline echoes every
+    // keystroke through this internal hook; while muted, swallow it. Non-TTY
+    // input never echoes, so the hook being absent there is fine.
+    const rlInternal = this.rl as unknown as { _writeToOutput?: (s: string) => void };
+    const original = rlInternal._writeToOutput?.bind(this.rl);
+    if (original) {
+      rlInternal._writeToOutput = (s: string): void => {
+        if (!this.muted) original(s);
+      };
+    }
+    this.rl.on("line", (line) => {
+      if (this.waiter) {
+        const w = this.waiter;
+        this.waiter = null;
+        w.resolve(line);
+      } else {
+        this.lines.push(line);
+      }
+    });
+    this.rl.on("close", () => {
+      this.closed = true;
+      if (this.waiter) {
+        const w = this.waiter;
+        this.waiter = null;
+        w.reject(new Error("input closed"));
+      }
+    });
+    // Ctrl-C during a question: end the wizard instead of leaving readline in
+    // its default paused state. question() below rejects via the close event.
+    this.rl.on("SIGINT", () => {
+      this.output.write("\n");
+      this.rl.close();
+    });
+  }
+
+  say(text: string): void {
+    this.output.write(text + "\n");
+  }
+
+  private question(prompt: string): Promise<string> {
+    this.output.write(prompt);
+    const queued = this.lines.shift();
+    if (queued !== undefined) return Promise.resolve(queued);
+    if (this.closed) return Promise.reject(new Error("input closed"));
+    return new Promise((resolve, reject) => {
+      this.waiter = { resolve, reject };
+    });
+  }
+
+  /**
+   * Ask for a line of input. An empty answer returns `def` when one is given
+   * (shown in brackets). Re-asks while `validate` returns an error string.
+   */
+  async ask(
+    label: string,
+    opts: { def?: string; validate?: (value: string) => string | null } = {},
+  ): Promise<string> {
+    for (;;) {
+      const suffix = opts.def ? ` [${opts.def}]` : "";
+      const raw = (await this.question(`${label}${suffix}: `)).trim();
+      const value = raw === "" && opts.def !== undefined ? opts.def : raw;
+      const error = opts.validate?.(value) ?? null;
+      if (error === null) return value;
+      this.say(`  ${error}`);
+    }
+  }
+
+  /** Ask without echoing the typed input (passwords). */
+  async askHidden(label: string): Promise<string> {
+    this.output.write(`${label}: `);
+    this.muted = true;
+    try {
+      return await this.question("");
+    } finally {
+      this.muted = false;
+      this.output.write("\n");
+    }
+  }
+
+  async askYesNo(label: string, def: boolean): Promise<boolean> {
+    const hint = def ? "Y/n" : "y/N";
+    for (;;) {
+      const raw = (await this.question(`${label} [${hint}]: `)).trim().toLowerCase();
+      if (raw === "") return def;
+      if (raw === "y" || raw === "yes") return true;
+      if (raw === "n" || raw === "no") return false;
+      this.say("  Please answer y or n.");
+    }
+  }
+
+  async askChoice(label: string, choices: string[], def: string): Promise<string> {
+    return this.ask(`${label} (${choices.join("/")})`, {
+      def,
+      validate: (v) => (choices.includes(v) ? null : `Must be one of: ${choices.join(", ")}`),
+    });
+  }
+
+  close(): void {
+    this.rl.close();
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,7 +91,7 @@ export interface AppConfig {
  * the actual prefix, once in the duplicate-detection loop, and once inside an
  * error message that had to agree with both (issue #124).
  */
-function envPrefix(name: string): string {
+export function envPrefix(name: string): string {
   return name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,13 +26,23 @@ import { extractBearerToken, normalizeClientIp, VERSION, loadBuildInfo } from ".
 const USAGE = `ccu-mcp — MCP server for a HomeMatic CCU (debmatic, CCU3, OpenCCU/RaspberryMatic)
 
 Usage:
-  ccu-mcp [--stdio | --http]
+  ccu-mcp [--stdio | --http] [--env <path>]
+  ccu-mcp init   [--env <path>]
+  ccu-mcp doctor [--env <path>]
   ccu-mcp --version
   ccu-mcp --help
+
+Subcommands:
+  init             Interactive setup: probe the CCU, pin its TLS certificate,
+                   test the login, and write an env file (default: ./.env)
+  doctor           Validate an existing env file end-to-end: reachability,
+                   certificate pin, login, privilege level
 
 Options:
   --stdio          Serve MCP over stdin/stdout (overrides MCP_TRANSPORT)
   --http           Serve MCP over HTTP (default)
+  --env <path>     Load configuration from this dotenv file (already-set
+                   environment variables win, like node's own --env-file)
   -v, --version    Print the version and exit
   -h, --help       Print this help and exit
 
@@ -81,7 +91,26 @@ function handleInfoFlags(argv: string[]): boolean {
 }
 
 async function main(): Promise<void> {
-  if (handleInfoFlags(process.argv.slice(2))) return;
+  const argv = process.argv.slice(2);
+
+  // Subcommands run in the same no-environment-needed early path as the info
+  // flags (issue #112): `ccu-mcp init` exists precisely because there is no
+  // valid configuration yet. Dynamic import keeps server startup unaffected.
+  if (argv[0] === "init" || argv[0] === "doctor") {
+    const mod = argv[0] === "init" ? await import("./cli/init.js") : await import("./cli/doctor.js");
+    process.exitCode = await mod.run(argv.slice(1));
+    return;
+  }
+
+  if (handleInfoFlags(argv)) return;
+
+  // `--env` for server mode: lets an MCP client entry reference the file
+  // `ccu-mcp init` wrote instead of inlining credentials in its JSON config.
+  // Same precedence as node's own flag: already-set environment wins.
+  if (argv.includes("--env")) {
+    const { envFileArg, loadEnvFile, applyEnvVars } = await import("./cli/common.js");
+    applyEnvVars(loadEnvFile(envFileArg(argv)));
+  }
 
   const logger = createLogger();
   const config = loadConfig();

--- a/test/e2e/cli-init.test.ts
+++ b/test/e2e/cli-init.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, spawnSync } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, rmSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { AddressInfo } from "node:net";
+import { DIST, distMissing } from "./_dist.js";
+
+// The wizard subcommands run against the BUILT dist like every e2e suite:
+// piped answers drive `ccu-mcp init` against a mock CCU, and `ccu-mcp doctor`
+// then validates the file init wrote. This proves the whole chain — argv
+// dispatch, prompting over a pipe, probing, login, env writing — not just the
+// units.
+
+function startMockCcu(): Promise<{ server: Server; port: number }> {
+  const results: Record<string, unknown> = {
+    "Session.login": "mock-session-id",
+    "Session.logout": true,
+    "Session.renew": true,
+    "CCU.getVersion": "3.85.7-mock",
+  };
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      let method = "";
+      try {
+        method = (JSON.parse(body) as { method: string }).method;
+      } catch {
+        // fall through
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      if (Object.hasOwn(results, method)) {
+        res.end(JSON.stringify({ version: "2.0", result: results[method], error: null }));
+      } else {
+        res.end(
+          JSON.stringify({
+            version: "2.0",
+            result: null,
+            error: { name: "JSONRPCError", code: 501, message: `unknown method ${method}` },
+          }),
+        );
+      }
+    });
+  });
+  return new Promise((resolve) =>
+    server.listen(0, "127.0.0.1", () =>
+      resolve({ server, port: (server.address() as AddressInfo).port }),
+    ),
+  );
+}
+
+/** Run the built CLI with a scrubbed env and the given stdin (no mock needed). */
+function runCli(args: string[], input = "") {
+  return spawnSync(process.execPath, [DIST, ...args], {
+    env: { PATH: process.env.PATH ?? "" },
+    input,
+    encoding: "utf-8",
+    timeout: 60_000,
+  });
+}
+
+/**
+ * Async variant for tests whose child talks to the mock CCU hosted in THIS
+ * process: spawnSync would block the event loop, the mock could never answer,
+ * and every probe would time out.
+ */
+function runCliAsync(
+  args: string[],
+  input = "",
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [DIST, ...args], {
+      env: { PATH: process.env.PATH ?? "" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf-8").on("data", (chunk: string) => (stdout += chunk));
+    child.stderr.setEncoding("utf-8").on("data", (chunk: string) => (stderr += chunk));
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`CLI run timed out\nstdout so far:\n${stdout}`));
+    }, 60_000);
+    child.on("close", (status) => {
+      clearTimeout(timer);
+      resolve({ status, stdout, stderr });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.stdin.end(input);
+  });
+}
+
+describe.skipIf(distMissing)("CLI wizard (built dist)", () => {
+  let dir: string;
+  let envPath: string;
+  let mock: { server: Server; port: number };
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), "e2e-cli-init-"));
+    envPath = join(dir, ".env");
+    mock = await startMockCcu();
+  });
+
+  afterAll(() => {
+    mock.server.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("--help documents the subcommands and the --env flag", () => {
+    const res = runCli(["--help"]);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("init");
+    expect(res.stdout).toContain("doctor");
+    expect(res.stdout).toContain("--env");
+  });
+
+  it("init writes a working .env from piped answers", async () => {
+    const answers = ["n", "127.0.0.1", "n", String(mock.port), "", "e2e-secret", ""].join("\n");
+    const res = await runCliAsync(["init", "--env", envPath], answers);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("privilege level ADMIN");
+    expect(res.stdout).not.toContain("e2e-secret");
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("CCU_HOST=127.0.0.1");
+    expect(content).toContain("CCU_PASSWORD=e2e-secret");
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("doctor passes on the file init wrote", async () => {
+    const res = await runCliAsync(["doctor", "--env", envPath]);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("All checks passed");
+  });
+
+  it("doctor fails on a broken configuration", () => {
+    const brokenPath = join(dir, "broken.env");
+    writeFileSync(brokenPath, "CCU_HOST=127.0.0.1\n"); // password missing
+    const res = runCli(["doctor", "--env", brokenPath]);
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain("configuration invalid");
+  });
+
+  it("the server itself accepts --env (file is loaded before config validation)", () => {
+    // CCU_HOST comes from the file, CCU_PASSWORD is still missing — the error
+    // proves the env file WAS applied (otherwise it would complain about
+    // CCU_HOST first) without having to boot a whole server.
+    const hostOnly = join(dir, "host-only.env");
+    writeFileSync(hostOnly, "CCU_HOST=127.0.0.1\n");
+    const res = runCli(["--http", "--env", hostOnly]);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("CCU_PASSWORD");
+    expect(res.stderr).not.toContain("CCU_HOST environment variable");
+  });
+
+  it("init without answers exits 130 and writes nothing", () => {
+    const emptyPath = join(dir, "never.env");
+    const res = runCli(["init", "--env", emptyPath]);
+    expect(res.status).toBe(130);
+    expect(() => statSync(emptyPath)).toThrow();
+  });
+});

--- a/test/unit/_mock-ccu.ts
+++ b/test/unit/_mock-ccu.ts
@@ -1,0 +1,88 @@
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
+import type { AddressInfo } from "node:net";
+
+/**
+ * Minimal mock CCU JSON-RPC endpoint for the CLI wizard tests: answers every
+ * POST with the configured result for the request's method, or a JSON-RPC
+ * error envelope. Values in `results` may be an error spec to simulate CCU
+ * error codes (e.g. 400 access denied for privilege probes).
+ */
+export type MockResult = unknown | { __error: { code: number; message: string } };
+
+export interface MockCcu {
+  port: number;
+  calls: string[];
+  close: () => Promise<void>;
+}
+
+function handler(results: Record<string, MockResult>, calls: string[]) {
+  return (req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse): void => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      let method = "";
+      try {
+        method = (JSON.parse(body) as { method: string }).method;
+      } catch {
+        // fall through to the unknown-method error envelope
+      }
+      calls.push(method);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      if (Object.hasOwn(results, method)) {
+        const value = results[method] as MockResult;
+        if (value !== null && typeof value === "object" && "__error" in (value as object)) {
+          const e = (value as { __error: { code: number; message: string } }).__error;
+          res.end(JSON.stringify({ version: "2.0", result: null, error: { name: "Error", ...e } }));
+          return;
+        }
+        res.end(JSON.stringify({ version: "2.0", result: value, error: null }));
+        return;
+      }
+      res.end(
+        JSON.stringify({
+          version: "2.0",
+          result: null,
+          error: { name: "JSONRPCError", code: 501, message: `unknown method ${method}` },
+        }),
+      );
+    });
+  };
+}
+
+export function startMockCcu(results: Record<string, MockResult> = {}): Promise<MockCcu> {
+  const calls: string[] = [];
+  const server: HttpServer = createHttpServer(handler(results, calls));
+  return listen(server, calls);
+}
+
+export function startMockCcuTls(
+  tls: { cert: string; key: string },
+  results: Record<string, MockResult> = {},
+): Promise<MockCcu> {
+  const calls: string[] = [];
+  const server: HttpsServer = createHttpsServer(tls, handler(results, calls));
+  return listen(server, calls);
+}
+
+function listen(server: HttpServer | HttpsServer, calls: string[]): Promise<MockCcu> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        port: (server.address() as AddressInfo).port,
+        calls,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+/** The standard happy-path result set: login works, the user is ADMIN. */
+export function adminResults(): Record<string, MockResult> {
+  return {
+    "Session.login": "mock-session-id",
+    "Session.logout": true,
+    "Session.renew": true,
+    "CCU.getVersion": "3.85.7-mock",
+  };
+}

--- a/test/unit/cli-doctor.test.ts
+++ b/test/unit/cli-doctor.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PassThrough } from "node:stream";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { X509Certificate } from "node:crypto";
+import { run } from "../../src/cli/doctor.js";
+import type { PromptIo } from "../../src/cli/prompt.js";
+import { startMockCcu, startMockCcuTls, adminResults, type MockCcu } from "./_mock-ccu.js";
+
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+
+// doctor loads the env file into process.env (same precedence as the server's
+// --env flag), so every test must start from a scrubbed environment and leave
+// no residue for the next one.
+const savedEnv = { ...process.env };
+function scrubEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (/^(CCU_|MCP_|CACHE_)/.test(key)) delete process.env[key];
+  }
+}
+function restoreEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, savedEnv);
+}
+
+function makeIo(answers: string[], tty = false): { io: PromptIo; output: () => string } {
+  const input = new PassThrough() as PassThrough & { isTTY?: boolean };
+  if (tty) input.isTTY = true;
+  const output = new PassThrough();
+  let out = "";
+  output.on("data", (chunk) => (out += String(chunk)));
+  input.end(answers.join("\n") + "\n");
+  return { io: { input, output }, output: () => out };
+}
+
+describe("ccu-mcp doctor", () => {
+  let dir: string;
+  let envPath: string;
+  let mock: MockCcu | undefined;
+
+  beforeEach(() => {
+    scrubEnv();
+    dir = mkdtempSync(join(tmpdir(), "cli-doctor-"));
+    envPath = join(dir, ".env");
+  });
+
+  afterEach(async () => {
+    restoreEnv();
+    rmSync(dir, { recursive: true, force: true });
+    await mock?.close();
+    mock = undefined;
+  });
+
+  it("passes on a valid flat configuration", async () => {
+    mock = await startMockCcu(adminResults());
+    writeFileSync(envPath, `CCU_HOST=127.0.0.1\nCCU_PORT=${mock.port}\nCCU_PASSWORD=pw\n`);
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain("All checks passed");
+    expect(output()).toContain("privilege level ADMIN");
+  });
+
+  it("fails when the env file does not exist", async () => {
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", join(dir, "missing.env")], io)).toBe(1);
+    expect(output()).toContain("✗");
+  });
+
+  it("reports configuration errors as findings", async () => {
+    writeFileSync(envPath, "CCU_HOST=127.0.0.1\n"); // no password
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(output()).toContain("configuration invalid");
+    expect(output()).toContain("CCU_PASSWORD");
+  });
+
+  it("fails on an unreachable CCU", async () => {
+    // Reserve a port and free it again so nothing answers there.
+    mock = await startMockCcu();
+    const port = mock.port;
+    await mock.close();
+    mock = undefined;
+    writeFileSync(envPath, `CCU_HOST=127.0.0.1\nCCU_PORT=${port}\nCCU_PASSWORD=pw\n`);
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(output()).toContain("not reachable");
+  });
+
+  it("checks every profile of a multi-target file", async () => {
+    mock = await startMockCcu(adminResults());
+    writeFileSync(
+      envPath,
+      [
+        "CCU_PROFILES=prod,dev",
+        "CCU_DEFAULT_PROFILE=prod",
+        `CCU_PROD_HOST=127.0.0.1`,
+        `CCU_PROD_PORT=${mock.port}`,
+        "CCU_PROD_PASSWORD=pw",
+        `CCU_DEV_HOST=127.0.0.1`,
+        `CCU_DEV_PORT=${mock.port}`,
+        "CCU_DEV_PASSWORD=pw",
+        "",
+      ].join("\n"),
+    );
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain('Target "prod"');
+    expect(output()).toContain('Target "dev"');
+  });
+});
+
+describe.skipIf(!HAVE_OPENSSL)("ccu-mcp doctor TLS pin checks", () => {
+  let dir: string;
+  let tlsDir: string;
+  let envPath: string;
+  let mock: MockCcu;
+  let fingerprint: string;
+
+  beforeEach(async () => {
+    scrubEnv();
+    dir = mkdtempSync(join(tmpdir(), "cli-doctor-tls-"));
+    tlsDir = mkdtempSync(join(tmpdir(), "cli-doctor-cert-"));
+    envPath = join(dir, ".env");
+    const certPath = join(tlsDir, "cert.pem");
+    const keyPath = join(tlsDir, "key.pem");
+    spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=ccu-doctor",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    const certPem = readFileSync(certPath, "utf-8");
+    fingerprint = new X509Certificate(certPem).fingerprint256;
+    mock = await startMockCcuTls({ cert: certPem, key: readFileSync(keyPath, "utf-8") }, adminResults());
+  });
+
+  afterEach(async () => {
+    restoreEnv();
+    await mock.close();
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(tlsDir, { recursive: true, force: true });
+  });
+
+  function writeEnv(pin: string): void {
+    writeFileSync(
+      envPath,
+      `CCU_HOST=127.0.0.1\nCCU_PORT=${mock.port}\nCCU_HTTPS=true\nCCU_TLS_FINGERPRINT=${pin}\nCCU_PASSWORD=pw\n`,
+    );
+  }
+
+  it("passes when the pinned fingerprint matches", async () => {
+    writeEnv(fingerprint);
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain("fingerprint matches");
+  });
+
+  it("reports a mismatch and skips the login test (non-interactive)", async () => {
+    writeEnv("00".repeat(32));
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(output()).toContain("does NOT match");
+    expect(output()).toContain("skipping the login test");
+    // Non-interactive: the file must not have been touched.
+    expect(readFileSync(envPath, "utf-8")).toContain("00".repeat(32));
+  });
+
+  it("offers to refresh the pin when interactive, then a re-run passes", async () => {
+    writeEnv("00".repeat(32));
+    const first = makeIo(["y"], true);
+    expect(await run(["--env", envPath], first.io)).toBe(1);
+    expect(first.output()).toContain("Pin updated");
+    expect(readFileSync(envPath, "utf-8")).toContain(`CCU_TLS_FINGERPRINT=${fingerprint}`);
+
+    // Doctor's env application skips already-set keys; scrub between runs so
+    // the second run reads the refreshed file, not the first run's residue.
+    scrubEnv();
+    const second = makeIo([]);
+    expect(await run(["--env", envPath], second.io)).toBe(0);
+    expect(second.output()).toContain("All checks passed");
+  });
+
+  it("leaves the pin alone when the user declines", async () => {
+    writeEnv("00".repeat(32));
+    const { io } = makeIo(["n"], true);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(readFileSync(envPath, "utf-8")).toContain("00".repeat(32));
+  });
+});

--- a/test/unit/cli-env-writer.test.ts
+++ b/test/unit/cli-env-writer.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { parseEnv } from "node:util";
+import { mkdtempSync, rmSync, statSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  MANAGED_KEY_RE,
+  quoteEnvValue,
+  buildEnvContent,
+  mergeEnvContent,
+  replaceEnvKey,
+  writeEnvFile,
+  type WizardProfile,
+} from "../../src/cli/env-writer.js";
+
+function profile(overrides: Partial<WizardProfile> = {}): WizardProfile {
+  return {
+    name: "default",
+    host: "ccu.local",
+    port: 443,
+    https: true,
+    user: "Admin",
+    password: "pw",
+    protected: false,
+    readonly: false,
+    ...overrides,
+  };
+}
+
+describe("quoteEnvValue", () => {
+  // Round-trip through the same parser doctor and the server's --env flag
+  // use: whatever the writer quotes, parseEnv must read back verbatim.
+  it("round-trips awkward values through util.parseEnv", () => {
+    const values = ["plain", "with space", "pa#ss", 'quo"te', "s'ngle", "back`tick", 'mi"x\'ed', "", "tra1l1ng!"];
+    for (const value of values) {
+      const parsed = parseEnv(`KEY=${quoteEnvValue(value)}`) as Record<string, string>;
+      expect(parsed.KEY, JSON.stringify(value)).toBe(value);
+    }
+  });
+
+  it("rejects a value containing all three quote characters", () => {
+    expect(() => quoteEnvValue("a\"b'c`d")).toThrow(/quote characters/);
+  });
+});
+
+describe("buildEnvContent", () => {
+  it("writes flat vars for a single target", () => {
+    const content = buildEnvContent([profile({ tlsFingerprint: "AB:CD" })], "default");
+    expect(content).toContain("CCU_HOST=ccu.local");
+    expect(content).toContain("CCU_PORT=443");
+    expect(content).toContain("CCU_HTTPS=true");
+    expect(content).toContain("CCU_USER=Admin");
+    expect(content).toContain("CCU_PASSWORD=pw");
+    expect(content).toContain("CCU_TLS_FINGERPRINT=AB:CD");
+    expect(content).not.toContain("CCU_PROFILES");
+    expect(content).not.toContain("PROTECTED");
+  });
+
+  it("writes CCU_PROFILES form for multiple targets", () => {
+    const content = buildEnvContent(
+      [
+        profile({ name: "prod", protected: true }),
+        profile({ name: "dev", host: "dev.local", https: false, port: 80, readonly: true }),
+      ],
+      "prod",
+    );
+    expect(content).toContain("CCU_PROFILES=prod,dev");
+    expect(content).toContain("CCU_DEFAULT_PROFILE=prod");
+    expect(content).toContain("CCU_PROD_HOST=ccu.local");
+    expect(content).toContain("CCU_PROD_PROTECTED=true");
+    expect(content).toContain("CCU_DEV_HOST=dev.local");
+    expect(content).toContain("CCU_DEV_READONLY=true");
+    expect(content).not.toContain("CCU_DEV_PROTECTED");
+    expect(content).not.toContain("\nCCU_HOST=");
+  });
+});
+
+describe("mergeEnvContent", () => {
+  const existing = [
+    "# operator notes",
+    "MCP_AUTH_TOKEN=tok123",
+    "CCU_HOST=old.local",
+    "CCU_PASSWORD=oldpw",
+    "CCU_OLDPROF_HOST=stale.local",
+    "CCU_RATE_LIMIT_BURST=50",
+    "CCU_TIMEOUT=20000",
+    "LOG_LEVEL=debug",
+  ].join("\n");
+
+  it("replaces managed keys (any profile prefix) and preserves the rest", () => {
+    const managed = buildEnvContent([profile()], "default");
+    const { content, replaced } = mergeEnvContent(existing, managed);
+    expect(replaced).toEqual(["CCU_HOST", "CCU_PASSWORD", "CCU_OLDPROF_HOST"]);
+    expect(content).toContain("CCU_HOST=ccu.local");
+    expect(content).not.toContain("old.local");
+    expect(content).not.toContain("stale.local");
+    // Operator-owned lines survive: token, comments, tuning knobs.
+    expect(content).toContain("MCP_AUTH_TOKEN=tok123");
+    expect(content).toContain("# operator notes");
+    expect(content).toContain("CCU_RATE_LIMIT_BURST=50");
+    expect(content).toContain("CCU_TIMEOUT=20000");
+    expect(content).toContain("LOG_LEVEL=debug");
+  });
+
+  it("managed-key regex owns the roster keys but not tuning knobs", () => {
+    for (const line of ["CCU_PROFILES=a,b", "CCU_DEFAULT_PROFILE=a", "CCU_PROD_TLS_FINGERPRINT=x"]) {
+      expect(MANAGED_KEY_RE.test(line), line).toBe(true);
+    }
+    for (const line of ["CCU_RATE_LIMIT_BURST=1", "CCU_RATE_LIMIT_RATE=1", "CCU_TIMEOUT=1", "CCU_PROD_SCRIPT_TIMEOUT=1", "MCP_PORT=3000"]) {
+      expect(MANAGED_KEY_RE.test(line), line).toBe(false);
+    }
+  });
+});
+
+describe("replaceEnvKey", () => {
+  it("replaces an existing key in place", () => {
+    const content = "CCU_HOST=x\nCCU_TLS_FINGERPRINT=old\nLOG_LEVEL=info\n";
+    const out = replaceEnvKey(content, "CCU_TLS_FINGERPRINT", "new");
+    expect(out).toContain("CCU_TLS_FINGERPRINT=new");
+    expect(out).not.toContain("old");
+    expect(out).toContain("LOG_LEVEL=info");
+  });
+
+  it("appends when the key is missing", () => {
+    const out = replaceEnvKey("CCU_HOST=x\n", "CCU_TLS_FINGERPRINT", "new");
+    expect(out).toContain("CCU_HOST=x");
+    expect(out.trimEnd().endsWith("CCU_TLS_FINGERPRINT=new")).toBe(true);
+  });
+});
+
+describe("writeEnvFile", () => {
+  it("writes mode 0600", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cli-env-"));
+    try {
+      const path = join(dir, ".env");
+      writeEnvFile(path, "CCU_HOST=x\n");
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+      expect(readFileSync(path, "utf-8")).toBe("CCU_HOST=x\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/cli-init.test.ts
+++ b/test/unit/cli-init.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PassThrough } from "node:stream";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { X509Certificate } from "node:crypto";
+import { run } from "../../src/cli/init.js";
+import type { PromptIo } from "../../src/cli/prompt.js";
+import { startMockCcu, startMockCcuTls, adminResults, type MockCcu } from "./_mock-ccu.js";
+
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+
+function makeIo(answers: string[]): { io: PromptIo; output: () => string } {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  let out = "";
+  output.on("data", (chunk) => (out += String(chunk)));
+  input.end(answers.join("\n") + "\n");
+  return { io: { input, output }, output: () => out };
+}
+
+describe("ccu-mcp init", () => {
+  let dir: string;
+  let envPath: string;
+  let mock: MockCcu | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "cli-init-"));
+    envPath = join(dir, ".env");
+  });
+
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true });
+    await mock?.close();
+    mock = undefined;
+  });
+
+  it("writes a flat .env for a single target (happy path)", async () => {
+    mock = await startMockCcu(adminResults());
+    const { io, output } = makeIo([
+      "n", // multiple targets?
+      "127.0.0.1", // host
+      "n", // HTTPS?
+      String(mock.port), // port
+      "", // user -> Admin
+      "s3cret", // password
+    ]);
+    const code = await run(["--env", envPath], io);
+    expect(code).toBe(0);
+    expect(output()).toContain("privilege level ADMIN");
+    expect(output()).toContain("--env");
+    expect(output()).not.toContain("s3cret"); // never echo the password
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("CCU_HOST=127.0.0.1");
+    expect(content).toContain(`CCU_PORT=${mock.port}`);
+    expect(content).toContain("CCU_HTTPS=false");
+    expect(content).toContain("CCU_USER=Admin");
+    expect(content).toContain("CCU_PASSWORD=s3cret");
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("writes CCU_PROFILES for a multi-target setup", async () => {
+    mock = await startMockCcu(adminResults());
+    const p = String(mock.port);
+    const { io } = makeIo([
+      "y", // multiple targets
+      "", // name -> prod
+      "127.0.0.1", "n", p, "", "pw1", // endpoint + creds
+      "y", // protected
+      "", // readonly -> n
+      "y", // add another
+      "dev", // name
+      "127.0.0.1", "n", p, "", "pw2",
+      "", "", // protected/readonly -> n
+      "", // add another -> n
+      "dev", // default target
+    ]);
+    const code = await run(["--env", envPath], io);
+    expect(code).toBe(0);
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("CCU_PROFILES=prod,dev");
+    expect(content).toContain("CCU_DEFAULT_PROFILE=dev");
+    expect(content).toContain("CCU_PROD_PROTECTED=true");
+    expect(content).toContain("CCU_DEV_HOST=127.0.0.1");
+    expect(content).not.toContain("CCU_DEV_PROTECTED");
+  });
+
+  it("warns about USER-level accounts", async () => {
+    mock = await startMockCcu({
+      ...adminResults(),
+      "CCU.getVersion": { __error: { code: 400, message: "access denied" } },
+    });
+    const { io, output } = makeIo(["n", "127.0.0.1", "n", String(mock.port), "claude", "pw"]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain("privilege level USER");
+    expect(output()).toContain("need an ADMIN-level CCU user");
+  });
+
+  it("aborts without writing when credentials fail and the user gives up", async () => {
+    mock = await startMockCcu({
+      ...adminResults(),
+      "Session.login": { __error: { code: 400, message: "access denied" } },
+    });
+    const { io, output } = makeIo([
+      "n", "127.0.0.1", "n", String(mock.port), "", "wrongpw",
+      "n", // re-enter?
+      "n", // save anyway?
+    ]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(output()).toContain("Login failed");
+    expect(existsSync(envPath)).toBe(false);
+  });
+
+  it("can save untested credentials on explicit request", async () => {
+    mock = await startMockCcu({
+      ...adminResults(),
+      "Session.login": { __error: { code: 400, message: "access denied" } },
+    });
+    const { io } = makeIo([
+      "n", "127.0.0.1", "n", String(mock.port), "", "maybe-right",
+      "n", // re-enter?
+      "y", // save anyway
+    ]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(readFileSync(envPath, "utf-8")).toContain("CCU_PASSWORD=maybe-right");
+  });
+
+  it("preserves foreign lines and asks before replacing managed keys", async () => {
+    mock = await startMockCcu(adminResults());
+    writeFileSync(envPath, "MCP_AUTH_TOKEN=tok\nCCU_HOST=old.local\n");
+    const { io, output } = makeIo([
+      "n", "127.0.0.1", "n", String(mock.port), "", "pw",
+      "y", // replace existing CCU settings
+    ]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain("already configures a CCU");
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("MCP_AUTH_TOKEN=tok");
+    expect(content).toContain("CCU_HOST=127.0.0.1");
+    expect(content).not.toContain("old.local");
+  });
+
+  it("leaves an existing file untouched when the user declines", async () => {
+    mock = await startMockCcu(adminResults());
+    const before = "CCU_HOST=old.local\nCCU_PASSWORD=oldpw\n";
+    writeFileSync(envPath, before);
+    const { io } = makeIo([
+      "n", "127.0.0.1", "n", String(mock.port), "", "pw",
+      "n", // do NOT replace
+    ]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(readFileSync(envPath, "utf-8")).toBe(before);
+  });
+
+  it("returns 130 when the input closes mid-wizard", async () => {
+    const { io } = makeIo(["n"]); // only the first answer, then EOF
+    expect(await run(["--env", envPath], io)).toBe(130);
+    expect(existsSync(envPath)).toBe(false);
+  });
+});
+
+describe.skipIf(!HAVE_OPENSSL)("ccu-mcp init over HTTPS", () => {
+  let dir: string;
+  let tlsDir: string;
+  let mock: MockCcu;
+  let fingerprint: string;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "cli-init-tls-"));
+    tlsDir = mkdtempSync(join(tmpdir(), "cli-init-cert-"));
+    const certPath = join(tlsDir, "cert.pem");
+    const keyPath = join(tlsDir, "key.pem");
+    spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=ccu-init",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    const certPem = readFileSync(certPath, "utf-8");
+    fingerprint = new X509Certificate(certPem).fingerprint256;
+    mock = await startMockCcuTls({ cert: certPem, key: readFileSync(keyPath, "utf-8") }, adminResults());
+  });
+
+  afterEach(async () => {
+    await mock.close();
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(tlsDir, { recursive: true, force: true });
+  });
+
+  it("shows the certificate and pins its fingerprint", async () => {
+    const envPath = join(dir, ".env");
+    const { io, output } = makeIo([
+      "n", "127.0.0.1",
+      "y", // HTTPS
+      String(mock.port),
+      "y", // pin fingerprint
+      "", "pw",
+    ]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain("ccu-init"); // subject CN shown
+    expect(readFileSync(envPath, "utf-8")).toContain(`CCU_TLS_FINGERPRINT=${fingerprint}`);
+  });
+});

--- a/test/unit/cli-probe.test.ts
+++ b/test/unit/cli-probe.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { X509Certificate } from "node:crypto";
+import type { AddressInfo } from "node:net";
+import {
+  probeApi,
+  probeConfig,
+  fetchCert,
+  fingerprintMatches,
+  testLogin,
+} from "../../src/cli/probe.js";
+import { startMockCcu, startMockCcuTls, adminResults, type MockCcu } from "./_mock-ccu.js";
+
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+
+describe("probeApi", () => {
+  it("classifies a JSON-RPC error envelope as a CCU", async () => {
+    const mock = await startMockCcu(); // every method -> error envelope
+    try {
+      const outcome = await probeApi(probeConfig("127.0.0.1", mock.port, false));
+      expect(outcome.kind).toBe("ccu");
+    } finally {
+      await mock.close();
+    }
+  });
+
+  it("classifies a non-JSON-RPC HTTP server as not-ccu", async () => {
+    const server: Server = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<html>hello</html>");
+    });
+    const port = await new Promise<number>((resolve) =>
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port)),
+    );
+    try {
+      const outcome = await probeApi(probeConfig("127.0.0.1", port, false));
+      expect(outcome.kind).toBe("not-ccu");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("classifies a closed port as unreachable", async () => {
+    // Grab an ephemeral port and free it again — nothing listens there now.
+    const server: Server = createServer(() => {});
+    const port = await new Promise<number>((resolve) =>
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port)),
+    );
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    const outcome = await probeApi(probeConfig("127.0.0.1", port, false));
+    expect(outcome.kind).toBe("unreachable");
+  });
+});
+
+describe("testLogin", () => {
+  let mock: MockCcu;
+
+  afterAll(async () => {
+    await mock?.close();
+  });
+
+  it("reports ADMIN when the capability probe answers", async () => {
+    mock = await startMockCcu(adminResults());
+    const result = await testLogin({ ...probeConfig("127.0.0.1", mock.port, false), user: "Admin", password: "pw" });
+    expect(result).toMatchObject({ ok: true, role: "ADMIN", version: "3.85.7-mock" });
+    // The probe must clean up after itself: the session it minted is logged out.
+    expect(mock.calls).toContain("Session.logout");
+    await mock.close();
+  });
+
+  it("reports USER when the ADMIN-only probe is denied", async () => {
+    // Code 400 is the CCU's "access denied"; with the session still valid the
+    // session manager surfaces it as a privilege denial, which means USER.
+    mock = await startMockCcu({
+      ...adminResults(),
+      "CCU.getVersion": { __error: { code: 400, message: "access denied" } },
+    });
+    const result = await testLogin({ ...probeConfig("127.0.0.1", mock.port, false), user: "claude", password: "pw" });
+    expect(result).toMatchObject({ ok: true, role: "USER" });
+    await mock.close();
+  });
+
+  it("reports UNKNOWN when the probe fails for a non-privilege reason", async () => {
+    mock = await startMockCcu({
+      ...adminResults(),
+      "CCU.getVersion": { __error: { code: 501, message: "internal error" } },
+    });
+    const result = await testLogin({ ...probeConfig("127.0.0.1", mock.port, false), user: "Admin", password: "pw" });
+    expect(result).toMatchObject({ ok: true, role: "UNKNOWN" });
+    await mock.close();
+  });
+
+  it("returns the structured error when login fails", async () => {
+    mock = await startMockCcu({
+      ...adminResults(),
+      "Session.login": { __error: { code: 400, message: "access denied" } },
+    });
+    const result = await testLogin({ ...probeConfig("127.0.0.1", mock.port, false), user: "Admin", password: "wrong" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.error).toBe("AUTH");
+    await mock.close();
+  });
+});
+
+describe.skipIf(!HAVE_OPENSSL)("fetchCert (real HTTPS server)", () => {
+  let mock: MockCcu;
+  let fingerprint: string;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "cli-probe-tls-"));
+    const certPath = join(tmpDir, "cert.pem");
+    const keyPath = join(tmpDir, "key.pem");
+    const gen = spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=ccu-test",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    if (gen.status !== 0) throw new Error("openssl failed to generate test cert");
+    const certPem = readFileSync(certPath, "utf-8");
+    fingerprint = new X509Certificate(certPem).fingerprint256;
+    mock = await startMockCcuTls({ cert: certPem, key: readFileSync(keyPath, "utf-8") }, adminResults());
+  });
+
+  afterAll(async () => {
+    await mock?.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the certificate's SHA-256 fingerprint and subject", async () => {
+    const cert = await fetchCert("127.0.0.1", mock.port);
+    expect(fingerprintMatches(cert.fingerprint256, fingerprint)).toBe(true);
+    expect(cert.subjectCN).toBe("ccu-test");
+  });
+
+  it("fingerprintMatches is colon- and case-insensitive", () => {
+    expect(fingerprintMatches(fingerprint.replace(/:/g, "").toLowerCase(), fingerprint)).toBe(true);
+    expect(fingerprintMatches("00".repeat(32), fingerprint)).toBe(false);
+  });
+
+  it("probes and logs in over HTTPS with a pinned fingerprint", async () => {
+    const config = {
+      ...probeConfig("127.0.0.1", mock.port, true),
+      tlsFingerprint: fingerprint,
+      user: "Admin",
+      password: "pw",
+    };
+    expect((await probeApi(config)).kind).toBe("ccu");
+    const result = await testLogin(config);
+    expect(result).toMatchObject({ ok: true, role: "ADMIN" });
+  });
+
+  it("rejects on a connection that is not TLS", async () => {
+    const plain = await startMockCcu();
+    try {
+      await expect(fetchCert("127.0.0.1", plain.port, 2000)).rejects.toThrow();
+    } finally {
+      await plain.close();
+    }
+  });
+});

--- a/test/unit/cli-prompt.test.ts
+++ b/test/unit/cli-prompt.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { PassThrough } from "node:stream";
+import { Prompter, type PromptIo } from "../../src/cli/prompt.js";
+
+function makeIo(text?: string): { io: PromptIo; input: PassThrough; output: () => string } {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  let out = "";
+  output.on("data", (chunk) => (out += String(chunk)));
+  if (text !== undefined) input.end(text);
+  return { io: { input, output }, input, output: () => out };
+}
+
+describe("Prompter", () => {
+  it("returns the trimmed answer", async () => {
+    const { io } = makeIo("  debmatic  \n");
+    const ui = new Prompter(io);
+    expect(await ui.ask("Host")).toBe("debmatic");
+    ui.close();
+  });
+
+  it("falls back to the default on empty input and shows it in the prompt", async () => {
+    const { io, output } = makeIo("\n");
+    const ui = new Prompter(io);
+    expect(await ui.ask("CCU user", { def: "Admin" })).toBe("Admin");
+    expect(output()).toContain("[Admin]");
+    ui.close();
+  });
+
+  it("re-asks while validate rejects", async () => {
+    const { io, output } = makeIo("nope\n42\n");
+    const ui = new Prompter(io);
+    const answer = await ui.ask("Port", {
+      validate: (v) => (/^\d+$/.test(v) ? null : "Digits only."),
+    });
+    expect(answer).toBe("42");
+    expect(output()).toContain("Digits only.");
+    ui.close();
+  });
+
+  // The regression this design exists for: piped input delivers every answer
+  // in ONE chunk before the second question is even asked. rl.question()
+  // would emit the excess lines with no listener attached and drop them.
+  it("answers multiple questions from a single buffered chunk", async () => {
+    const { io } = makeIo("one\ntwo\nthree\n");
+    const ui = new Prompter(io);
+    expect(await ui.ask("A")).toBe("one");
+    await new Promise((r) => setTimeout(r, 10)); // let any stray events fire
+    expect(await ui.ask("B")).toBe("two");
+    expect(await ui.ask("C")).toBe("three");
+    ui.close();
+  });
+
+  it("parses yes/no with a default", async () => {
+    const { io, output } = makeIo("\ny\nno\nmaybe\nn\n");
+    const ui = new Prompter(io);
+    expect(await ui.askYesNo("Q1", true)).toBe(true); // empty -> default
+    expect(await ui.askYesNo("Q2", false)).toBe(true);
+    expect(await ui.askYesNo("Q3", true)).toBe(false);
+    expect(await ui.askYesNo("Q4", true)).toBe(false); // "maybe" re-asks, then "n"
+    expect(output()).toContain("Please answer y or n.");
+    ui.close();
+  });
+
+  it("askChoice accepts only listed values", async () => {
+    const { io, output } = makeIo("staging\ndev\n");
+    const ui = new Prompter(io);
+    expect(await ui.askChoice("Default target", ["prod", "dev"], "prod")).toBe("dev");
+    expect(output()).toContain("Must be one of: prod, dev");
+    ui.close();
+  });
+
+  it("askHidden returns the answer without echoing it", async () => {
+    const { io, output } = makeIo("s3cret\n");
+    const ui = new Prompter(io);
+    expect(await ui.askHidden("Password")).toBe("s3cret");
+    expect(output()).toContain("Password: ");
+    expect(output()).not.toContain("s3cret");
+    ui.close();
+  });
+
+  it("rejects a pending question when the input closes", async () => {
+    const { io, input } = makeIo();
+    const ui = new Prompter(io);
+    const pending = ui.ask("Host");
+    input.end();
+    await expect(pending).rejects.toThrow("input closed");
+  });
+
+  it("rejects new questions after close", async () => {
+    const { io } = makeIo("only-line\n");
+    const ui = new Prompter(io);
+    expect(await ui.ask("A")).toBe("only-line");
+    ui.close();
+    await expect(ui.ask("B")).rejects.toThrow("input closed");
+  });
+});


### PR DESCRIPTION
First phase of the configuration-experience plan (ROADMAP → Configuration experience, #194). Closes #195 and its sub-issues #197–#202.

## What's in here

- **`ccu-mcp init`** — interactive wizard: probe (auto-detect HTTPS/port), show + pin the TLS certificate, test login, report ADMIN/USER privilege level, write a 0600 env file (flat or `CCU_PROFILES`), print ready-to-paste MCP client snippets. Re-running preserves foreign lines and confirms before replacing managed CCU keys.
- **`ccu-mcp doctor`** — end-to-end validation of an env file: config errors, reachability, pin match (with interactive refresh offer), login, privilege level; exit 1 on any failure.
- **`--env <path>`** server flag — dotenv loading so client configs need no inline credentials. Named `--env` because node itself intercepts `--env-file` even after the script path and dies when the file is missing — the exact starting state of `init`.
- Probe core is prompting-free for reuse by the LLM-guided setup (#196).

## Notes for review

- `normalizeFingerprint` (client.ts) and `envPrefix` (config.ts) are now exported; no behavior change.
- New `src/cli` coverage-baseline entry seeded at measured 89.7/77.3 (uncovered remainder is TTY-only paths: raw-mode echo muting, SIGINT).
- Tests: 4 unit files (prompt, env-writer, probe, init+doctor flows against mock CCUs incl. a real-TLS one) + an e2e suite spawning the built dist with piped answers. The e2e helper uses async `spawn` — `spawnSync` would block the event loop hosting the mock CCU.
- Verified live: `doctor` against the prod CCU passes all checks (real pin, real login, ADMIN detected); a deliberately wrong pin is reported with both fingerprints and skips the login test; the offline dev container is reported unreachable.

Additive only — no change to existing server behavior. Ships as 1.11.0 (no release with this PR).