### PR TITLE
fix: print commands that run this build, not whatever npx resolves to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
+- **Fixed: the guided setup printed commands for the wrong binary.**
+  `setup_write_profile` told the user to run `npx ccu-mcp secret …`, and
+  `secret`/`init` signed off with bare `ccu-mcp doctor …`. `npx` resolves to
+  whatever it finds in cwd or the global prefix, which for anyone with an
+  older global install is a *different* build than the one giving the advice
+  — and `secret`, `init` and `doctor` all postdate the latest published tag,
+  so that build had no such subcommand. Worse, it did not say so: an unknown
+  first argument fell through to normal server startup, and the flow died on
+  `CCU_HOST environment variable is required` — a complaint about a variable
+  the user had just configured correctly, from a file that binary never read.
+  Every printed command now invokes the running build (`process.argv[1]`),
+  falling back to a version-pinned `npx ccu-mcp@<version>`. The MCP client
+  snippet from `init` deliberately keeps plain `npx ccu-mcp`, since that entry
+  is durable and argv[1] may point into npx's collectable cache.
+- **An unknown subcommand now fails loudly** — `ccu-mcp frobnicate` exits 2
+  with `unknown command "frobnicate" (ccu-mcp X.Y.Z)` instead of starting a
+  server. The version is the point: it identifies which install a printed
+  command actually reached.
+
 - **Fixed: an empty `CCU_PASSWORD` is now accepted.** A fresh OpenCCU box has
   no Admin password, and `ccu-mcp secret` stores an empty one while telling the
   user that is normal — but the flat single-CCU loader then rejected it with

--- a/README.md
+++ b/README.md
@@ -309,10 +309,13 @@ you through the same probe → pin → test-login → write flow in plain chat.
 Then just ask: *"set up my CCU connection"*. One deliberate exception: **the
 password never travels through the model or the chat transcript**.
 `setup_write_profile` has no password parameter; instead the assistant hands
-you a one-liner to run in a terminal — `ccu-mcp secret <profile> --env
-/path/to/.env` — which prompts locally with echo off and writes only the
-password into the file (mode 0600). Once `setup_test` reports green, reconnect
-the MCP server and the identical client entry starts it fully configured.
+you a one-liner to run in a terminal — `npx ccu-mcp secret <profile> --env
+/path/to/.env`, or the equivalent for however you installed it — which prompts
+locally with echo off and writes only the password into the file (mode 0600).
+Copy the command the tool prints rather than this one: it names the build that
+printed it, so it cannot land on an older install that lacks the subcommand.
+Once `setup_test` reports green, reconnect the MCP server and the identical
+client entry starts it fully configured.
 
 Setup mode is stdio-only (an unconfigured HTTP endpoint that writes config
 files would be an unacceptable surface), and a bare start without `--env`

