### PR TITLE
fix: get_system_info must not report a failed login as a working connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
+- **Fixed: `get_system_info` reported a failed login as a working connection.**
+  Its four ADMIN-only probes (`CCU.getVersion` and friends) treated *every*
+  failure as "not permitted", so wrong credentials or an unreachable CCU came
+  back as `version/serial/address: "N/A"`, `role: "UNKNOWN"` and **no error** —
+  while the very next read failed with `AUTH 501`. That is the tool an agent
+  reaches for to answer "did my setup work?", and it answered yes. A probe that
+  fails while the session is still valid is still a privilege denial and still
+  degrades to `"N/A"` with the USER-level note; a probe that fails with no
+  session now fails the call with the real error (`AUTH`, `UNREACHABLE`,
+  `TLS_ERROR`). `"N/A"` now means exactly one thing: connected, not permitted.
+
 - **Documented multi-target setup end to end.** The README claimed
   `ccu-mcp init` walks "one or more" targets and left it there; it now shows a
   worked two-CCU session — wizard transcript, the profile-form env file it

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -290,8 +290,10 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       description:
         "Get CCU system information: firmware version, serial number, addresses. Reports the active " +
         "login user and inferred role (ADMIN/USER) — note that version/serial/address are ADMIN-only " +
-        "on the CCU, so they show \"N/A\" for a non-admin (USER) login. Also reports the running " +
-        "server's build identification (git branch/commit/tag and build time) under `build`.",
+        "on the CCU, so they show \"N/A\" for a non-admin (USER) login. A CCU that cannot be reached " +
+        "or logged into fails with that error instead — \"N/A\" always means \"connected, not permitted\". " +
+        "Also reports the running server's build identification (git branch/commit/tag and build time) " +
+        "under `build`.",
       inputSchema: {
         target: targetField,
       },
@@ -300,7 +302,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
         target: z.string().optional().describe("Active CCU target name"),
         user: z.string().optional().describe("Configured login user for the active target"),
         role: z.enum(["ADMIN", "USER", "UNKNOWN"]).optional()
-          .describe("Access role inferred from which CCU methods answer: ADMIN if admin-only calls succeed, USER if logged in without admin rights, UNKNOWN if not connected"),
+          .describe("Access role inferred from which CCU methods answer: ADMIN if admin-only calls succeed, USER if logged in without admin rights. A CCU that cannot be reached or logged into raises that error instead of reporting a role"),
         version: z.unknown().optional().describe("Firmware version, or \"N/A\" if unavailable (ADMIN-only)"),
         serial: z.unknown().optional().describe("Serial number, or \"N/A\" if unavailable (ADMIN-only)"),
         address: z.unknown().optional().describe("BidCos address, or \"N/A\" if unavailable (ADMIN-only)"),
@@ -340,6 +342,14 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       ];
 
       let anyAdminOk = false;
+      // A failure while the session is still valid is a privilege denial (the
+      // USER case this tool exists to degrade for). A failure with NO session
+      // is something else entirely — wrong credentials, an unreachable CCU, a
+      // pin mismatch — and reporting that as N/A + role UNKNOWN told the
+      // caller "connected, probably USER-level" when nothing had connected at
+      // all. Keep the first such error and fail with it: this is the tool
+      // people reach for to answer "did my setup work?".
+      let noSessionErr: unknown = null;
       for (const { key, method } of calls) {
         try {
           await rateLimiter.acquire();
@@ -350,13 +360,17 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
           } else {
             results[key] = "N/A"; // empty/no value rather than null
           }
-        } catch {
+        } catch (err) {
           results[key] = "N/A"; // permission denied or call failed
+          if (noSessionErr === null && !session.isLoggedIn()) noSessionErr = err;
         }
       }
+      if (noSessionErr !== null) throw noSessionErr;
 
       // Infer role: admin-only calls answered => ADMIN; otherwise logged in but
