### PR TITLE
feat: LLM-guided setup — setup mode, setup_* tools, ccu-mcp secret (#196)

### DIFF
--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -50,7 +50,9 @@ src/ccu 91.6 87.1
 # src/cli (init-wizard PR): seeded at measured (89.7/77.3). Interactive CLI
 # code; the uncovered remainder is TTY-only paths (raw-mode echo suppression,
 # SIGINT) that a piped test harness cannot reach.
-src/cli 89.7 77.3
+# branches 77.3 -> 78.3 (llm-setup PR): RAISED, earned by
+# test/unit/cli-secret.test.ts covering secret.ts's flat/profile/error arms.
+src/cli 89.7 78.3
 src/health 100.0 100.0
 src/http 100.0 100.0
 # src/middleware 99.2/92.2 -> 99.2/95.2 (prototype-key PR): branches RAISED,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
   precedence. (Named `--env` because node's own CLI intercepts an
   `--env-file` argument even after the script path and refuses to start when
   the file does not exist yet — exactly the state `init` begins in.)
+- **LLM-guided setup (setup mode)** (#196): started with `--stdio --env
+  <path>` and a missing/invalid configuration, the server no longer exits —
+  it comes up as a minimal MCP server exposing only `setup_status`,
+  `setup_probe`, `setup_write_profile` and `setup_test`, so it can be
+  registered in an MCP client *before* it is configured and the LLM walks the
+  user through the same probe → pin → test-login → write flow in chat. The
+  password never travels through the model or the transcript:
+  `setup_write_profile` has no password parameter and hands off to the new
+  **`ccu-mcp secret [profile]`** subcommand, a local hidden prompt that
+  writes only the password key into the env file (mode 0600; also the
+  password-rotation path). After `setup_test` passes, reconnecting the server
+  with the identical client entry starts it fully configured. Setup mode is
+  stdio-only; a bare start without `--env` still fails loudly, and the HTTP
+  transport never enters it.
 
 ## v1.10.0 — 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ ccu-mcp init           # interactive setup: probe the CCU, pin its TLS cert,
                        #   test the login, write an env file (default ./.env)
 ccu-mcp doctor         # validate an env file end-to-end: reachability,
                        #   certificate pin, login, privilege level
+ccu-mcp secret [prof]  # store the CCU password into an env file via a local
+                       #   hidden prompt (used by the LLM-guided setup below;
+                       #   also the password-rotation path)
 ccu-mcp --stdio        # serve over stdin/stdout (overrides MCP_TRANSPORT)
 ccu-mcp --http         # serve over HTTP (default)
 ccu-mcp --env <path>   # load configuration from a dotenv file (already-set
@@ -282,6 +285,38 @@ tools need ADMIN), and ends with a ready-to-paste MCP client snippet. It
 needs no pre-existing configuration. `ccu-mcp doctor` exits non-zero when any
 check fails, so it also works in scripts; run it interactively to be offered
 a pin refresh when the CCU's certificate legitimately rotated.
+
+### LLM-guided setup (setup mode)
+
+The wizard has a conversational twin: register the server in an MCP client
+**before** configuring it. Started with `--stdio --env <path>` and a missing or
+incomplete configuration, the server comes up in **setup mode** — a minimal MCP
+server exposing only four `setup_*` tools (`setup_status`, `setup_probe`,
+`setup_write_profile`, `setup_test`) plus instructions that let the LLM walk
+you through the same probe → pin → test-login → write flow in plain chat.
+
+```json
+{
+  "mcpServers": {
+    "ccu-mcp": {
+      "command": "npx",
+      "args": ["ccu-mcp", "--stdio", "--env", "/path/to/.env"]
+    }
+  }
+}
+```
+
+Then just ask: *"set up my CCU connection"*. One deliberate exception: **the
+password never travels through the model or the chat transcript**.
+`setup_write_profile` has no password parameter; instead the assistant hands
+you a one-liner to run in a terminal — `ccu-mcp secret <profile> --env
+/path/to/.env` — which prompts locally with echo off and writes only the
+password into the file (mode 0600). Once `setup_test` reports green, reconnect
+the MCP server and the identical client entry starts it fully configured.
+
+Setup mode is stdio-only (an unconfigured HTTP endpoint that writes config
+files would be an unacceptable surface), and a bare start without `--env`
+still fails loudly instead of silently serving setup tools.
 
 `--version` and `--help` need no configuration — use them to check what an
 installed copy actually is, e.g. after updating:
@@ -372,7 +407,10 @@ without switching.
 Some mistakes stop the server at startup instead of being ignored. Each of these
 would otherwise fail *silently* and much later, so the exit is deliberate.
 `ccu-mcp doctor` reports the same errors against an env file without starting
-the server, alongside its live checks (reachability, certificate pin, login):
+the server, alongside its live checks (reachability, certificate pin, login).
+One exception: started with `--stdio --env <path>`, a failing configuration
+enters [setup mode](#llm-guided-setup-setup-mode) (with the error in the
+server's instructions) instead of exiting, so it can be fixed conversationally:
 
 | Message | Cause and why it's fatal |
 |---|---|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,14 +58,16 @@ discarding it each night wasted most of the value of running the fuzzer.
      privilege level (USER vs ADMIN), writes a valid `.env`, and emits
      ready-to-paste client config snippets. Works over SSH, adds no attack
      surface.
-  2. **LLM-guided setup on the same core.** Register the server with an empty
-     config (it already starts without one) and let a `setup` tool walk the
-     conversation through the same probe/pin/validate steps. One deliberate
-     exception: the password never travels through the model or the chat
-     transcript — the setup tool hands off to `ccu-mcp secret <profile>`, a
-     one-line local prompt that writes just the secret. MCP elicitation could
-     replace the chat round-trips where clients support it, but the spec
-     forbids eliciting secrets, so the CLI hand-off stays either way.
+  2. **LLM-guided setup on the same core.** Started with `--stdio --env
+     <path>` and a missing/invalid config, the server enters a stdio-only
+     *setup mode* exposing just `setup_*` tools, so it can be registered in an
+     MCP client before it is configured and the conversation walks through the
+     same probe/pin/validate steps. One deliberate exception: the password
+     never travels through the model or the chat transcript — the setup flow
+     hands off to `ccu-mcp secret <profile>`, a one-line local prompt that
+     writes just the secret. MCP elicitation could replace the chat
+     round-trips where clients support it, but the spec forbids eliciting
+     secrets, so the CLI hand-off stays either way.
   3. Maybe later, `ccu-mcp config --ui` — a browser form bound to 127.0.0.1
      with a one-time token, process exits when closed. Only if the above turns
      out not to be enough.

--- a/scripts/coverage-ratchet.mjs
+++ b/scripts/coverage-ratchet.mjs
@@ -229,10 +229,10 @@ for (const [dir, want] of [...floors].sort()) {
   }
 }
 
-if (process.env.CCU_HOST) {
+if (process.env.CCU_HOST || process.env.CCU_DEV_HOST) {
   console.log(
-    "\nNOTE: CCU_HOST is set, so the live-integration suites ran and these " +
-      "numbers are HIGHER than CI will measure. Do not raise floors from this run.",
+    "\nNOTE: CCU_HOST/CCU_DEV_HOST is set, so live-integration suites ran and " +
+      "these numbers are HIGHER than CI will measure. Do not raise floors from this run.",
   );
 }
 

--- a/src/cli/env-writer.ts
+++ b/src/cli/env-writer.ts
@@ -41,10 +41,19 @@ export function quoteEnvValue(value: string): string {
   );
 }
 
-/** Render the managed block: flat vars for one target, CCU_PROFILES for more. */
-export function buildEnvContent(profiles: WizardProfile[], defaultProfile: string): string {
+/**
+ * Render the managed block: flat vars for one target, CCU_PROFILES for more.
+ * `forceProfileForm` keeps the CCU_PROFILES form even for a single target —
+ * the setup tool needs it when the one profile has a real name (a flat write
+ * would silently drop the name the conversation established).
+ */
+export function buildEnvContent(
+  profiles: WizardProfile[],
+  defaultProfile: string,
+  forceProfileForm = false,
+): string {
   const lines: string[] = [
-    "# Written by `ccu-mcp init` — https://github.com/claymore666/ccu-mcp#configuration",
+    "# Written by ccu-mcp setup — https://github.com/claymore666/ccu-mcp#configuration",
   ];
   const emit = (prefix: string, p: WizardProfile): void => {
     lines.push(`CCU_${prefix}HOST=${quoteEnvValue(p.host)}`);
@@ -56,7 +65,7 @@ export function buildEnvContent(profiles: WizardProfile[], defaultProfile: strin
     if (p.protected) lines.push(`CCU_${prefix}PROTECTED=true`);
     if (p.readonly) lines.push(`CCU_${prefix}READONLY=true`);
   };
-  if (profiles.length === 1) {
+  if (profiles.length === 1 && !forceProfileForm) {
     emit("", profiles[0]);
   } else {
     lines.push(`CCU_PROFILES=${profiles.map((p) => p.name).join(",")}`);

--- a/src/cli/secret.ts
+++ b/src/cli/secret.ts
@@ -1,0 +1,81 @@
+import { resolve } from "node:path";
+import { Prompter, type PromptIo } from "./prompt.js";
+import { envFileArg, loadEnvFile } from "./common.js";
+import { quoteEnvValue, readEnvFile, replaceEnvKey, writeEnvFile } from "./env-writer.js";
+import { envPrefix } from "../config.js";
+
+/**
+ * `ccu-mcp secret [profile]` — store ONE value, the CCU password, into the env
+ * file via a local hidden prompt. This is the hand-off the MCP setup flow
+ * (tools/setup.ts) prints so the password never travels through the model or
+ * the chat transcript; it is also the documented rotation path.
+ */
+export async function run(argv: string[], io?: PromptIo): Promise<number> {
+  const out = io?.output ?? process.stdout;
+  const say = (text: string): void => void out.write(text + "\n");
+  let envPath: string;
+  let vars: Record<string, string>;
+  let content: string | undefined;
+  try {
+    envPath = envFileArg(argv);
+    content = readEnvFile(envPath);
+    if (content === undefined) {
+      say(`ccu-mcp secret: ${resolve(envPath)} does not exist — run \`ccu-mcp init\` or the MCP setup flow first.`);
+      return 1;
+    }
+    vars = loadEnvFile(envPath);
+  } catch (err) {
+    say(`ccu-mcp secret: ${(err as Error).message}`);
+    return 1;
+  }
+
+  // The profile name is the first bare positional argument (skip --env's value).
+  const profileArg = argv.find((a, i) => !a.startsWith("--") && argv[i - 1] !== "--env");
+
+  const names = vars.CCU_PROFILES?.split(",").map((s) => s.trim()).filter(Boolean) ?? [];
+  let key: string;
+  let target: string;
+  if (names.length > 0) {
+    if (!profileArg) {
+      say(`This file configures named targets (${names.join(", ")}) — say which one:`);
+      say(`  ccu-mcp secret <profile> --env ${envPath}`);
+      return 1;
+    }
+    const match = names.find((n) => n.toLowerCase() === profileArg.toLowerCase());
+    if (!match) {
+      say(`ccu-mcp secret: "${profileArg}" is not one of the configured targets (${names.join(", ")}).`);
+      return 1;
+    }
+    key = `CCU_${envPrefix(match)}_PASSWORD`;
+    target = `${vars[`CCU_${envPrefix(match)}_USER`] || "Admin"}@${vars[`CCU_${envPrefix(match)}_HOST`] || match}`;
+  } else {
+    if (profileArg) {
+      say(`ccu-mcp secret: this file uses the single-CCU form — no profile name needed:`);
+      say(`  ccu-mcp secret --env ${envPath}`);
+      return 1;
+    }
+    key = "CCU_PASSWORD";
+    target = `${vars.CCU_USER || "Admin"}@${vars.CCU_HOST || "CCU"}`;
+  }
+
+  const ui = new Prompter(io ?? { input: process.stdin, output: process.stdout });
+  try {
+    const password = await ui.askHidden(`CCU password for ${target} (input hidden)`);
+    if (password === "") {
+      ui.say("  Storing an EMPTY password (normal for a fresh OpenCCU dev box).");
+    }
+    writeEnvFile(envPath, replaceEnvKey(content, key, quoteEnvValue(password)));
+    ui.say(`Wrote ${key} to ${resolve(envPath)} (mode 0600).`);
+    ui.say(`Verify with: ccu-mcp doctor --env ${envPath}`);
+    return 0;
+  } catch (err) {
+    if ((err as Error).message === "input closed") {
+      process.stderr.write("ccu-mcp secret: input closed — nothing written.\n");
+      return 130;
+    }
+    process.stderr.write(`ccu-mcp secret: ${(err as Error).message}\n`);
+    return 1;
+  } finally {
+    ui.close();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ Usage:
   ccu-mcp [--stdio | --http] [--env <path>]
   ccu-mcp init   [--env <path>]
   ccu-mcp doctor [--env <path>]
+  ccu-mcp secret [<profile>] [--env <path>]
   ccu-mcp --version
   ccu-mcp --help
 
@@ -37,9 +38,14 @@ Subcommands:
                    test the login, and write an env file (default: ./.env)
   doctor           Validate an existing env file end-to-end: reachability,
                    certificate pin, login, privilege level
+  secret           Store the CCU password into the env file via a local hidden
+                   prompt (used by the LLM-guided setup; also for rotation)
 
 Options:
-  --stdio          Serve MCP over stdin/stdout (overrides MCP_TRANSPORT)
+  --stdio          Serve MCP over stdin/stdout (overrides MCP_TRANSPORT).
+                   With --env and a missing/incomplete configuration the server
+                   starts in SETUP MODE, exposing only setup_* tools that let
+                   an LLM configure it conversationally
   --http           Serve MCP over HTTP (default)
   --env <path>     Load configuration from this dotenv file (already-set
                    environment variables win, like node's own --env-file)
@@ -96,8 +102,13 @@ async function main(): Promise<void> {
   // Subcommands run in the same no-environment-needed early path as the info
   // flags (issue #112): `ccu-mcp init` exists precisely because there is no
   // valid configuration yet. Dynamic import keeps server startup unaffected.
-  if (argv[0] === "init" || argv[0] === "doctor") {
-    const mod = argv[0] === "init" ? await import("./cli/init.js") : await import("./cli/doctor.js");
+  if (argv[0] === "init" || argv[0] === "doctor" || argv[0] === "secret") {
+    const mod =
+      argv[0] === "init"
+        ? await import("./cli/init.js")
+        : argv[0] === "doctor"
+          ? await import("./cli/doctor.js")
+          : await import("./cli/secret.js");
     process.exitCode = await mod.run(argv.slice(1));
     return;
   }
@@ -107,13 +118,50 @@ async function main(): Promise<void> {
   // `--env` for server mode: lets an MCP client entry reference the file
   // `ccu-mcp init` wrote instead of inlining credentials in its JSON config.
   // Same precedence as node's own flag: already-set environment wins.
+  let envPath: string | undefined;
   if (argv.includes("--env")) {
     const { envFileArg, loadEnvFile, applyEnvVars } = await import("./cli/common.js");
-    applyEnvVars(loadEnvFile(envFileArg(argv)));
+    envPath = envFileArg(argv); // throws on a missing value — always fatal
+    try {
+      applyEnvVars(loadEnvFile(envPath));
+    } catch (err) {
+      // A missing/unreadable env file is exactly the state the LLM-guided
+      // setup starts from (issue #196) — over stdio it leads into setup mode
+      // below. Everywhere else it stays fatal, as before.
+      if (!argv.includes("--stdio")) throw err;
+    }
   }
 
   const logger = createLogger();
-  const config = loadConfig();
+  let config: ReturnType<typeof loadConfig>;
+  try {
+    config = loadConfig();
+  } catch (err) {
+    // Setup mode (issue #196): started for stdio with an explicit --env file
+    // but no loadable configuration, serve only the setup_* tools so an LLM
+    // can walk the user through writing that file. Strictly stdio — an
+    // unconfigured, unauthenticated HTTP endpoint that writes config files is
+    // not an acceptable surface. A bare start still fails loudly.
+    if (envPath === undefined || !argv.includes("--stdio")) throw err;
+    const { resolve } = await import("node:path");
+    const { createSetupServer } = await import("./setup-server.js");
+    const setupServer = createSetupServer(resolve(envPath), (err as Error).message, logger);
+    await setupServer.connect(new StdioServerTransport());
+    logger.info("server_ready", { transport: "stdio", mode: "setup" });
+    let closing = false;
+    const closeSetup = (): void => {
+      if (closing) return;
+      closing = true;
+      void setupServer.close().finally(() => process.exit(0));
+    };
+    process.on("SIGTERM", closeSetup);
+    process.on("SIGINT", closeSetup);
+    // Same stdin-EOF hook as the configured stdio server below: the client
+    // terminates by closing the pipe, not by signaling.
+    process.stdin.on("end", closeSetup);
+    process.stdin.on("close", closeSetup);
+    return;
+  }
 
   logger.info("starting", {
     transport: config.mcp.transport,

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,23 @@ export interface ServerDeps {
 export const serverSubscriptions = new WeakMap<McpServer, Set<string>>();
 
 /**
+ * The server's `Implementation` identity, shared between the configured server
+ * and the setup-mode server (setup-server.ts) so a client listing either shows
+ * the same name/title. `description` mirrors server.json's, so the registry
+ * entry and the live handshake say the same thing.
+ */
+export const SERVER_IDENTITY = {
+  name: "ccu-mcp",
+  // title/description/websiteUrl are the human-facing half of
+  // `Implementation`: a client listing servers shows these rather than the
+  // package name.
+  title: "HomeMatic CCU",
+  description: "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
+  websiteUrl: "https://github.com/claymore666/ccu-mcp",
+  version: VERSION,
+};
+
+/**
  * Sent to the client in the `initialize` result and, in most clients, put in
  * front of the model before it calls anything. It is the one piece of guidance
  * that arrives without the model choosing to ask for it — `help` only helps a
@@ -90,17 +107,7 @@ function invalidParams(message: string): McpError {
 
 export function createMcpServer(deps: ServerDeps): McpServer {
   const server = new McpServer(
-    {
-      name: "ccu-mcp",
-      // title/description/websiteUrl are the human-facing half of
-      // `Implementation`: a client listing servers shows these rather than the
-      // package name. `description` mirrors server.json's, so the registry
-      // entry and the live handshake say the same thing.
-      title: "HomeMatic CCU",
-      description: "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
-      websiteUrl: "https://github.com/claymore666/ccu-mcp",
-      version: VERSION,
-    },
+    SERVER_IDENTITY,
     {
       instructions: INSTRUCTIONS,
       capabilities: {

--- a/src/setup-server.ts
+++ b/src/setup-server.ts
@@ -1,0 +1,48 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SERVER_IDENTITY } from "./server.js";
+import { registerSetupTools } from "./tools/setup.js";
+import type { Logger } from "./logger.js";
+
+/**
+ * Instructions for setup mode. Unlike the configured server's, these must
+ * carry the whole flow: the client has never seen this server work, so the
+ * model's only guidance is what arrives with the initialize result. The
+ * password rule is stated twice on purpose — it is the one step where the
+ * model doing the "helpful" thing (asking for the password in chat) would be
+ * wrong.
+ */
+function setupInstructions(envPath: string, configError: string): string {
+  return `This ccu-mcp server is NOT configured yet — it started in setup mode because loading \
+its configuration failed (${configError}). Only the setup_* tools are available; they write to \
+${envPath}.
+
+Walk the user through configuring their HomeMatic CCU connection:
+1. setup_status shows what the env file already contains.
+2. Ask for the CCU's hostname or IP; setup_probe finds the port/HTTPS and fetches the TLS \
+certificate. On HTTPS, recommend pinning the certificate fingerprint.
+3. setup_write_profile writes the connection settings. It has no password parameter.
+4. The password must NEVER travel through this conversation — do not ask for it, and refuse it \
+if offered. Instead have the user run the \`ccu-mcp secret\` command printed by \
+setup_write_profile in a terminal; it prompts locally with echo off and stores only the password.
+5. setup_test verifies reachability, the certificate pin and the login.
+6. When every check passes, tell the user to reconnect this MCP server (restart the client or \
+its MCP connection) — it will start fully configured with the normal tool set.
+
+Multiple CCUs (e.g. prod and dev) are supported: repeat steps 2-5 with a name per target \
+("default" means a single unnamed CCU).`;
+}
+
+/**
+ * The minimal MCP server the process runs when started with --stdio --env
+ * <path> and an invalid/missing configuration (see index.ts). Same identity as
+ * the configured server, but only the four setup tools — no resources, no
+ * prompts, no CCU-backed anything.
+ */
+export function createSetupServer(envPath: string, configError: string, logger: Logger): McpServer {
+  const server = new McpServer(SERVER_IDENTITY, {
+    instructions: setupInstructions(envPath, configError),
+    capabilities: { tools: {}, logging: {} },
+  });
+  registerSetupTools(server, { envPath, configError, logger });
+  return server;
+}

--- a/src/tools/setup.ts
+++ b/src/tools/setup.ts
@@ -1,0 +1,495 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Logger } from "../logger.js";
+import { loadConfig, envPrefix, type AppConfig } from "../config.js";
+import { loadEnvFile, displayFingerprint } from "../cli/common.js";
+import {
+  buildEnvContent,
+  mergeEnvContent,
+  readEnvFile,
+  writeEnvFile,
+  type WizardProfile,
+} from "../cli/env-writer.js";
+import {
+  probeApi,
+  probeConfig,
+  fetchCert,
+  fingerprintMatches,
+  testLogin,
+  type CertInfo,
+} from "../cli/probe.js";
+import { runTool } from "../middleware/tool-handler.js";
+import { structuredResult } from "../utils.js";
+
+/**
+ * Dependencies of the setup-mode toolset. Deliberately tiny: setup mode exists
+ * BECAUSE there is no valid config, so none of the usual ServerDeps
+ * (targets/session/resolver) can exist yet. The env-file path comes from the
+ * server's own --env flag, never from a tool argument — the model must not be
+ * able to point the writer at an arbitrary file.
+ */
+export interface SetupDeps {
+  /** Absolute path of the env file named by --env. */
+  envPath: string;
+  /** Why loadConfig() rejected the current state, verbatim. */
+  configError: string;
+  logger: Logger;
+}
+
+const PROBE_TIMEOUT = 5_000;
+
+/** True-ish dotenv boolean; garbage reads as false (status is advisory only). */
+function boolVar(v: string | undefined): boolean {
+  return v?.trim().toLowerCase() === "true";
+}
+
+/**
+ * Read the wizard-managed profiles back OUT of a dotenv key/value map, so
+ * setup_write_profile can upsert one profile while preserving the others
+ * (including their already-secret-stored passwords, which never surface in
+ * any tool result).
+ */
+export function profilesFromVars(vars: Record<string, string>): {
+  profiles: WizardProfile[];
+  defaultProfile?: string;
+} {
+  const fromKeys = (prefix: string, name: string): WizardProfile => {
+    const g = (suffix: string): string | undefined => vars[`CCU_${prefix}${suffix}`];
+    const https = boolVar(g("HTTPS"));
+    return {
+      name,
+      host: g("HOST")?.trim() ?? "",
+      port: /^\d+$/.test(g("PORT")?.trim() ?? "") ? Number(g("PORT")!.trim()) : https ? 443 : 80,
+      https,
+      tlsFingerprint: g("TLS_FINGERPRINT")?.trim() || undefined,
+      user: g("USER")?.trim() || "Admin",
+      password: g("PASSWORD") ?? "",
+      protected: boolVar(g("PROTECTED")),
+      readonly: boolVar(g("READONLY")),
+    };
+  };
+  const names = vars.CCU_PROFILES?.split(",").map((s) => s.trim()).filter(Boolean);
+  if (names && names.length > 0) {
+    return {
+      profiles: names.map((n) => fromKeys(`${envPrefix(n)}_`, n)),
+      defaultProfile: vars.CCU_DEFAULT_PROFILE?.trim() || undefined,
+    };
+  }
+  if (vars.CCU_HOST) return { profiles: [fromKeys("", "default")] };
+  return { profiles: [] };
+}
+
+/**
+ * Evaluate the env FILE with the real loadConfig(), which reads process.env.
+ * Snapshot the environment, make the file the sole source of truth for every
+ * variable the config owns, load, restore. Synchronous throughout (no await
+ * between swap and restore), so nothing else can observe the altered env.
+ */
+export function configFromEnvFile(path: string): AppConfig {
+  const vars = loadEnvFile(path);
+  const saved: Record<string, string | undefined> = {};
+  const owned = /^(CCU_|MCP_|CACHE_|RESOURCE_POLL_INTERVAL$|LOG_LEVEL$)/;
+  for (const key of Object.keys(process.env)) {
+    if (owned.test(key)) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(vars)) {
+    saved[key] = saved[key] ?? process.env[key];
+    process.env[key] = value;
+  }
+  try {
+    return loadConfig();
+  } finally {
+    for (const key of Object.keys(vars)) delete process.env[key];
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+const certShape = {
+  fingerprint256: z.string(),
+  subjectCN: z.string().optional(),
+  issuerCN: z.string().optional(),
+  validFrom: z.string().optional(),
+  validTo: z.string().optional(),
+};
+
+function certResult(cert: CertInfo): Record<string, unknown> {
+  return {
+    fingerprint256: displayFingerprint(cert.fingerprint256),
+    subjectCN: cert.subjectCN,
+    issuerCN: cert.issuerCN,
+    validFrom: cert.validFrom,
+    validTo: cert.validTo,
+  };
+}
+
+function secretCommand(deps: SetupDeps, profileName: string): string {
+  const profileArg = profileName === "default" ? "" : ` ${profileName}`;
+  return `npx ccu-mcp secret${profileArg} --env ${deps.envPath}`;
+}
+
+function registerStatus(server: McpServer, deps: SetupDeps): void {
+  server.registerTool(
+    "setup_status",
+    {
+      title: "Setup: current state",
+      description:
+        "Report why the server is in setup mode, which env file it will write, and what that " +
+        "file already contains: each configured CCU target with host/port/HTTPS/user, whether a " +
+        "TLS fingerprint is pinned, and whether a password has been stored (as a boolean — the " +
+        "password itself is never readable through any setup tool).",
+      inputSchema: {},
+      outputSchema: {
+        envPath: z.string(),
+        fileExists: z.boolean(),
+        configError: z.string(),
+        defaultProfile: z.string().optional(),
+        profiles: z.array(
+          z.object({
+            name: z.string(),
+            host: z.string(),
+            port: z.number(),
+            https: z.boolean(),
+            user: z.string(),
+            tlsFingerprintPinned: z.boolean(),
+            passwordStored: z.boolean(),
+            protected: z.boolean(),
+            readonly: z.boolean(),
+          }),
+        ),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async () =>
+      runTool("setup_status", deps.logger, async () => {
+        const content = readEnvFile(deps.envPath);
+        const vars = content === undefined ? {} : loadEnvFile(deps.envPath);
+        const { profiles, defaultProfile } = profilesFromVars(vars);
+        return structuredResult({
+          envPath: deps.envPath,
+          fileExists: content !== undefined,
+          configError: deps.configError,
+          defaultProfile,
+          profiles: profiles.map((p) => ({
+            name: p.name,
+            host: p.host,
+            port: p.port,
+            https: p.https,
+            user: p.user,
+            tlsFingerprintPinned: p.tlsFingerprint !== undefined,
+            // Key present in the file — an empty password is legal for named
+            // profiles (OpenCCU dev boxes), so presence is what matters here;
+            // setup_test gives the real verdict.
+            passwordStored: `CCU_${p.name === "default" && !vars.CCU_PROFILES ? "" : `${envPrefix(p.name)}_`}PASSWORD` in vars,
+            protected: p.protected,
+            readonly: p.readonly,
+          })),
+        });
+      }),
+  );
+}
+
+function registerProbe(server: McpServer, deps: SetupDeps): void {
+  server.registerTool(
+    "setup_probe",
+    {
+      title: "Setup: probe a CCU",
+      description:
+        "Check whether a CCU JSON-RPC API answers at a host. Without port/https the two stock " +
+        "endpoints are tried (443 HTTPS, then 80 HTTP). Over HTTPS the presented TLS certificate " +
+        "is fetched (unverified, for display) so the user can decide to pin its fingerprint in " +
+        "setup_write_profile — recommend pinning.",
+      inputSchema: {
+        host: z.string().describe("CCU hostname or IP"),
+        port: z.number().int().min(1).max(65535).optional()
+          .describe("Probe exactly this port (default: auto-detect 443/80)"),
+        https: z.boolean().optional().describe("Probe with HTTPS (required when port is given)"),
+      },
+      outputSchema: {
+        reachable: z.boolean(),
+        detail: z.string(),
+        port: z.number().optional(),
+        https: z.boolean().optional(),
+        cert: z.object(certShape).optional(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runTool("setup_probe", deps.logger, async (log) => {
+        log({ host: args.host });
+        const candidates =
+          args.port !== undefined
+            ? [{ port: args.port, https: args.https ?? args.port === 443 }]
+            : [
+                { port: 443, https: true },
+                { port: 80, https: false },
+              ];
+        let lastDetail = "";
+        for (const c of candidates) {
+          const outcome = await probeApi(probeConfig(args.host, c.port, c.https, PROBE_TIMEOUT));
+          lastDetail = `${c.https ? "https" : "http"}://${args.host}:${c.port} — ${outcome.detail}`;
+          if (outcome.kind !== "ccu") continue;
+          let cert: CertInfo | undefined;
+          if (c.https) {
+            try {
+              cert = await fetchCert(args.host, c.port);
+            } catch {
+              // Reachability is established; an unreadable cert only means no
+              // pin can be offered.
+            }
+          }
+          return structuredResult({
+            reachable: true,
+            detail: `CCU API found on port ${c.port} (${c.https ? "HTTPS" : "HTTP"})`,
+            port: c.port,
+            https: c.https,
+            ...(cert ? { cert: certResult(cert) } : {}),
+          });
+        }
+        return structuredResult({ reachable: false, detail: `No CCU API found: ${lastDetail}` });
+      }),
+  );
+}
+
+function registerWriteProfile(server: McpServer, deps: SetupDeps): void {
+  server.registerTool(
+    "setup_write_profile",
+    {
+      title: "Setup: write a CCU target",
+      description:
+        "Add or update one CCU target in the env file (connection settings only). There is " +
+        "deliberately NO password parameter: the password must never travel through the model " +
+        "or the chat — after writing, have the user run the printed `ccu-mcp secret` command in " +
+        "a terminal (hidden prompt), then call setup_test. Other targets and unmanaged variables " +
+        "in the file are preserved.",
+      inputSchema: {
+        name: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/).default("default")
+          .describe('Target name (e.g. "prod", "dev"); "default" writes the flat single-CCU form'),
+        host: z.string().describe("CCU hostname or IP"),
+        port: z.number().int().min(1).max(65535),
+        https: z.boolean(),
+        tlsFingerprint: z.string().optional()
+          .describe("SHA-256 fingerprint from setup_probe to pin (HTTPS only, recommended)"),
+        user: z.string().default("Admin").describe("CCU username"),
+        protected: z.boolean().optional()
+          .describe("Write tools on this target then require confirm:true"),
+        readonly: z.boolean().optional().describe("Refuse write tools on this target entirely"),
+        makeDefault: z.boolean().optional().describe("Make this the startup-default target"),
+      },
+      outputSchema: {
+        written: z.boolean(),
+        envPath: z.string(),
+        profiles: z.array(z.string()),
+        defaultProfile: z.string(),
+        nextStep: z.string(),
+      },
+    },
+    async (args) =>
+      runTool("setup_write_profile", deps.logger, async (log) => {
+        // The SDK applies the zod defaults on the wire; direct handler calls
+        // (unit tests) may omit them.
+        const name = args.name ?? "default";
+        const user = args.user ?? "Admin";
+        log({ profile: name, host: args.host });
+        if (!args.https && args.tlsFingerprint) {
+          throw new Error("tlsFingerprint only applies over HTTPS — drop it or set https: true");
+        }
+        const existing = readEnvFile(deps.envPath);
+        const vars = existing === undefined ? {} : loadEnvFile(deps.envPath);
+        const parsed = profilesFromVars(vars);
+        const profiles = parsed.profiles;
+        const idx = profiles.findIndex((p) => envPrefix(p.name) === envPrefix(name));
+        const previous = idx >= 0 ? profiles[idx] : undefined;
+        const updated: WizardProfile = {
+          name,
+          host: args.host,
+          port: args.port,
+          https: args.https,
+          tlsFingerprint: args.tlsFingerprint,
+          user,
+          // Same endpoint: a stored password stays valid, keep it. New or
+          // moved target: never carry a secret over to a different box.
+          password:
+            previous && previous.host === args.host && previous.port === args.port
+              ? previous.password
+              : "",
+          protected: args.protected ?? previous?.protected ?? false,
+          readonly: args.readonly ?? previous?.readonly ?? false,
+        };
+        if (idx >= 0) profiles[idx] = updated;
+        else profiles.push(updated);
+
+        let defaultProfile = parsed.defaultProfile ?? profiles[0].name;
+        if (args.makeDefault) defaultProfile = updated.name;
+        if (!profiles.some((p) => p.name === defaultProfile)) defaultProfile = profiles[0].name;
+
+        // A single target genuinely named "default" is the flat form (same as
+        // init); any real name keeps the CCU_PROFILES form so it survives.
+        const forceProfileForm = !(profiles.length === 1 && profiles[0].name === "default");
+        const managed = buildEnvContent(profiles, defaultProfile, forceProfileForm);
+        const content = existing === undefined ? managed : mergeEnvContent(existing, managed).content;
+        writeEnvFile(deps.envPath, content);
+
+        const nextStep = updated.password === ""
+          ? `Ask the user to run this in a terminal (the password is typed there, hidden — never in this chat):\n  ${secretCommand(deps, updated.name)}\nThen call setup_test.`
+          : "The stored password was kept. Call setup_test to verify the target.";
+        return structuredResult({
+          written: true,
+          envPath: deps.envPath,
+          profiles: profiles.map((p) => p.name),
+          defaultProfile,
+          nextStep,
+        });
+      }),
+  );
+}
+
+function registerTest(server: McpServer, deps: SetupDeps): void {
+  server.registerTool(
+    "setup_test",
+    {
+      title: "Setup: verify the configuration",
+      description:
+        "Validate the env file end-to-end, like `ccu-mcp doctor`: configuration loads, each " +
+        "target's CCU API is reachable, a pinned TLS fingerprint matches the presented " +
+        "certificate, and the login works (reporting the ADMIN/USER privilege level). When " +
+        "everything passes, tell the user to reconnect this MCP server — it will restart fully " +
+        "configured with the normal tool set.",
+      inputSchema: {},
+      outputSchema: {
+        ok: z.boolean(),
+        findings: z.array(
+          z.object({
+            profile: z.string(),
+            check: z.string(),
+            ok: z.boolean(),
+            detail: z.string(),
+          }),
+        ),
+        nextStep: z.string(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async () =>
+      runTool("setup_test", deps.logger, async () => {
+        const findings: { profile: string; check: string; ok: boolean; detail: string }[] = [];
+        let config: AppConfig;
+        try {
+          config = configFromEnvFile(deps.envPath);
+        } catch (err) {
+          findings.push({
+            profile: "-",
+            check: "config",
+            ok: false,
+            detail: `configuration invalid: ${(err as Error).message}`,
+          });
+          return structuredResult({
+            ok: false,
+            findings,
+            nextStep:
+              "Fix the reported problem (setup_write_profile for connection settings; " +
+              "`ccu-mcp secret` for the password), then call setup_test again.",
+          });
+        }
+        findings.push({
+          profile: "-",
+          check: "config",
+          ok: true,
+          detail: `configuration loads: ${config.profiles.length} target(s), default "${config.defaultProfile}"`,
+        });
+
+        for (const p of config.profiles) {
+          const outcome = await probeApi(p.ccu);
+          if (outcome.kind !== "ccu") {
+            findings.push({
+              profile: p.name,
+              check: "reachability",
+              ok: false,
+              detail: `CCU API not reachable: ${outcome.detail}`,
+            });
+            continue;
+          }
+          findings.push({ profile: p.name, check: "reachability", ok: true, detail: "CCU API reachable" });
+
+          if (p.ccu.https && p.ccu.tlsFingerprint) {
+            let presented: string;
+            try {
+              presented = (await fetchCert(p.ccu.host, p.ccu.port)).fingerprint256;
+            } catch (err) {
+              findings.push({
+                profile: p.name,
+                check: "tls-pin",
+                ok: false,
+                detail: `could not read the TLS certificate: ${(err as Error).message}`,
+              });
+              continue;
+            }
+            if (!fingerprintMatches(p.ccu.tlsFingerprint, presented)) {
+              findings.push({
+                profile: p.name,
+                check: "tls-pin",
+                ok: false,
+                detail:
+                  `pinned fingerprint does NOT match the presented certificate ` +
+                  `(pinned ${displayFingerprint(p.ccu.tlsFingerprint)}, presented ${displayFingerprint(presented)}). ` +
+                  "If the certificate was legitimately renewed, re-pin via setup_write_profile; " +
+                  "if not, this could be an interception attempt — investigate before continuing.",
+              });
+              continue;
+            }
+            findings.push({
+              profile: p.name,
+              check: "tls-pin",
+              ok: true,
+              detail: "pinned TLS fingerprint matches the presented certificate",
+            });
+          }
+
+          const login = await testLogin(p.ccu);
+          if (!login.ok) {
+            findings.push({
+              profile: p.name,
+              check: "login",
+              ok: false,
+              detail: `login failed: ${login.error.message}${login.error.hint ? ` — ${login.error.hint}` : ""}`,
+            });
+            continue;
+          }
+          const version = login.version ? ` (CCU ${login.version})` : "";
+          const roleNote =
+            login.role === "USER"
+              ? " — note: script-based tools (run_script, create_system_variable, acknowledge_service_messages) need an ADMIN-level CCU user"
+              : "";
+          findings.push({
+            profile: p.name,
+            check: "login",
+            ok: true,
+            detail: `login OK as "${p.ccu.user}"${version} — privilege level ${login.role}${roleNote}`,
+          });
+        }
+
+        const ok = findings.every((f) => f.ok);
+        return structuredResult({
+          ok,
+          findings,
+          nextStep: ok
+            ? "All checks passed. Tell the user to reconnect this MCP server (restart the client " +
+              "or its MCP connection) — it will start fully configured with the normal tool set."
+            : "Fix the failing check (setup_write_profile for connection settings; `ccu-mcp secret` " +
+              "for the password), then call setup_test again.",
+        });
+      }),
+  );
+}
+
+export function registerSetupTools(server: McpServer, deps: SetupDeps): void {
+  registerStatus(server, deps);
+  registerProbe(server, deps);
+  registerWriteProfile(server, deps);
+  registerTest(server, deps);
+}

--- a/test/e2e/setup-mode.test.ts
+++ b/test/e2e/setup-mode.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { DIST, distMissing } from "./_dist.js";
+import { startMockCcu, adminResults, type MockCcu } from "../unit/_mock-ccu.js";
+
+// End-to-end test of SETUP MODE (issue #196): the BUILT server, started with
+// --stdio --env <missing file>, must come up as a minimal MCP server exposing
+// only the setup_* tools, let the flow write a real env file (password via the
+// `ccu-mcp secret` CLI, never through the MCP transport), verify it with
+// setup_test, and then — restarted with the identical command line — come up
+// fully configured. That restart is the product promise: the MCP client entry
+// never changes between "not configured yet" and "configured".
+
+/** process.env with every server config var scrubbed. */
+function cleanEnv(): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (/^(CCU_|MCP_|CACHE_|RESOURCE_POLL_INTERVAL$|LOG_LEVEL$)/.test(key)) delete env[key];
+  }
+  return env;
+}
+
+/** Same newline-delimited JSON-RPC framing as stdio-transport.test.ts. */
+class StdioClient {
+  private buffer = "";
+  private pending = new Map<number, (msg: any) => void>();
+  private nextId = 1;
+
+  constructor(private child: ChildProcess) {
+    child.stdout!.setEncoding("utf-8");
+    child.stdout!.on("data", (chunk: string) => {
+      this.buffer += chunk;
+      let nl: number;
+      while ((nl = this.buffer.indexOf("\n")) !== -1) {
+        const line = this.buffer.slice(0, nl).trim();
+        this.buffer = this.buffer.slice(nl + 1);
+        if (!line) continue;
+        let msg: any;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (typeof msg.id === "number" && this.pending.has(msg.id)) {
+          this.pending.get(msg.id)!(msg);
+          this.pending.delete(msg.id);
+        }
+      }
+    });
+  }
+
+  request(method: string, params: unknown = {}, timeoutMs = 10_000): Promise<any> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`stdio request "${method}" timed out`));
+      }, timeoutMs);
+      this.pending.set(id, (msg) => { clearTimeout(timer); resolve(msg); });
+      this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  }
+
+  notify(method: string, params: unknown = {}): void {
+    this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+  }
+}
+
+function spawnServer(envPath: string): { child: ChildProcess; client: StdioClient } {
+  const child = spawn("node", [DIST, "--stdio", "--env", envPath], {
+    env: { ...cleanEnv(), LOG_LEVEL: "error", CACHE_DIR: mkdtempSync(join(tmpdir(), "setup-e2e-cache-")) },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return { child, client: new StdioClient(child) };
+}
+
+async function initialize(client: StdioClient): Promise<any> {
+  const init = await client.request("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "e2e-setup", version: "1" },
+  }, 20_000);
+  client.notify("notifications/initialized");
+  return init;
+}
+
+function endChild(child: ChildProcess | undefined): Promise<number | null> {
+  if (!child || child.exitCode !== null) return Promise.resolve(child?.exitCode ?? null);
+  const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
+  child.stdin!.end();
+  const killTimer = setTimeout(() => child.kill("SIGKILL"), 10_000);
+  return exited.finally(() => clearTimeout(killTimer));
+}
+
+describe.skipIf(distMissing)("setup mode e2e (built server)", () => {
+  let dir: string;
+  let envPath: string;
+  let ccu: MockCcu;
+  let child: ChildProcess | undefined;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), "setup-e2e-"));
+    envPath = join(dir, ".env");
+    ccu = await startMockCcu(adminResults());
+  });
+
+  afterAll(async () => {
+    await endChild(child);
+    await ccu.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("walks the whole flow: setup server → write → secret CLI → verify → configured restart", async () => {
+    // 1. The env file does not exist: the identical client command line must
+    //    yield the setup server, announced via its instructions.
+    const first = spawnServer(envPath);
+    child = first.child;
+    const init = await initialize(first.client);
+    expect(init.result?.serverInfo?.name).toBe("ccu-mcp");
+    expect(init.result?.instructions).toContain("setup mode");
+    expect(init.result?.instructions).toContain("NEVER travel through this conversation");
+
+    const tools = await first.client.request("tools/list");
+    const names = (tools.result?.tools ?? []).map((t: { name: string }) => t.name).sort();
+    expect(names).toEqual(["setup_probe", "setup_status", "setup_test", "setup_write_profile"]);
+
+    // 2. Status → probe → write, all over MCP.
+    const status = await first.client.request("tools/call", { name: "setup_status", arguments: {} });
+    expect(status.result?.structuredContent?.fileExists).toBe(false);
+
+    const probe = await first.client.request("tools/call", {
+      name: "setup_probe",
+      arguments: { host: "127.0.0.1", port: ccu.port, https: false },
+    });
+    expect(probe.result?.structuredContent?.reachable).toBe(true);
+
+    const write = await first.client.request("tools/call", {
+      name: "setup_write_profile",
+      arguments: { name: "dev", host: "127.0.0.1", port: ccu.port, https: false },
+    });
+    expect(write.result?.structuredContent?.written).toBe(true);
+    expect(write.result?.structuredContent?.nextStep).toContain("ccu-mcp secret dev");
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+    // The password is NOT in the file yet — and there is no way to put it
+    // there over MCP.
+    expect(readFileSync(envPath, "utf-8")).toContain('CCU_DEV_PASSWORD=""');
+
+    // 3. The password arrives out-of-band through the local CLI.
+    const secret = spawn("node", [DIST, "secret", "dev", "--env", envPath], {
+      env: { ...cleanEnv() },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    secret.stdin.end("mock-password\n");
+    const secretExit = await new Promise<number | null>((resolve) => secret.once("exit", resolve));
+    expect(secretExit).toBe(0);
+    expect(readFileSync(envPath, "utf-8")).toContain("CCU_DEV_PASSWORD=mock-password");
+
+    // 4. Verification over MCP goes green and points at reconnecting.
+    const test = await first.client.request("tools/call", { name: "setup_test", arguments: {} }, 20_000);
+    expect(test.result?.structuredContent?.ok).toBe(true);
+    expect(test.result?.structuredContent?.nextStep).toContain("reconnect");
+
+    // 5. "Reconnect": stdin EOF ends the setup server cleanly…
+    expect(await endChild(child)).toBe(0);
+
+    // 6. …and the SAME command line now starts the configured server.
+    const second = spawnServer(envPath);
+    child = second.child;
+    const reinit = await initialize(second.client);
+    expect(reinit.result?.instructions ?? "").not.toContain("setup mode");
+    const fullTools = await second.client.request("tools/list");
+    expect((fullTools.result?.tools ?? []).length).toBeGreaterThan(20);
+    expect(await endChild(child)).toBe(0);
+    child = undefined;
+  }, 90_000);
+
+  it("never enters setup mode without --stdio: HTTP with a broken config still dies", () => {
+    const res = spawnSync("node", [DIST, "--http", "--env", join(dir, "does-not-exist.env")], {
+      env: { ...cleanEnv() },
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("does-not-exist.env");
+  });
+
+  it("never enters setup mode without --env: a bare stdio start still fails loudly", () => {
+    const res = spawnSync("node", [DIST, "--stdio"], {
+      env: { ...cleanEnv() },
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("CCU_HOST");
+  });
+});

--- a/test/integration/setup-live.test.ts
+++ b/test/integration/setup-live.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PassThrough } from "node:stream";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createSetupServer } from "../../src/setup-server.js";
+import { probeApi, probeConfig, testLogin } from "../../src/cli/probe.js";
+import { run as runSecret } from "../../src/cli/secret.js";
+import { run as runDoctor } from "../../src/cli/doctor.js";
+import { Logger } from "../../src/logger.js";
+import { callTool, parseToolResult } from "../unit/_helpers.js";
+
+// Live integration for the setup flow against the OpenCCU dev VM — a real
+// ReGa, no radio hardware, Admin with (usually) an empty password. Gated on
+// CCU_DEV_HOST, so `npm test` stays hermetic; run it with the VM up:
+//
+//   CCU_DEV_HOST=127.0.0.1 CCU_DEV_PORT=18080 npm test
+//
+// (CCU_DEV_USER / CCU_DEV_PASSWORD override the Admin/empty default.) These
+// are the dev-profile variable names from .env, read directly by this suite —
+// deliberately NOT via loadConfig, so the flat CCU_* vars can simultaneously
+// point the tools-live suite at another box (or the same one).
+
+const DEV_HOST = process.env.CCU_DEV_HOST;
+const describeIf = DEV_HOST ? describe : describe.skip;
+
+const DEV = {
+  host: DEV_HOST ?? "",
+  port: parseInt(process.env.CCU_DEV_PORT || "80", 10),
+  https: process.env.CCU_DEV_HTTPS === "true",
+  user: process.env.CCU_DEV_USER || "Admin",
+  password: process.env.CCU_DEV_PASSWORD ?? "",
+};
+
+describeIf("setup flow against the live dev CCU", () => {
+  let dir: string;
+  let envPath: string;
+  let server: McpServer;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "setup-live-"));
+    envPath = join(dir, ".env");
+    server = createSetupServer(envPath, "CCU_HOST environment variable is required", new Logger("error"));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("probeApi classifies the real JSON-RPC endpoint as a CCU", async () => {
+    const outcome = await probeApi(probeConfig(DEV.host, DEV.port, DEV.https));
+    expect(outcome.kind).toBe("ccu");
+  });
+
+  it("testLogin detects the ADMIN role against the real ReGa", async () => {
+    const result = await testLogin({
+      host: DEV.host,
+      port: DEV.port,
+      https: DEV.https,
+      tlsVerify: false,
+      user: DEV.user,
+      password: DEV.password,
+      timeout: 10_000,
+      scriptTimeout: 30_000,
+    });
+    expect(result).toMatchObject({ ok: true, role: "ADMIN" });
+    if (result.ok) expect(result.version).toMatch(/^\d+\./);
+  });
+
+  it("walks probe → write → secret → setup_test green, then doctor agrees", async () => {
+    const probe = parseToolResult(
+      await callTool(server, "setup_probe", { host: DEV.host, port: DEV.port, https: DEV.https }),
+    ) as any;
+    expect(probe.reachable).toBe(true);
+
+    const write = parseToolResult(
+      await callTool(server, "setup_write_profile", {
+        name: "dev",
+        host: DEV.host,
+        port: DEV.port,
+        https: DEV.https,
+        user: DEV.user,
+      }),
+    ) as any;
+    expect(write.written).toBe(true);
+
+    // The password hand-off, exactly as a user would run it (piped answer
+    // standing in for the hidden prompt).
+    const input = new PassThrough();
+    const output = new PassThrough();
+    output.on("data", () => {});
+    input.end(DEV.password + "\n");
+    expect(await runSecret(["dev", "--env", envPath], { input, output })).toBe(0);
+
+    const test = parseToolResult(await callTool(server, "setup_test")) as any;
+    expect(test.ok).toBe(true);
+    expect(test.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ profile: "dev", check: "login", ok: true }),
+      ]),
+    );
+
+    // Independent second opinion: the doctor CLI on the same file. It loads
+    // the env file into process.env, so scrub what it may set afterwards.
+    const before = { ...process.env };
+    try {
+      const docOut = new PassThrough();
+      let doc = "";
+      docOut.on("data", (chunk) => (doc += String(chunk)));
+      const docIn = new PassThrough();
+      docIn.end();
+      expect(await runDoctor(["--env", envPath], { input: docIn, output: docOut })).toBe(0);
+      expect(doc).toContain("All checks passed");
+      expect(doc).toContain("privilege level ADMIN");
+    } finally {
+      for (const key of Object.keys(process.env)) {
+        if (!(key in before)) delete process.env[key];
+      }
+      Object.assign(process.env, before);
+    }
+
+    // The file holds what the flow established — and nothing else leaked out.
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("CCU_PROFILES=dev");
+    expect(content).toContain(`CCU_DEV_HOST=${DEV.host}`);
+  });
+});

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -82,8 +82,11 @@ describeIf("MCP tools against live CCU", () => {
     }
   }, 60_000);
 
-  it("get_values by channel list returns exactly the requested channels", async () => {
+  it("get_values by channel list returns exactly the requested channels", async (ctx) => {
     const devices = parseToolResult(await callTool(server, "list_devices")) as Array<{ channels: Array<{ address: string }> }>;
+    // A device-less CCU (the OpenCCU dev VM has no RF hardware) has nothing to
+    // read — skip rather than fail on the environment.
+    if (devices.length === 0) ctx.skip();
     const channel = devices[0]!.channels[0]!.address;
 
     const result = parseToolResult(await callTool(server, "get_values", { channels: [channel] })) as any[];
@@ -255,7 +258,7 @@ describeIf("MCP tools against live CCU", () => {
 
   // Assign a channel to a room, verify via list_rooms, then revert — leaving the
   // CCU as found. Skips gracefully if the CCU has no rooms/channels to work with.
-  it("assign_channel → verify via list_rooms → unassign (live)", async () => {
+  it("assign_channel → verify via list_rooms → unassign (live)", async (ctx) => {
     const rooms = parseToolResult(await callTool(server, "list_rooms")) as Array<{ id: string; name: string; channelIds: string[] }>;
     expect(rooms.length).toBeGreaterThan(0);
     // Filtered list_devices returns FULL channel objects (with `id`); the
@@ -263,6 +266,9 @@ describeIf("MCP tools against live CCU", () => {
     const populated = rooms.find((r) => r.channelIds.length > 0) ?? rooms[0]!;
     const devices = parseToolResult(await callTool(server, "list_devices", { room: populated.name })) as Array<{ channels: Array<{ id: string; address: string }> }>;
     const channel = devices.flatMap((d) => d.channels).find((c) => c.id && c.address);
+    // A device-less CCU (the OpenCCU dev VM) has no channel to move — skip
+    // rather than fail on the environment.
+    if (!channel) ctx.skip();
     expect(channel).toBeDefined();
 
     // Pick a room the channel is NOT already in, so the revert is a true revert.

--- a/test/unit/cli-secret.test.ts
+++ b/test/unit/cli-secret.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PassThrough } from "node:stream";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseEnv } from "node:util";
+import { run } from "../../src/cli/secret.js";
+import type { PromptIo } from "../../src/cli/prompt.js";
+
+function makeIo(answers: string[]): { io: PromptIo; output: () => string } {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  let out = "";
+  output.on("data", (chunk) => (out += String(chunk)));
+  if (answers.length > 0) input.end(answers.join("\n") + "\n");
+  else input.end();
+  return { io: { input, output }, output: () => out };
+}
+
+describe("ccu-mcp secret", () => {
+  let dir: string;
+  let envPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "cli-secret-"));
+    envPath = join(dir, ".env");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes CCU_PASSWORD into a flat file, 0600, everything else untouched", async () => {
+    writeFileSync(envPath, "# note\nCCU_HOST=ccu.local\nCCU_USER=Admin\nCCU_PASSWORD=\"\"\nLOG_LEVEL=debug\n");
+    const { io, output } = makeIo(["hunter2"]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    const content = readFileSync(envPath, "utf-8");
+    expect(parseEnv(content).CCU_PASSWORD).toBe("hunter2");
+    expect(content).toContain("# note");
+    expect(content).toContain("LOG_LEVEL=debug");
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+    expect(output()).toContain("Wrote CCU_PASSWORD");
+    // The hidden prompt must not echo the password back.
+    expect(output()).not.toContain("hunter2");
+  });
+
+  it("targets the named profile's key in a CCU_PROFILES file", async () => {
+    writeFileSync(
+      envPath,
+      "CCU_PROFILES=prod,dev\nCCU_PROD_HOST=a\nCCU_PROD_PASSWORD=keepme\nCCU_DEV_HOST=b\nCCU_DEV_PASSWORD=\"\"\n",
+    );
+    const { io } = makeIo(["devpw"]);
+    expect(await run(["dev", "--env", envPath], io)).toBe(0);
+    const vars = parseEnv(readFileSync(envPath, "utf-8"));
+    expect(vars.CCU_DEV_PASSWORD).toBe("devpw");
+    expect(vars.CCU_PROD_PASSWORD).toBe("keepme");
+  });
+
+  it("quotes awkward passwords so they round-trip through parseEnv", async () => {
+    writeFileSync(envPath, "CCU_HOST=ccu.local\n");
+    const password = 'sp ace#ha"sh';
+    const { io } = makeIo([password]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(parseEnv(readFileSync(envPath, "utf-8")).CCU_PASSWORD).toBe(password);
+  });
+
+  it("accepts an empty password with a note", async () => {
+    writeFileSync(envPath, "CCU_PROFILES=dev\nCCU_DEV_HOST=127.0.0.1\n");
+    const { io, output } = makeIo([""]);
+    expect(await run(["dev", "--env", envPath], io)).toBe(0);
+    expect(output()).toContain("EMPTY password");
+    expect(parseEnv(readFileSync(envPath, "utf-8")).CCU_DEV_PASSWORD).toBe("");
+  });
+
+  it("requires a profile name when the file defines profiles", async () => {
+    writeFileSync(envPath, "CCU_PROFILES=prod,dev\nCCU_PROD_HOST=a\nCCU_DEV_HOST=b\n");
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(output()).toContain("prod, dev");
+  });
+
+  it("rejects an unknown profile name", async () => {
+    writeFileSync(envPath, "CCU_PROFILES=prod\nCCU_PROD_HOST=a\n");
+    const { io, output } = makeIo(["x"]);
+    expect(await run(["staging", "--env", envPath], io)).toBe(1);
+    expect(output()).toContain('"staging" is not one of');
+  });
+
+  it("rejects a profile name against a flat file", async () => {
+    writeFileSync(envPath, "CCU_HOST=a\n");
+    const { io, output } = makeIo(["x"]);
+    expect(await run(["prod", "--env", envPath], io)).toBe(1);
+    expect(output()).toContain("single-CCU form");
+  });
+
+  it("fails cleanly when the env file does not exist", async () => {
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", join(dir, "missing.env")], io)).toBe(1);
+    expect(output()).toContain("does not exist");
+  });
+
+  it("exits 130 when input closes before an answer", async () => {
+    writeFileSync(envPath, "CCU_HOST=a\n");
+    const input = new PassThrough();
+    const output = new PassThrough();
+    output.on("data", () => {});
+    input.end(); // EOF with no line at all
+    expect(await run(["--env", envPath], { input, output })).toBe(130);
+    // Nothing written.
+    expect(readFileSync(envPath, "utf-8")).toBe("CCU_HOST=a\n");
+  });
+});

--- a/test/unit/setup-tools.test.ts
+++ b/test/unit/setup-tools.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { X509Certificate } from "node:crypto";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createSetupServer } from "../../src/setup-server.js";
+import { configFromEnvFile, profilesFromVars } from "../../src/tools/setup.js";
+import { Logger } from "../../src/logger.js";
+import { callTool, parseToolResult } from "./_helpers.js";
+import { startMockCcu, startMockCcuTls, adminResults, type MockCcu } from "./_mock-ccu.js";
+
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+const CONFIG_ERROR = "CCU_HOST environment variable is required";
+
+function makeServer(envPath: string): McpServer {
+  return createSetupServer(envPath, CONFIG_ERROR, new Logger("error"));
+}
+
+function registeredTools(server: McpServer): string[] {
+  return Object.keys((server as any)._registeredTools).sort();
+}
+
+describe("setup-mode server", () => {
+  let dir: string;
+  let envPath: string;
+  let server: McpServer;
+  let mock: MockCcu | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "setup-tools-"));
+    envPath = join(dir, ".env");
+    server = makeServer(envPath);
+  });
+
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true });
+    await mock?.close();
+    mock = undefined;
+  });
+
+  it("registers exactly the four setup tools — nothing CCU-backed", () => {
+    expect(registeredTools(server)).toEqual([
+      "setup_probe",
+      "setup_status",
+      "setup_test",
+      "setup_write_profile",
+    ]);
+    expect((server as any)._registeredResources ?? {}).toEqual({});
+    expect((server as any)._registeredPrompts ?? {}).toEqual({});
+  });
+
+  it("carries the flow and the password rule in its instructions", () => {
+    const instructions = (server.server as any)._instructions as string;
+    expect(instructions).toContain(envPath);
+    expect(instructions).toContain(CONFIG_ERROR);
+    expect(instructions).toContain("NEVER travel through this conversation");
+    expect(instructions).toContain("ccu-mcp secret");
+  });
+
+  it("setup_write_profile exposes no password parameter", () => {
+    const tool = (server as any)._registeredTools.setup_write_profile;
+    expect(Object.keys(tool.inputSchema.shape)).not.toContain("password");
+  });
+
+  describe("setup_status", () => {
+    it("reports a missing file with the config error", async () => {
+      const res = parseToolResult(await callTool(server, "setup_status")) as any;
+      expect(res.fileExists).toBe(false);
+      expect(res.configError).toBe(CONFIG_ERROR);
+      expect(res.profiles).toEqual([]);
+    });
+
+    it("reads a flat file back, reporting the password only as a boolean", async () => {
+      writeFileSync(envPath, "CCU_HOST=ccu.local\nCCU_PORT=8080\nCCU_PASSWORD=hunter2\n");
+      const raw = await callTool(server, "setup_status");
+      const res = parseToolResult(raw) as any;
+      expect(res.profiles).toEqual([
+        expect.objectContaining({
+          name: "default",
+          host: "ccu.local",
+          port: 8080,
+          https: false,
+          user: "Admin",
+          passwordStored: true,
+          tlsFingerprintPinned: false,
+        }),
+      ]);
+      expect(JSON.stringify(raw)).not.toContain("hunter2");
+    });
+
+    it("reads a multi-profile file back", async () => {
+      writeFileSync(
+        envPath,
+        [
+          "CCU_PROFILES=prod,dev",
+          "CCU_DEFAULT_PROFILE=prod",
+          "CCU_PROD_HOST=ccu.local",
+          "CCU_PROD_HTTPS=true",
+          "CCU_PROD_PORT=443",
+          "CCU_PROD_TLS_FINGERPRINT=AA:BB",
+          "CCU_PROD_PASSWORD=secret",
+          "CCU_PROD_PROTECTED=true",
+          "CCU_DEV_HOST=127.0.0.1",
+          "CCU_DEV_PORT=18080",
+          "",
+        ].join("\n"),
+      );
+      const res = parseToolResult(await callTool(server, "setup_status")) as any;
+      expect(res.defaultProfile).toBe("prod");
+      expect(res.profiles).toHaveLength(2);
+      expect(res.profiles[0]).toMatchObject({
+        name: "prod",
+        https: true,
+        tlsFingerprintPinned: true,
+        passwordStored: true,
+        protected: true,
+      });
+      expect(res.profiles[1]).toMatchObject({ name: "dev", port: 18080, passwordStored: false });
+    });
+  });
+
+  describe("setup_probe", () => {
+    it("finds a CCU on an explicit port", async () => {
+      mock = await startMockCcu();
+      const res = parseToolResult(
+        await callTool(server, "setup_probe", { host: "127.0.0.1", port: mock.port, https: false }),
+      ) as any;
+      expect(res.reachable).toBe(true);
+      expect(res.port).toBe(mock.port);
+      expect(res.https).toBe(false);
+      expect(res.cert).toBeUndefined();
+    });
+
+    it("reports an unreachable endpoint", async () => {
+      mock = await startMockCcu();
+      const port = mock.port;
+      await mock.close();
+      mock = undefined;
+      const res = parseToolResult(
+        await callTool(server, "setup_probe", { host: "127.0.0.1", port, https: false }),
+      ) as any;
+      expect(res.reachable).toBe(false);
+      expect(res.detail).toContain("No CCU API found");
+    });
+  });
+
+  describe("setup_write_profile", () => {
+    it("writes the flat form for a single default target, without a password", async () => {
+      const res = parseToolResult(
+        await callTool(server, "setup_write_profile", {
+          name: "default",
+          host: "ccu.local",
+          port: 80,
+          https: false,
+          user: "Admin",
+        }),
+      ) as any;
+      expect(res.written).toBe(true);
+      expect(res.nextStep).toContain("ccu-mcp secret");
+      expect(res.nextStep).toContain(envPath);
+      const content = readFileSync(envPath, "utf-8");
+      expect(content).toContain("CCU_HOST=ccu.local");
+      expect(content).not.toContain("CCU_PROFILES");
+      expect(content).toContain('CCU_PASSWORD=""');
+      expect(statSync(envPath).mode & 0o777).toBe(0o600);
+    });
+
+    it("keeps the CCU_PROFILES form for a named single target", async () => {
+      await callTool(server, "setup_write_profile", {
+        name: "dev",
+        host: "127.0.0.1",
+        port: 18080,
+        https: false,
+        user: "Admin",
+      });
+      const content = readFileSync(envPath, "utf-8");
+      expect(content).toContain("CCU_PROFILES=dev");
+      expect(content).toContain("CCU_DEV_HOST=127.0.0.1");
+    });
+
+    it("upserts a second target, preserving the first one's stored password", async () => {
+      writeFileSync(
+        envPath,
+        "CCU_PROFILES=prod\nCCU_DEFAULT_PROFILE=prod\nCCU_PROD_HOST=ccu.local\nCCU_PROD_PORT=443\nCCU_PROD_HTTPS=true\nCCU_PROD_USER=Admin\nCCU_PROD_PASSWORD=hunter2\n# operator note\nLOG_LEVEL=debug\n",
+      );
+      const raw = await callTool(server, "setup_write_profile", {
+        name: "dev",
+        host: "127.0.0.1",
+        port: 18080,
+        https: false,
+        user: "Admin",
+      });
+      const res = parseToolResult(raw) as any;
+      expect(res.profiles).toEqual(["prod", "dev"]);
+      expect(res.defaultProfile).toBe("prod");
+      expect(JSON.stringify(raw)).not.toContain("hunter2");
+      const content = readFileSync(envPath, "utf-8");
+      expect(content).toContain("CCU_PROD_PASSWORD=hunter2");
+      expect(content).toContain("CCU_DEV_HOST=127.0.0.1");
+      expect(content).toContain("LOG_LEVEL=debug");
+      expect(content).toContain("# operator note");
+    });
+
+    it("keeps a stored password when rewriting the same endpoint, drops it when the host moves", async () => {
+      writeFileSync(envPath, "CCU_HOST=ccu.local\nCCU_PORT=80\nCCU_PASSWORD=hunter2\n");
+      await callTool(server, "setup_write_profile", {
+        name: "default",
+        host: "ccu.local",
+        port: 80,
+        https: false,
+        user: "Other",
+      });
+      expect(readFileSync(envPath, "utf-8")).toContain("CCU_PASSWORD=hunter2");
+
+      await callTool(server, "setup_write_profile", {
+        name: "default",
+        host: "elsewhere.local",
+        port: 80,
+        https: false,
+        user: "Other",
+      });
+      const content = readFileSync(envPath, "utf-8");
+      expect(content).not.toContain("hunter2");
+      expect(content).toContain('CCU_PASSWORD=""');
+    });
+
+    it("honors makeDefault", async () => {
+      await callTool(server, "setup_write_profile", {
+        name: "prod", host: "ccu.local", port: 80, https: false, user: "Admin",
+      });
+      const res = parseToolResult(
+        await callTool(server, "setup_write_profile", {
+          name: "dev", host: "127.0.0.1", port: 18080, https: false, user: "Admin", makeDefault: true,
+        }),
+      ) as any;
+      expect(res.defaultProfile).toBe("dev");
+      expect(readFileSync(envPath, "utf-8")).toContain("CCU_DEFAULT_PROFILE=dev");
+    });
+
+    it("rejects a fingerprint on a plain-HTTP target", async () => {
+      const res = callTool(server, "setup_write_profile", {
+        name: "default", host: "ccu.local", port: 80, https: false, user: "Admin",
+        tlsFingerprint: "AA:BB",
+      });
+      await expect(res).rejects.toThrow(/HTTPS/);
+    });
+  });
+
+  describe("setup_test", () => {
+    it("reports an invalid configuration as a failing finding", async () => {
+      writeFileSync(envPath, "CCU_HOST=ccu.local\n"); // flat form, no password
+      const res = parseToolResult(await callTool(server, "setup_test")) as any;
+      expect(res.ok).toBe(false);
+      expect(res.findings[0]).toMatchObject({ check: "config", ok: false });
+      expect(res.findings[0].detail).toContain("CCU_PASSWORD");
+    });
+
+    it("passes end-to-end against a mock CCU and points at reconnecting", async () => {
+      mock = await startMockCcu(adminResults());
+      writeFileSync(envPath, `CCU_HOST=127.0.0.1\nCCU_PORT=${mock.port}\nCCU_PASSWORD=hunter2\n`);
+      const raw = await callTool(server, "setup_test");
+      const res = parseToolResult(raw) as any;
+      expect(res.ok).toBe(true);
+      expect(res.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ check: "reachability", ok: true }),
+          expect.objectContaining({ check: "login", ok: true }),
+        ]),
+      );
+      expect(res.findings.find((f: any) => f.check === "login").detail).toContain("ADMIN");
+      expect(res.nextStep).toContain("reconnect");
+      expect(JSON.stringify(raw)).not.toContain("hunter2");
+    });
+
+    it("fails on an unreachable CCU without aborting other profiles", async () => {
+      mock = await startMockCcu(adminResults());
+      // Reserve a port and free it again so nothing answers there.
+      const dead = await startMockCcu();
+      const deadPort = dead.port;
+      await dead.close();
+      writeFileSync(
+        envPath,
+        [
+          "CCU_PROFILES=up,down",
+          "CCU_UP_HOST=127.0.0.1",
+          `CCU_UP_PORT=${mock.port}`,
+          "CCU_UP_PASSWORD=pw",
+          "CCU_DOWN_HOST=127.0.0.1",
+          `CCU_DOWN_PORT=${deadPort}`,
+          "CCU_DOWN_PASSWORD=pw",
+          "",
+        ].join("\n"),
+      );
+      const res = parseToolResult(await callTool(server, "setup_test")) as any;
+      expect(res.ok).toBe(false);
+      expect(res.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ profile: "up", check: "login", ok: true }),
+          expect.objectContaining({ profile: "down", check: "reachability", ok: false }),
+        ]),
+      );
+    });
+  });
+});
+
+describe("configFromEnvFile", () => {
+  let dir: string;
+  let envPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "setup-cfg-"));
+    envPath = join(dir, ".env");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.CCU_HOST;
+    delete process.env.CCU_PASSWORD;
+  });
+
+  it("evaluates the FILE, not the process environment", () => {
+    process.env.CCU_HOST = "process-sentinel";
+    process.env.CCU_PASSWORD = "process-pw";
+    writeFileSync(envPath, "CCU_HOST=file.local\nCCU_PASSWORD=file-pw\n");
+    const config = configFromEnvFile(envPath);
+    expect(config.ccu.host).toBe("file.local");
+    // …and restores the environment afterwards.
+    expect(process.env.CCU_HOST).toBe("process-sentinel");
+    expect(process.env.CCU_PASSWORD).toBe("process-pw");
+  });
+
+  it("restores the environment even when loadConfig throws", () => {
+    process.env.CCU_HOST = "process-sentinel";
+    writeFileSync(envPath, "CCU_HOST=file.local\n"); // missing password → throws
+    expect(() => configFromEnvFile(envPath)).toThrow(/CCU_PASSWORD/);
+    expect(process.env.CCU_HOST).toBe("process-sentinel");
+  });
+});
+
+describe("profilesFromVars", () => {
+  it("returns nothing for an empty map", () => {
+    expect(profilesFromVars({})).toEqual({ profiles: [] });
+  });
+
+  it("defaults port from the HTTPS flag when PORT is missing or garbage", () => {
+    const { profiles } = profilesFromVars({ CCU_HOST: "a", CCU_HTTPS: "true", CCU_PORT: "x" });
+    expect(profiles[0].port).toBe(443);
+  });
+});
+
+describe.skipIf(!HAVE_OPENSSL)("setup_test TLS pin checks", () => {
+  let dir: string;
+  let tlsDir: string;
+  let envPath: string;
+  let server: McpServer;
+  let mock: MockCcu;
+  let fingerprint: string;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "setup-tls-"));
+    tlsDir = mkdtempSync(join(tmpdir(), "setup-cert-"));
+    envPath = join(dir, ".env");
+    server = makeServer(envPath);
+    const certPath = join(tlsDir, "cert.pem");
+    const keyPath = join(tlsDir, "key.pem");
+    spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=ccu-setup",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    const certPem = readFileSync(certPath, "utf-8");
+    fingerprint = new X509Certificate(certPem).fingerprint256;
+    mock = await startMockCcuTls({ cert: certPem, key: readFileSync(keyPath, "utf-8") }, adminResults());
+  });
+
+  afterEach(async () => {
+    await mock.close();
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(tlsDir, { recursive: true, force: true });
+  });
+
+  function writeEnv(pin: string): void {
+    writeFileSync(
+      envPath,
+      `CCU_HOST=127.0.0.1\nCCU_PORT=${mock.port}\nCCU_HTTPS=true\nCCU_TLS_FINGERPRINT=${pin}\nCCU_PASSWORD=pw\n`,
+    );
+  }
+
+  it("setup_probe returns the presented certificate for pinning", async () => {
+    const res = parseToolResult(
+      await callTool(server, "setup_probe", { host: "127.0.0.1", port: mock.port, https: true }),
+    ) as any;
+    expect(res.reachable).toBe(true);
+    expect(res.cert.fingerprint256.replace(/:/g, "")).toBe(fingerprint.replace(/:/g, ""));
+    expect(res.cert.subjectCN).toBe("ccu-setup");
+  });
+
+  it("setup_test passes with the right pin", async () => {
+    writeEnv(fingerprint);
+    const res = parseToolResult(await callTool(server, "setup_test")) as any;
+    expect(res.ok).toBe(true);
+    expect(res.findings).toEqual(
+      expect.arrayContaining([expect.objectContaining({ check: "tls-pin", ok: true })]),
+    );
+  });
+
+  it("setup_test flags a mismatch and skips that profile's login", async () => {
+    writeEnv("00".repeat(32));
+    const res = parseToolResult(await callTool(server, "setup_test")) as any;
+    expect(res.ok).toBe(false);
+    const pin = res.findings.find((f: any) => f.check === "tls-pin");
+    expect(pin.ok).toBe(false);
+    expect(pin.detail).toContain("does NOT match");
+    expect(res.findings.some((f: any) => f.check === "login")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #196. Closes #204. Closes #205. Closes #206. Closes #207.

Phase 2 of the configuration-experience plan (ROADMAP, #194), building on the wizard core from #195/#203.

## Setup mode

Started with `--stdio --env <path>` and a missing/invalid configuration, the server no longer exits — it comes up as a minimal MCP server (same identity, own instructions) exposing only four tools:

- `setup_status` — env-file path, the config-load error, the targets already in the file (password presence reported as a boolean only)
- `setup_probe` — CCU endpoint detection (443/80 auto-try) + TLS certificate fetch for the pin decision
- `setup_write_profile` — upserts one target's connection settings (flat form for a single `default`, `CCU_PROFILES` otherwise); preserves other targets, their stored passwords, and unmanaged lines
- `setup_test` — doctor-equivalent verification: config loads, reachability, pin match, login + ADMIN/USER role

So the server can be registered in an MCP client **before** it is configured; after `setup_test` goes green, the identical client entry restarts it fully configured.

Guardrails:
- **The password never travels through the model or the chat transcript.** `setup_write_profile` has no password parameter; it hands off to the new `ccu-mcp secret [profile]` subcommand — a local hidden prompt writing only the password key (0600, tmp+rename). Also the documented rotation path.
- Setup mode is **stdio-only** (an unconfigured HTTP endpoint that writes config files is not an acceptable surface); the HTTP transport still dies on a bad config.
- A bare start without `--env` still fails loudly — the existing `cli-flags` e2e guard is untouched.
- The env-file path comes from the server's own `--env` flag, never from a tool argument.

## Tests

- Unit: `setup-tools.test.ts` (33 incl. TLS pin match/mismatch via the openssl-gated mock, env-swap restore semantics, password-never-in-output assertions), `cli-secret.test.ts`
- e2e: `setup-mode.test.ts` drives the **built** server over stdio through the whole flow — setup server → probe → write → `secret` CLI child → `setup_test` green → clean EOF shutdown → same command line restarts configured (>20 tools). Plus the two negative gates (no setup mode without `--stdio`, none without `--env`).
- Live (new, gated on `CCU_DEV_HOST`): `test/integration/setup-live.test.ts` runs the same flow against the local OpenCCU QEMU dev VM (real ReGa, ADMIN role detection, doctor cross-check). Run with `CCU_DEV_HOST=127.0.0.1 CCU_DEV_PORT=18080 npm test`.
- Coverage: `src/cli` branch floor raised 77.3 → 78.3 (earned by the secret tests); ratchet's live-run warning now also triggers on `CCU_DEV_HOST`.

Also fixes a latent coverage bug found on the way: a template-literal dynamic import in `src/index.ts` made vite's transform fail silently, dropping the file from the coverage report (and tripping the ratchet's `!exempt` guard) — kept as explicit static import branches.

## Docs

README (setup-mode section, `secret` in the flag list, configuration-errors note), CHANGELOG (Unreleased), ROADMAP (phase-2 wording corrected: the server did *not* "already start with an empty config" — setup mode is the deliberate startup path that makes register-before-configure true).
