### PR TITLE
fix: accept an empty CCU_PASSWORD (presence, not non-emptiness)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,9 @@
 # Hostname or IP of your CCU — set this to your own box (e.g. a hostname like
 # homematic-ccu3 or an IP like 192.168.1.50). Required; there is no default.
 CCU_HOST=your-ccu-hostname-or-ip
-# CCU admin password.
+# CCU admin password. The variable must be present; an empty value is a valid
+# password for a box that has none (a fresh OpenCCU), so it is accepted as-is —
+# fill it in, or `ccu-mcp secret` will prompt for it without echoing.
 CCU_PASSWORD=
 
 # ─── CCU connection (optional) ──────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
+- **Fixed: an empty `CCU_PASSWORD` is now accepted.** A fresh OpenCCU box has
+  no Admin password, and `ccu-mcp secret` stores an empty one while telling the
+  user that is normal — but the flat single-CCU loader then rejected it with
+  `CCU_PASSWORD environment variable is required` and the server would not
+  start. The rule is now presence, not non-emptiness: the variable must be
+  set, its value may be empty. An absent key is still an error, and is what
+  distinguishes "not entered yet" from "chosen to be empty". Named profiles
+  (`CCU_<NAME>_PASSWORD`) already allowed empty and are unchanged.
+  Correspondingly, `setup_write_profile` no longer writes a `PASSWORD=""`
+  placeholder for a new target — it leaves the key out, so a setup-mode server
+  stays in setup mode until `ccu-mcp secret` has run.
 - **`ccu-mcp init`** — interactive setup wizard (#195): probes the CCU
   (auto-detecting HTTPS/port), shows the TLS certificate and pins its SHA-256
   fingerprint on confirmation, tests the login, reports the detected privilege

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ All configuration is via environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CCU_HOST` | required | Hostname or IP of your CCU |
-| `CCU_PASSWORD` | required | CCU admin password |
+| `CCU_PASSWORD` | required | CCU admin password. Must be set, but may be empty for a box without one (a fresh OpenCCU) |
 | `CCU_USER` | `Admin` | CCU username |
 | `CCU_PORT` | `80` | API port (`443` when using HTTPS) |
 | `CCU_HTTPS` | `false` | Connect via HTTPS (self-signed certs supported) |
@@ -415,7 +415,7 @@ server's instructions) instead of exiting, so it can be fixed conversationally:
 | Message | Cause and why it's fatal |
 |---|---|
 | `CCU_HOST environment variable is required` | No CCU configured (and no `CCU_PROFILES`). |
-| `CCU_PASSWORD environment variable is required` | Unset **or empty**. Note the asymmetry: a *profile* password may be empty (`CCU_<NAME>_PASSWORD=`, e.g. an OpenCCU dev box), the flat one may not. |
+| `CCU_PASSWORD environment variable is required` | The variable is **absent**. An empty value is accepted — a fresh OpenCCU box has no Admin password — so this means "not set yet", which is also what keeps a setup-mode server in setup mode until `ccu-mcp secret` stores one. |
 | `CCU_DEFAULT_PROFILE is set but CCU_PROFILES is not` | A leftover from a profile setup. Ignoring it would point writes at the flat `CCU_HOST` box while the env file suggests a named target. |
 | `CCU_PROFILES is set but lists no profile names` | Empty or comma-only value. |
 | `CCU_PROFILES lists "<name>" more than once` | Duplicate profile name. |

--- a/src/cli/env-writer.ts
+++ b/src/cli/env-writer.ts
@@ -9,7 +9,13 @@ export interface WizardProfile {
   https: boolean;
   tlsFingerprint?: string;
   user: string;
-  password: string;
+  /**
+   * Undefined means "no password decided yet" — the key is then left out of
+   * the file entirely, so loading fails and the server stays in setup mode
+   * until `ccu-mcp secret` writes one. An empty string is a real choice (a
+   * fresh OpenCCU box has no Admin password) and IS written.
+   */
+  password?: string;
   protected: boolean;
   readonly: boolean;
 }
@@ -60,7 +66,7 @@ export function buildEnvContent(
     lines.push(`CCU_${prefix}PORT=${p.port}`);
     lines.push(`CCU_${prefix}HTTPS=${p.https}`);
     lines.push(`CCU_${prefix}USER=${quoteEnvValue(p.user)}`);
-    lines.push(`CCU_${prefix}PASSWORD=${quoteEnvValue(p.password)}`);
+    if (p.password !== undefined) lines.push(`CCU_${prefix}PASSWORD=${quoteEnvValue(p.password)}`);
     if (p.tlsFingerprint) lines.push(`CCU_${prefix}TLS_FINGERPRINT=${p.tlsFingerprint}`);
     if (p.protected) lines.push(`CCU_${prefix}PROTECTED=true`);
     if (p.readonly) lines.push(`CCU_${prefix}READONLY=true`);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -39,7 +39,9 @@ function toCcuConfig(p: WizardProfile): CcuConfig {
     tlsVerify: false,
     tlsFingerprint: p.tlsFingerprint,
     user: p.user,
-    password: p.password,
+    // The file-level "not decided yet" distinction has no meaning on the wire:
+    // a login attempt sends an empty password either way.
+    password: p.password ?? "",
     timeout: 10_000,
     scriptTimeout: 30_000,
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -204,10 +204,24 @@ export function loadConfig(): AppConfig {
     }
   };
 
+  // The flat form's password must be PRESENT, but may be empty: a fresh OpenCCU
+  // box has no Admin password, and rejecting "" left it unconfigurable — the
+  // setup wizard's own `ccu-mcp secret` writes an empty value and says it is
+  // normal, then the server refused to start on it. Absence stays an error: it
+  // is what distinguishes "not entered yet" from "chosen to be empty", and so
+  // is what holds the server in setup mode until the secret has been stored.
+  const requirePasswordEnv = (envName: string): string => {
+    const value = process.env[envName];
+    if (value === undefined) {
+      throw new Error(`${envName} environment variable is required — run \`ccu-mcp secret\` to store one (an empty password is allowed)`);
+    }
+    return value;
+  };
+
   // Build one named profile from CCU_<PREFIX>_* env vars (issue #69). These are
   // read DYNAMICALLY (template-literal keys), so the env-example-sync test's
   // literal scan doesn't see them — intentional; they're documented as comments