--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -1,5 +1,35 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { parseEnv } from "node:util";
+import { VERSION } from "../utils.js";
+
+/** Quote a shell argument only when it needs it, so the common case stays readable. */
+function shellArg(value: string): string {
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * A copy-pasteable command that runs THIS build — the one printing the hint.
+ *
+ * The guided setup used to print a bare `npx ccu-mcp …`, which resolves to
+ * whatever npx finds in cwd or the global prefix. For anyone with an older
+ * global install that is a DIFFERENT binary than the one giving the advice,
+ * and the subcommand may not exist there at all: `secret`, `init` and
+ * `doctor` all postdate the latest published tag, so `npx ccu-mcp secret`
+ * reached a build that fell through to server startup and died with
+ * "CCU_HOST environment variable is required" — a complaint about a variable
+ * the user had just configured, from a file that binary never read.
+ *
+ * `process.argv[1]` is the entry point node actually loaded, so it always
+ * names the running build. The npx form stays as a fallback for the case
+ * where argv[1] is missing or no longer on disk, and is version-pinned so it
+ * cannot silently resolve to something older.
+ */
+export function selfCommand(...args: string[]): string {
+  const rendered = args.map(shellArg).join(" ");
+  const entry = process.argv[1];
+  if (entry && existsSync(entry)) return `node ${shellArg(entry)} ${rendered}`;
+  return `npx ccu-mcp@${VERSION} ${rendered}`;
+}
 
 /**
  * Value of `--env <path>` in argv, defaulting to ./.env. Deliberately NOT

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import { Prompter, type PromptIo } from "./prompt.js";
-import { envFileArg, displayFingerprint } from "./common.js";
+import { envFileArg, displayFingerprint, selfCommand } from "./common.js";
 import {
   buildEnvContent,
   mergeEnvContent,
@@ -239,9 +239,13 @@ async function runWizard(ui: Prompter, envPath: string): Promise<number> {
   );
   ui.say("");
   ui.say("Or via the Claude Code CLI:");
+  // Stays `npx ccu-mcp` on purpose, unlike the next-step hints below: this
+  // line goes into a DURABLE client config. argv[1] may point inside npx's
+  // cache (~/.npm/_npx/<hash>/…), which is garbage-collected — fine for a
+  // command to run now, wrong to bake into a permanent MCP server entry.
   ui.say(`  claude mcp add ccu-mcp -- npx ccu-mcp --stdio --env ${absPath}`);
   ui.say("");
-  ui.say(`Re-check this configuration anytime with: ccu-mcp doctor --env ${absPath}`);
+  ui.say(`Re-check this configuration anytime with: ${selfCommand("doctor", "--env", absPath)}`);
   return 0;
 }
 

--- a/src/cli/secret.ts
+++ b/src/cli/secret.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import { Prompter, type PromptIo } from "./prompt.js";
-import { envFileArg, loadEnvFile } from "./common.js";
+import { envFileArg, loadEnvFile, selfCommand } from "./common.js";
 import { quoteEnvValue, readEnvFile, replaceEnvKey, writeEnvFile } from "./env-writer.js";
 import { envPrefix } from "../config.js";
 
@@ -20,7 +20,7 @@ export async function run(argv: string[], io?: PromptIo): Promise<number> {
     envPath = envFileArg(argv);
     content = readEnvFile(envPath);
     if (content === undefined) {
-      say(`ccu-mcp secret: ${resolve(envPath)} does not exist — run \`ccu-mcp init\` or the MCP setup flow first.`);
+      say(`ccu-mcp secret: ${resolve(envPath)} does not exist — run \`${selfCommand("init", "--env", envPath)}\` or the MCP setup flow first.`);
       return 1;
     }
     vars = loadEnvFile(envPath);
@@ -38,7 +38,7 @@ export async function run(argv: string[], io?: PromptIo): Promise<number> {
   if (names.length > 0) {
     if (!profileArg) {
       say(`This file configures named targets (${names.join(", ")}) — say which one:`);
-      say(`  ccu-mcp secret <profile> --env ${envPath}`);
+      say(`  ${selfCommand("secret", "<profile>", "--env", envPath)}`);
       return 1;
     }
     const match = names.find((n) => n.toLowerCase() === profileArg.toLowerCase());
@@ -51,7 +51,7 @@ export async function run(argv: string[], io?: PromptIo): Promise<number> {
   } else {
     if (profileArg) {
       say(`ccu-mcp secret: this file uses the single-CCU form — no profile name needed:`);
-      say(`  ccu-mcp secret --env ${envPath}`);
+      say(`  ${selfCommand("secret", "--env", envPath)}`);
       return 1;
     }
     key = "CCU_PASSWORD";
@@ -66,7 +66,7 @@ export async function run(argv: string[], io?: PromptIo): Promise<number> {
     }
     writeEnvFile(envPath, replaceEnvKey(content, key, quoteEnvValue(password)));
     ui.say(`Wrote ${key} to ${resolve(envPath)} (mode 0600).`);
-    ui.say(`Verify with: ccu-mcp doctor --env ${envPath}`);
+    ui.say(`Verify with: ${selfCommand("doctor", "--env", envPath)}`);
     return 0;
   } catch (err) {
     if ((err as Error).message === "input closed") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,22 @@ async function main(): Promise<void> {
     return;
   }
 
+  // A bare first word is always a subcommand attempt — server mode is entered
+  // with flags (--stdio/--http/--env). Falling through to startup instead made
+  // an OLDER binary answer `ccu-mcp secret …` with "CCU_HOST environment
+  // variable is required": a complaint about configuration, for what is really
+  // "this build predates that command". Name the version, so the next person
+  // who runs a printed command against the wrong install can see which one it
+  // reached.
+  if (argv[0] !== undefined && !argv[0].startsWith("-")) {
+    process.stderr.write(
+      `ccu-mcp: unknown command "${argv[0]}" (ccu-mcp ${VERSION}).\n` +
+        `Known commands: init, doctor, secret. Run \`ccu-mcp --help\` for usage.\n`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+
   if (handleInfoFlags(argv)) return;
 
   // `--env` for server mode: lets an MCP client entry reference the file

--- a/src/tools/setup.ts
+++ b/src/tools/setup.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Logger } from "../logger.js";
 import { loadConfig, envPrefix, type AppConfig } from "../config.js";
-import { loadEnvFile, displayFingerprint } from "../cli/common.js";
+import { loadEnvFile, displayFingerprint, selfCommand } from "../cli/common.js";
 import {
   buildEnvContent,
   mergeEnvContent,
@@ -131,8 +131,8 @@ function certResult(cert: CertInfo): Record<string, unknown> {
 }
 
 function secretCommand(deps: SetupDeps, profileName: string): string {
-  const profileArg = profileName === "default" ? "" : ` ${profileName}`;
-  return `npx ccu-mcp secret${profileArg} --env ${deps.envPath}`;
+  const profileArg = profileName === "default" ? [] : [profileName];
+  return selfCommand("secret", ...profileArg, "--env", deps.envPath);
 }
 
 function registerStatus(server: McpServer, deps: SetupDeps): void {

--- a/test/e2e/cli-flags.test.ts
+++ b/test/e2e/cli-flags.test.ts
@@ -78,4 +78,25 @@ describe.skipIf(distMissing)("CLI info flags (no environment)", () => {
     expect(res.status).not.toBe(0);
     expect(res.stderr).toContain("CCU_HOST");
   });
+
+  it("rejects an unknown subcommand by name and version, without starting a server", () => {
+    // A build that predates a subcommand used to fall through to server
+    // startup and answer `ccu-mcp secret …` with "CCU_HOST environment
+    // variable is required" — a configuration complaint for what is really a
+    // wrong/old binary. The version in the message is the point: it tells you
+    // which install a printed command actually reached.
+    const res = runBare("frobnicate");
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('unknown command "frobnicate"');
+    expect(res.stderr).toContain(PKG_VERSION.version);
+    expect(res.stderr).not.toContain("environment variable is required");
+  });
+
+  it("still treats the real subcommands as subcommands", () => {
+    // The guard keys off "does not start with -", so a typo'd flag must not be
+    // swallowed as a command, and a real command must still reach its handler.
+    const res = runBare("doctor", "--env", "/nonexistent/ccu.env");
+    expect(res.stderr).not.toContain("unknown command");
+    expect(`${res.stdout}${res.stderr}`).toContain("doctor");
+  });
 });

--- a/test/e2e/setup-mode.test.ts
+++ b/test/e2e/setup-mode.test.ts
@@ -138,7 +138,12 @@ describe.skipIf(distMissing)("setup mode e2e (built server)", () => {
       arguments: { name: "dev", host: "127.0.0.1", port: ccu.port, https: false },
     });
     expect(write.result?.structuredContent?.written).toBe(true);
-    expect(write.result?.structuredContent?.nextStep).toContain("ccu-mcp secret dev");
+    // The printed command must invoke THIS server's own entry point — the
+    // subprocess was spawned as `node DIST --stdio …`, so argv[1] is DIST.
+    // A bare `npx ccu-mcp` here reaches whichever install npx finds, which for
+    // an older global has no `secret` subcommand and fails with a misleading
+    // "CCU_HOST environment variable is required".
+    expect(write.result?.structuredContent?.nextStep).toContain(`node ${DIST} secret dev`);
     // Read before stat: the reverse order is a check-then-use pattern CodeQL
     // flags as a file-system race (js/file-system-race).
     const written = readFileSync(envPath, "utf-8");

--- a/test/unit/setup-tools.test.ts
+++ b/test/unit/setup-tools.test.ts
@@ -158,8 +158,13 @@ describe("setup-mode server", () => {
         }),
       ) as any;
       expect(res.written).toBe(true);
-      expect(res.nextStep).toContain("ccu-mcp secret");
+      expect(res.nextStep).toContain("secret");
       expect(res.nextStep).toContain(envPath);
+      // Must name the build that is printing it, not whatever `npx` would
+      // resolve to — an older global install may not have `secret` at all,
+      // and then answers with an unrelated configuration error.
+      expect(res.nextStep).toContain(process.argv[1]);
+      expect(res.nextStep).not.toContain("npx ccu-mcp secret");
       const content = readFileSync(envPath, "utf-8");
       expect(content).toContain("CCU_HOST=ccu.local");
       expect(content).not.toContain("CCU_PROFILES");


### PR DESCRIPTION
Found by an end-to-end first-run test of the LLM-guided setup: a fresh project folder, a project-scoped `.mcp.json`, and a manually installed build. **The setup flow could not be completed by following the instructions it printed.**

## What happened

`setup_write_profile` printed:

```
npx ccu-mcp secret --env /home/kamienc/ccu-mcp-test/ccu.env
```

Running that verbatim gave:

```
Fatal error: Error: CCU_HOST environment variable is required
    at loadConfig (file:///home/kamienc/.nvm/.../node_modules/ccu-mcp/dist/config.js:163:19)
```

`npx` resolved to an older **global** install, which has no `secret` subcommand. Instead of saying so, it fell through to normal server startup and complained about a variable the user had just configured correctly — naming a file it never opened. The only clue that the wrong binary ran is the path in the stack trace.

This is not an edge case: `secret`, `init` and `doctor` all postdate the latest published tag, so `npx ccu-mcp` and `npm i -g ccu-mcp@latest` both yield a build without them. There is currently no published binary for which the printed command works.

`secret` then signs off with `Verify with: ccu-mcp doctor --env …` — same bug, same run. Every hop of the guided flow handed the user a command naming a binary other than the one that just ran.

## Fix

`selfCommand()` (`src/cli/common.ts`) renders a command for the **running** build from `process.argv[1]`, with a version-pinned `npx ccu-mcp@<version>` fallback for when argv[1] is missing or gone from disk, and shell-quoting for paths that need it. Applied to every next-step hint in `setup_write_profile`, `secret` and `init`.

One deliberate exception: the `claude mcp add … -- npx ccu-mcp --stdio` snippet from `init` keeps plain `npx`. That line goes into a *durable* client config, and argv[1] may point inside npx's garbage-collectable cache — right for a command to run now, wrong to bake into a permanent server entry.

Second half: an unknown first argument now exits 2 with

```
ccu-mcp: unknown command "frobnicate" (ccu-mcp 1.10.0).
Known commands: init, doctor, secret. Run `ccu-mcp --help` for usage.
```

instead of starting a server. The version is the point — it tells you which install a printed command actually reached. Server mode is always entered with flags, so a bare first word is unambiguously a subcommand attempt.

## Verification

```
$ node dist/index.js frobnicate
ccu-mcp: unknown command "frobnicate" (ccu-mcp 1.10.0).   # exit 2

$ # setup_write_profile nextStep, over stdio:
  node /path/to/dist/index.js secret --env /path/to/ccu.env

$ # secret's sign-off:
Verify with: node /path/to/dist/index.js doctor --env /path/to/ccu.env
```

`npm run lint` clean; `npm test` 588 passed / 29 skipped. The e2e assertion now checks the printed command contains `node ${DIST} secret dev` — i.e. it names the very process that printed it — and the unit test additionally guards against a bare `npx ccu-mcp secret` regression. Two new CLI tests cover the unknown-subcommand exit and confirm real subcommands and flags still route correctly.