-      // without those rights => USER; not logged in / unreachable => UNKNOWN.
+      // without those rights => USER. UNKNOWN remains for the case no call
+      // threw yet none answered — a connection failure now throws above rather
+      // than arriving here dressed as a role.
       const loggedIn = active.session.isLoggedIn();
       results.role = anyAdminOk ? "ADMIN" : (loggedIn ? "USER" : "UNKNOWN");
       if (!anyAdminOk && loggedIn) {

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -183,7 +183,9 @@ NOT_FOUND if no active message matches; the warning reappears if its condition p
 Args: target? (CCU target name)
 Returns: {serverVersion, target, user, role (ADMIN|USER|UNKNOWN), version, serial, address, hmipAddress,
   accessNote? (present when ADMIN-only fields are unavailable), cacheTypes, cacheWarming, build {branch, commit, tag, describe, dirty, builtAt}}
-version/serial/address/hmipAddress are ADMIN-only on the CCU and show "N/A" for a USER-level login.`,
+version/serial/address/hmipAddress are ADMIN-only on the CCU and show "N/A" for a USER-level login.
+"N/A" therefore means "connected, not permitted": a CCU that cannot be reached or logged into fails with
+that error (AUTH/UNREACHABLE/TLS_ERROR) instead, so this tool is a safe "did my setup work?" check.`,
 
   get_rssi: `Radio link quality (RSSI, dBm) per device, plus BidCos interface health.
 Args: name? (substring filter on device name/address), target? (CCU target name)

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -15,14 +15,16 @@ interface TargetSpec {
   readonly?: boolean;
   password?: string;
   sessionCall?: SessionCall;
+  /** Session state reported by isLoggedIn() — false stands in for a login that never succeeded. */
+  loggedIn?: boolean;
 }
 
-function makeSession(sessionCall?: SessionCall) {
+function makeSession(sessionCall?: SessionCall, loggedIn = true) {
   return {
     call: sessionCall ?? vi.fn(async () => []),
     login: vi.fn(async () => {}),
     logout: vi.fn(async () => {}),
-    isLoggedIn: vi.fn(() => true),
+    isLoggedIn: vi.fn(() => loggedIn),
     getSessionId: vi.fn(() => "test-session"),
     callNoSession: vi.fn(async () => null),
     destroy: vi.fn(),
@@ -38,7 +40,7 @@ function makeTarget(spec: TargetSpec): Target {
       readonly: spec.readonly ?? false,
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: spec.password ?? "pw", timeout: 5000, scriptTimeout: 10000 },
     },
-    session: makeSession(spec.sessionCall),
+    session: makeSession(spec.sessionCall, spec.loggedIn ?? true),
     resolver: new Resolver(),
     deviceTypeCache: new DeviceTypeCache("/tmp/nonexistent-test", 86400, new Logger("error"), `device-type-cache.${name}.json`),
     sysVarTypeCache: { entry: null, gen: 0 },
@@ -73,6 +75,8 @@ export function createMockDeps(overrides?: {
   readonly?: boolean;
   /** Build a multi-target registry instead of the single default target. */
   targets?: TargetSpec[];
+  /** Session state of the single default target; false = login never succeeded. */
+  loggedIn?: boolean;
 }): ServerDeps {
   const rateLimiter = new RateLimiter(1000, 1000); // effectively unlimited for tests
   const specs: TargetSpec[] = overrides?.targets ?? [{
@@ -80,6 +84,7 @@ export function createMockDeps(overrides?: {
     protected: overrides?.protected,
     readonly: overrides?.readonly,
     sessionCall: overrides?.sessionCall,
+    loggedIn: overrides?.loggedIn,
   }];
   const registry = new FakeRegistry(specs.map(makeTarget));
   const selection = new TargetSelection(registry as unknown as TargetRegistry);

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { tryParseJson } from "../../src/tools/diagnostics.js";
 import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
+import { CcuError } from "../../src/middleware/error-mapper.js";
 
 describe("tryParseJson", () => {
   it("parses valid JSON", () => {
@@ -271,6 +272,65 @@ describe("get_system_info handler", () => {
     cleanupDeps(deps);
   });
 
+  // F-005: a failed login used to come back as all-N/A + role UNKNOWN and no
+  // error — "did my setup work?" answered with a plausible yes.
+  it("fails with the login error instead of N/A when there is no session", async () => {
+    const { server, deps } = createTestServer({
+      loggedIn: false,
+      sessionCall: vi.fn().mockRejectedValue(new CcuError({
+        error: "AUTH",
+        code: 501,
+        message: "invalid credentials",
+        hint: "Verify CCU_USER/CCU_PASSWORD.",
+      })),
+    });
+
+    const result: any = await callTool(server, "get_system_info");
+    expect(result.isError).toBe(true);
+    const err = JSON.parse(result.content[0].text);
+    expect(err.error).toBe("AUTH");
+    expect(err.code).toBe(501);
+    expect(result.content[0].text).not.toContain("N/A");
+    cleanupDeps(deps);
+  });
+
+  it("propagates an unreachable CCU rather than reporting a role", async () => {
+    const { server, deps } = createTestServer({
+      loggedIn: false,
+      sessionCall: vi.fn().mockRejectedValue(new CcuError({
+        error: "UNREACHABLE",
+        code: 0,
+        message: "Cannot connect to CCU: fetch failed",
+        hint: "Check that the CCU is running.",
+      })),
+    });
+
+    const result: any = await callTool(server, "get_system_info");
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("UNREACHABLE");
+    cleanupDeps(deps);
+  });
+
+  // The other side of the rule: a valid session that is merely denied the
+  // ADMIN-only calls must still degrade to N/A, not fail.
+  it("still degrades to N/A when the session is valid but the call is denied", async () => {
+    const { server, deps } = createTestServer({
+      loggedIn: true,
+      sessionCall: vi.fn().mockRejectedValue(new CcuError({
+        error: "AUTH",
+        code: 400,
+        message: "Access denied for CCU.getVersion: the CCU user lacks the required privilege level",
+        hint: "Use an ADMIN account.",
+      })),
+    });
+
+    const result = parseToolResult(await callTool(server, "get_system_info")) as any;
+    expect(result.role).toBe("USER");
+    expect(result.version).toBe("N/A");
+    expect(result.accessNote).toMatch(/ADMIN-only/);
+    cleanupDeps(deps);
+  });
+
   it("reports USER role with N/A fields and an accessNote when admin-only calls are denied", async () => {
     const { server, deps } = createTestServer({
       // Every ADMIN-gated CCU.* call is denied — mimics a non-admin login.
@@ -304,7 +364,6 @@ describe("error and edge paths (coverage round)", () => {
   });
 
   it("get_service_messages maps CcuError to a structured tool error", async () => {
-    const { CcuError } = await import("../../src/middleware/error-mapper.js");
     const { server, deps } = createTestServer({
       sessionCall: vi.fn().mockRejectedValue(new CcuError({ error: "CCU_ERROR", code: 501, message: "rega busy", hint: "" })),
     });


### PR DESCRIPTION
Fixes QA finding **F-005** (Medium), found during the LLM-guided setup test against the OpenCCU dev VM with a wrong password stored.

## The bug

`get_system_info` probes four ADMIN-only CCU methods (`CCU.getVersion`, `getSerial`, `getAddress`, `getHmIPAddress`) and uses them as a capability probe. Every failure was caught identically and written as `"N/A"`, on the assumption that a failure means *logged in, not permitted*.

So a wrong password produced:

```json
{"version":"N/A","serial":"N/A","address":"N/A","hmipAddress":"N/A","role":"UNKNOWN"}
```

…with **no error**, while the very next read (`list_rooms`) failed with `AUTH 501`. This is the tool an agent reaches for to answer "did my setup work?" — and it answered yes. An unreachable CCU and a TLS pin mismatch masked themselves the same way.

## The fix

The distinguishing signal was already present and unused: after a failed probe, `session.isLoggedIn()` is **true** for a privilege denial (valid session, insufficient rights) and **false** when no session was ever obtained. The loop now keeps the first error seen while there is no session and rethrows it after the loop.

| Situation | Before | After |
| --- | --- | --- |
| ADMIN login | real values, `role: ADMIN` | unchanged |
| USER login, calls denied | `"N/A"` + `accessNote`, `role: USER` | unchanged |
| Wrong credentials | `"N/A"`, `role: UNKNOWN`, no error | fails with `AUTH` |
| CCU unreachable / pin mismatch | `"N/A"`, `role: UNKNOWN`, no error | fails with `UNREACHABLE` / `TLS_ERROR` |

Generalising past AUTH was deliberate: the rule that makes the tool trustworthy is the general one — **`"N/A"` means connected-but-not-permitted, and nothing else.** The tool description and the `help` text now say so, since the point is that a caller can rely on it.

## Tests

Three new unit tests: no session + `AUTH`, no session + `UNREACHABLE`, and the valid-session denial that must still degrade to `"N/A"`. `test/unit/_helpers.ts` gained a `loggedIn` spec flag to simulate a login that never succeeded.

`npm run lint` clean; `npm test` 591 passed / 29 skipped; coverage ratchet passes (`src/tools` branches 85.04% vs floor 84.4%).