-  // in .env.example. Password may be empty (OpenCCU dev boxes default to it).
+  // in .env.example.
   const buildProfile = (name: string): CcuProfile => {
     const p = envPrefix(name);
     const get = (suffix: string): string | undefined => process.env[`CCU_${p}_${suffix}`]?.trim() || undefined;
@@ -226,6 +240,9 @@ export function loadConfig(): AppConfig {
         tlsFingerprint: get("TLS_FINGERPRINT"),
         caCert: readCaCert(`CCU_${p}_CA_CERT`, get("CA_CERT")),
         user: get("USER") || "Admin",
+        // Absent means empty here, unlike the flat form below — a named
+        // profile has never required the key (issue #69) and OpenCCU dev
+        // targets are configured exactly that way.
         password: process.env[`CCU_${p}_PASSWORD`] ?? "",
         timeout: parseIntEnv(`CCU_${p}_TIMEOUT`, "10000"),
         scriptTimeout: parseIntEnv(`CCU_${p}_SCRIPT_TIMEOUT`, "30000"),
@@ -250,8 +267,7 @@ export function loadConfig(): AppConfig {
     }
     const host = process.env.CCU_HOST;
     if (!host) throw new Error("CCU_HOST environment variable is required");
-    const password = process.env.CCU_PASSWORD;
-    if (!password) throw new Error("CCU_PASSWORD environment variable is required");
+    const password = requirePasswordEnv("CCU_PASSWORD");
     const flatHttps = parseBoolEnv("CCU_HTTPS");
     profiles = [{
       name: "default",

--- a/src/tools/setup.ts
+++ b/src/tools/setup.ts
@@ -63,7 +63,9 @@ export function profilesFromVars(vars: Record<string, string>): {
       https,
       tlsFingerprint: g("TLS_FINGERPRINT")?.trim() || undefined,
       user: g("USER")?.trim() || "Admin",
-      password: g("PASSWORD") ?? "",
+      // Undefined (key absent) and "" (deliberately empty) must stay distinct
+      // here — a rewrite has to preserve which of the two the file recorded.
+      password: g("PASSWORD"),
       protected: boolVar(g("PROTECTED")),
       readonly: boolVar(g("READONLY")),
     };
@@ -313,11 +315,14 @@ function registerWriteProfile(server: McpServer, deps: SetupDeps): void {
           tlsFingerprint: args.tlsFingerprint,
           user,
           // Same endpoint: a stored password stays valid, keep it. New or
-          // moved target: never carry a secret over to a different box.
+          // moved target: never carry a secret over to a different box — and
+          // leave the key out rather than writing an empty placeholder, which
+          // would look like a deliberately empty password and let the server
+          // start before `ccu-mcp secret` has run.
           password:
             previous && previous.host === args.host && previous.port === args.port
               ? previous.password
-              : "",
+              : undefined,
           protected: args.protected ?? previous?.protected ?? false,
           readonly: args.readonly ?? previous?.readonly ?? false,
         };
@@ -335,7 +340,7 @@ function registerWriteProfile(server: McpServer, deps: SetupDeps): void {
         const content = existing === undefined ? managed : mergeEnvContent(existing, managed).content;
         writeEnvFile(deps.envPath, content);
 
-        const nextStep = updated.password === ""
+        const nextStep = updated.password === undefined
           ? `Ask the user to run this in a terminal (the password is typed there, hidden — never in this chat):\n  ${secretCommand(deps, updated.name)}\nThen call setup_test.`
           : "The stored password was kept. Call setup_test to verify the target.";
         return structuredResult({

--- a/test/e2e/setup-mode.test.ts
+++ b/test/e2e/setup-mode.test.ts
@@ -140,9 +140,10 @@ describe.skipIf(distMissing)("setup mode e2e (built server)", () => {
     expect(write.result?.structuredContent?.written).toBe(true);
     expect(write.result?.structuredContent?.nextStep).toContain("ccu-mcp secret dev");
     expect(statSync(envPath).mode & 0o777).toBe(0o600);
-    // The password is NOT in the file yet — and there is no way to put it
-    // there over MCP.
-    expect(readFileSync(envPath, "utf-8")).toContain('CCU_DEV_PASSWORD=""');
+    // The password is NOT in the file yet — the key is absent rather than
+    // empty, so it cannot be mistaken for a deliberately empty password — and
+    // there is no way to put it there over MCP.
+    expect(readFileSync(envPath, "utf-8")).not.toContain("CCU_DEV_PASSWORD");
 
     // 3. The password arrives out-of-band through the local CLI.
     const secret = spawn("node", [DIST, "secret", "dev", "--env", envPath], {

--- a/test/e2e/setup-mode.test.ts
+++ b/test/e2e/setup-mode.test.ts
@@ -139,11 +139,14 @@ describe.skipIf(distMissing)("setup mode e2e (built server)", () => {
     });
     expect(write.result?.structuredContent?.written).toBe(true);
     expect(write.result?.structuredContent?.nextStep).toContain("ccu-mcp secret dev");
+    // Read before stat: the reverse order is a check-then-use pattern CodeQL
+    // flags as a file-system race (js/file-system-race).
+    const written = readFileSync(envPath, "utf-8");
     expect(statSync(envPath).mode & 0o777).toBe(0o600);
     // The password is NOT in the file yet — the key is absent rather than
     // empty, so it cannot be mistaken for a deliberately empty password — and
     // there is no way to put it there over MCP.
-    expect(readFileSync(envPath, "utf-8")).not.toContain("CCU_DEV_PASSWORD");
+    expect(written).not.toContain("CCU_DEV_PASSWORD");
 
     // 3. The password arrives out-of-band through the local CLI.
     const secret = spawn("node", [DIST, "secret", "dev", "--env", envPath], {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -410,6 +410,16 @@ describe("loadConfig", () => {
       expect(config.ccu.password).toBe("secret");
     });
 
+    it("accepts an empty flat CCU_PASSWORD, but not a missing one", () => {
+      process.env.CCU_HOST = "openccu";
+      // A fresh OpenCCU box has no Admin password; `ccu-mcp secret` stores "".
+      process.env.CCU_PASSWORD = "";
+      expect(loadConfig().ccu.password).toBe("");
+
+      delete process.env.CCU_PASSWORD;
+      expect(() => loadConfig()).toThrow(/CCU_PASSWORD environment variable is required/);
+    });
+
     it("builds one profile per CCU_PROFILES entry from CCU_<NAME>_* vars", () => {
       process.env.CCU_PROFILES = "prod,dev";
       process.env.CCU_DEFAULT_PROFILE = "prod";

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -28,9 +28,10 @@ function envKeysReferencedInCode(): Set<string> {
       keys.add(m[1] ?? m[2]);
     }
     // parseIntEnv("FOO", …) / parseDurationEnv("FOO", …) / parseBoolEnv("FOO")
-    // — indirect reads. Keep this alternation in step with the helpers in
-    // config.ts, or a var read only through a new helper looks undocumented.
-    for (const m of text.matchAll(/parse(?:Int|Duration|Bool)Env\("([A-Z][A-Z0-9_]*)"/g)) {
+    // / requirePasswordEnv("FOO", …) — indirect reads. Keep this alternation in
+    // step with the helpers in config.ts, or a var read only through a new
+    // helper looks undocumented.
+    for (const m of text.matchAll(/(?:parse(?:Int|Duration|Bool)|requirePassword)Env\("([A-Z][A-Z0-9_]*)"/g)) {
       keys.add(m[1]);
     }
   }

--- a/test/unit/setup-tools.test.ts
+++ b/test/unit/setup-tools.test.ts
@@ -163,7 +163,10 @@ describe("setup-mode server", () => {
       const content = readFileSync(envPath, "utf-8");
       expect(content).toContain("CCU_HOST=ccu.local");
       expect(content).not.toContain("CCU_PROFILES");
-      expect(content).toContain('CCU_PASSWORD=""');
+      // No placeholder: an absent key is what tells loadConfig the password has
+      // not been chosen yet, so the server stays in setup mode. `CCU_PASSWORD=""`
+      // would read as a deliberately empty one and start the server unconfigured.
+      expect(content).not.toContain("CCU_PASSWORD");
       expect(statSync(envPath).mode & 0o777).toBe(0o600);
     });
 
@@ -223,7 +226,20 @@ describe("setup-mode server", () => {
       });
       const content = readFileSync(envPath, "utf-8");
       expect(content).not.toContain("hunter2");
-      expect(content).toContain('CCU_PASSWORD=""');
+      expect(content).not.toContain("CCU_PASSWORD");
+    });
+
+    it("preserves a deliberately empty password across a rewrite of the same endpoint", async () => {
+      writeFileSync(envPath, 'CCU_HOST=ccu.local\nCCU_PORT=80\nCCU_PASSWORD=""\n');
+      const res = parseToolResult(
+        await callTool(server, "setup_write_profile", {
+          name: "default", host: "ccu.local", port: 80, https: false, user: "Admin",
+        }),
+      ) as any;
+      // An empty password the user chose is a decision, not a missing value:
+      // it survives the rewrite and must not send them back to `ccu-mcp secret`.
+      expect(readFileSync(envPath, "utf-8")).toContain('CCU_PASSWORD=""');
+      expect(res.nextStep).not.toContain("ccu-mcp secret");
     });
 
     it("honors makeDefault", async () => {


### PR DESCRIPTION
## Problem

Setting up the OpenCCU dev VM through the new LLM-guided setup (#196/#208) produced a valid env file the server refused to start on:

```
CCU_PASSWORD environment variable is required
```

The VM's Admin password is genuinely empty — `Session.login` with `""` returns a session id — and `ccu-mcp secret` stores it while printing *"Storing an EMPTY password (normal for a fresh OpenCCU dev box)"*. Then `loadConfig` rejected exactly that. The product contradicted itself, and a fresh OpenCCU box was unconfigurable through the flat single-CCU form.

Named profiles already allowed an empty password; the README documented the asymmetry as intended rather than treating it as the bug it was.

## Fix

The rule is **presence, not non-emptiness**: `CCU_PASSWORD` must be set, its value may be empty.

An absent key stays an error, deliberately — it is what distinguishes "not entered yet" from "chosen to be empty", and so is what holds a setup-mode server in setup mode until `ccu-mcp secret` has run. That forced the companion change: `setup_write_profile` no longer writes a `PASSWORD=""` placeholder for a new target. The placeholder is indistinguishable from a deliberate empty password, so keeping it would have let the server start unconfigured on the next reconnect.

Named profiles (`CCU_<NAME>_PASSWORD`) are untouched — absent still means empty, per the #69 contract. Requiring presence there too would be more symmetric but breaks a tested behaviour ("dev password intentionally unset"), so it is left as a separate decision.

## Verification

Against the real OpenCCU dev VM (`127.0.0.1:18443`, HTTPS, pinned cert):

- empty `CCU_PASSWORD=` → `doctor`: config loads, reachable, fingerprint matches, **login OK as "Admin" — privilege level ADMIN**
- key absent → `doctor`: `CCU_PASSWORD environment variable is required — run ccu-mcp secret to store one (an empty password is allowed)`
- `ccu-mcp secret` with empty input → writes `CCU_PASSWORD=""` → `doctor` all green

`npm run lint` clean; `npm test` 586 passed / 29 skipped. New regression tests cover empty-accepted / absent-rejected and preserving a deliberately empty password across a `setup_write_profile` rewrite.

## Docs

README's asymmetry note and env-var table, `.env.example`, and CHANGELOG updated.