### PR TITLE
fix: setup mode must not end before every target has a password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,9 @@ CCU_DEFAULT_PROFILE=
 # Per-profile vars follow the pattern CCU_<PROFILE>_<SETTING> (profile name
 # upper-cased, non-alphanumerics → "_"). Each profile supports the same settings
 # as the flat ones: HOST (required), PASSWORD (may be empty — OpenCCU dev boxes
-# default to it), USER, PORT, HTTPS, TIMEOUT, SCRIPT_TIMEOUT, TLS_FINGERPRINT,
+# default to it — but keep the key: an absent one reads as "not entered yet"
+# and holds a --stdio --env server in setup mode), USER, PORT, HTTPS,
+# TIMEOUT, SCRIPT_TIMEOUT, TLS_FINGERPRINT,
 # CA_CERT, TLS_VERIFY, plus two policy flags:
 #   CCU_<NAME>_PROTECTED=true  → write tools refuse unless called with confirm:true
 #   CCU_<NAME>_READONLY=true   → write tools are refused outright

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
+- **Fixed: the guided setup could leave setup mode before a password existed.**
+  A named target reads an absent `CCU_<NAME>_PASSWORD` as empty (the #69
+  contract), so `setup_write_profile` writing a host was enough for the next
+  start to load "successfully": the setup_* tools disappeared mid-flow and
+  every real call failed with `AUTH 501`, with nothing left in the
+  conversation to explain it. The setup-mode gate now asks whether the
+  configuration is *finished*, not merely loadable — a named target with no
+  password key at all keeps the server in setup mode, and the instructions
+  name the target plus the exact `ccu-mcp secret <name>` run that completes
+  it. What a configuration *means* is unchanged: `loadConfig` still reads an
+  absent key as empty, so an OpenCCU dev target configured that way keeps
+  working, and the check applies only where setup mode is reachable at all
+  (`--stdio --env`). To declare an empty password deliberate, write the key
+  with no value (`CCU_<NAME>_PASSWORD=`) — the same distinction the flat form
+  has drawn since the previous entry.
+
 - **Fixed: `get_system_info` reported a failed login as a working connection.**
   Its four ADMIN-only probes (`CCU.getVersion` and friends) treated *every*
   failure as "not permitted", so wrong credentials or an unreachable CCU came

--- a/README.md
+++ b/README.md
@@ -334,12 +334,12 @@ Several CCUs work here too — say so ("*I have a prod and a dev CCU*") and the
 assistant repeats probe → write → secret per target: `setup_write_profile`
 takes a `name` (plus `protected`, `readonly` and `makeDefault`) and upserts
 that one target, preserving the others and their already-stored passwords.
-Each target needs its own `ccu-mcp secret <name>` run. One caveat while the
-conversation is still in progress: as soon as a **named** target has a host,
-the configuration loads, so the next restart leaves setup mode even if no
-password has been stored yet (an absent `CCU_<NAME>_PASSWORD` reads as empty).
-Finish with `setup_test` — it reports the failing login — rather than
-reconnecting early.
+Each target needs its own `ccu-mcp secret <name>` run, and the server stays in
+setup mode until every configured target has one: reconnecting halfway through
+lands you back in setup mode, naming the target still missing a password and
+the exact `secret` command that finishes it. A CCU that genuinely has no
+password is not a missing one — write the key with an empty value
+(`CCU_<NAME>_PASSWORD=`) to say so deliberately.
 
 Setup mode is stdio-only (an unconfigured HTTP endpoint that writes config
 files would be an unacceptable surface), and a bare start without `--env`
@@ -590,7 +590,8 @@ server's instructions) instead of exiting, so it can be fixed conversationally:
 | Message | Cause and why it's fatal |
 |---|---|
 | `CCU_HOST environment variable is required` | No CCU configured (and no `CCU_PROFILES`). |
-| `CCU_PASSWORD environment variable is required` | The variable is **absent**. An empty value is accepted — a fresh OpenCCU box has no Admin password — so this means "not set yet", which is what keeps a single-CCU setup-mode server in setup mode until `ccu-mcp secret` stores one. Named profiles are deliberately laxer: an absent `CCU_<NAME>_PASSWORD` reads as empty and the server starts, so on that path a missing password surfaces as a failed login (`setup_test` / `doctor` report it) rather than as this error. |
+| `CCU_PASSWORD environment variable is required` | The variable is **absent**. An empty value is accepted — a fresh OpenCCU box has no Admin password — so this means "not set yet", which is what keeps a single-CCU setup-mode server in setup mode until `ccu-mcp secret` stores one. |
+| `no password stored yet for target <name>` | The profile-form equivalent, and setup-mode only: `CCU_<NAME>_PASSWORD` is absent. A *loaded* configuration still reads an absent key as empty (unchanged, so an OpenCCU dev target keeps working) — but for deciding whether setup is finished, absent means "not entered yet", so the server stays in setup mode and prints the `ccu-mcp secret <name>` run that completes it. Write `CCU_<NAME>_PASSWORD=` to declare an empty password deliberate. |
 | `CCU_DEFAULT_PROFILE is set but CCU_PROFILES is not` | A leftover from a profile setup. Ignoring it would point writes at the flat `CCU_HOST` box while the env file suggests a named target. |
 | `CCU_PROFILES is set but lists no profile names` | Empty or comma-only value. |
 | `CCU_PROFILES lists "<name>" more than once` | Duplicate profile name. |

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,6 +95,30 @@ export function envPrefix(name: string): string {
   return name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
 }
 
+/**
+ * Named targets that have no `CCU_<NAME>_PASSWORD` key at all — "not entered
+ * yet", as opposed to `CCU_<NAME>_PASSWORD=` which says "deliberately empty".
+ *
+ * Deliberately NOT enforced in `loadConfig`: a named profile has never
+ * required the key (issue #69), and an OpenCCU dev box configured that way
+ * must keep working. It is enforced only where the distinction decides
+ * something — the setup-mode gate in index.ts (issue #196, QA F-008). Without
+ * it, `setup_write_profile` writing a named target's host was enough for the
+ * next start to load "successfully" with an empty password, dropping the
+ * setup_* tools the flow still needs and failing every real call with
+ * AUTH 501. The flat form self-corrects because loadConfig requires
+ * CCU_PASSWORD to be present (issue #209); this gives the profile form the
+ * same behavior without changing what a configuration means.
+ */
+export function targetsAwaitingPassword(config: AppConfig): string[] {
+  // Flat form only ever has the one implicit target, and loadConfig already
+  // rejects a missing CCU_PASSWORD there.
+  if (!process.env.CCU_PROFILES?.trim()) return [];
+  return config.profiles
+    .filter((p) => process.env[`CCU_${envPrefix(p.name)}_PASSWORD`] === undefined)
+    .map((p) => p.name);
+}
+
 export function loadConfig(): AppConfig {
   // CLI flags override env vars for transport. Validate the env value: a typo
   // ("STDIO", "Stdio") must fail loudly, not silently select HTTP and leave a

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { randomUUID } from "node:crypto";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { loadConfig } from "./config.js";
+import { loadConfig, targetsAwaitingPassword, envPrefix } from "./config.js";
 import { createLogger } from "./logger.js";
 import { RateLimiter } from "./middleware/rate-limiter.js";
 import { TargetRegistry, TargetSelection } from "./ccu/target-registry.js";
@@ -149,9 +149,32 @@ async function main(): Promise<void> {
   }
 
   const logger = createLogger();
+  // Setup mode is only reachable from a stdio start that named an env file;
+  // computing it here keeps the extra completeness check below from turning a
+  // tolerated configuration into a fatal error on any other start path.
+  const setupEligible = envPath !== undefined && argv.includes("--stdio");
   let config: ReturnType<typeof loadConfig>;
   try {
     config = loadConfig();
+    // A loadable configuration is not necessarily a finished one. A named
+    // target whose password key was never written (QA F-008) loads with an
+    // empty password, so the server would leave setup mode mid-flow and then
+    // fail every call with AUTH 501 — with the setup_* tools gone, the model
+    // has no way to finish or explain it. Treat it as not-yet-configured, and
+    // say exactly which command completes it.
+    if (setupEligible) {
+      const pending = targetsAwaitingPassword(config);
+      if (pending.length > 0) {
+        const { selfCommand } = await import("./cli/common.js");
+        const runs = pending.map((n) => selfCommand("secret", n, "--env", envPath!)).join("  |  ");
+        throw new Error(
+          `no password stored yet for target${pending.length > 1 ? "s" : ""} ` +
+          `${pending.join(", ")} — run: ${runs}  ` +
+          `(a CCU that genuinely has no password needs the key present but empty: ` +
+          `CCU_${envPrefix(pending[0]!)}_PASSWORD=)`,
+        );
+      }
+    }
   } catch (err) {
     // Setup mode (issue #196): started for stdio with an explicit --env file
     // but no loadable configuration, serve only the setup_* tools so an LLM

--- a/test/e2e/setup-mode.test.ts
+++ b/test/e2e/setup-mode.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { mkdtempSync, rmSync, readFileSync, statSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { DIST, distMissing } from "./_dist.js";
@@ -181,6 +181,44 @@ describe.skipIf(distMissing)("setup mode e2e (built server)", () => {
     expect(await endChild(child)).toBe(0);
     child = undefined;
   }, 90_000);
+
+  // QA F-008: a named target loads with an empty password when its key was
+  // never written (the #69 contract), so writing just the host used to be
+  // enough to leave setup mode — full tool set, every call AUTH 501, and no
+  // setup_* tools left to explain it or finish the job.
+  it("stays in setup mode when a named target has no password key yet", async () => {
+    const pendingEnv = join(dir, "pending.env");
+    writeFileSync(pendingEnv, `CCU_PROFILES=prod\nCCU_PROD_HOST=127.0.0.1\nCCU_PROD_PORT=${ccu.port}\n`);
+
+    const s = spawnServer(pendingEnv);
+    child = s.child;
+    const init = await initialize(s.client);
+    expect(init.result?.instructions).toContain("setup mode");
+    // The message must name the target and the exact command that finishes it.
+    expect(init.result?.instructions).toContain("no password stored yet for target prod");
+    expect(init.result?.instructions).toContain("secret prod");
+    const tools = await s.client.request("tools/list");
+    const names = (tools.result?.tools ?? []).map((t: { name: string }) => t.name).sort();
+    expect(names).toEqual(["setup_probe", "setup_status", "setup_test", "setup_write_profile"]);
+    expect(await endChild(child)).toBe(0);
+    child = undefined;
+  }, 60_000);
+
+  // The other half of the rule: an empty password the user MEANT (key present,
+  // no value) is a finished configuration — the #69 OpenCCU dev-box case.
+  it("starts configured when the password key is present but empty", async () => {
+    const emptyPwEnv = join(dir, "emptypw.env");
+    writeFileSync(emptyPwEnv, `CCU_PROFILES=prod\nCCU_PROD_HOST=127.0.0.1\nCCU_PROD_PORT=${ccu.port}\nCCU_PROD_PASSWORD=\n`);
+
+    const s = spawnServer(emptyPwEnv);
+    child = s.child;
+    const init = await initialize(s.client);
+    expect(init.result?.instructions ?? "").not.toContain("setup mode");
+    const tools = await s.client.request("tools/list");
+    expect((tools.result?.tools ?? []).length).toBeGreaterThan(20);
+    expect(await endChild(child)).toBe(0);
+    child = undefined;
+  }, 60_000);
 
   it("never enters setup mode without --stdio: HTTP with a broken config still dies", () => {
     const res = spawnSync("node", [DIST, "--http", "--env", join(dir, "does-not-exist.env")], {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { loadConfig } from "../../src/config.js";
+import { loadConfig, targetsAwaitingPassword } from "../../src/config.js";
 
 describe("loadConfig", () => {
   const originalEnv = { ...process.env };
@@ -484,5 +484,47 @@ describe("loadConfig", () => {
       process.env.CCU_PROD_READONLY = "true";
       expect(loadConfig().profiles[0]!.readonly).toBe(true);
     });
+  });
+});
+
+describe("targetsAwaitingPassword", () => {
+  // The setup gate's rule (QA F-008). Deliberately separate from loadConfig,
+  // which still accepts an absent named-profile password as empty (issue #69).
+  const originalEnv = { ...process.env };
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("CCU_")) delete process.env[key];
+    }
+  });
+  afterEach(() => { process.env = { ...originalEnv }; });
+
+  it("names targets whose password key is absent", () => {
+    process.env.CCU_PROFILES = "prod,dev";
+    process.env.CCU_PROD_HOST = "debmatic";
+    process.env.CCU_PROD_PASSWORD = "pw";
+    process.env.CCU_DEV_HOST = "127.0.0.1";
+    expect(targetsAwaitingPassword(loadConfig())).toEqual(["dev"]);
+  });
+
+  it("treats a present-but-empty key as deliberately empty", () => {
+    process.env.CCU_PROFILES = "dev";
+    process.env.CCU_DEV_HOST = "127.0.0.1";
+    process.env.CCU_DEV_PASSWORD = "";
+    expect(targetsAwaitingPassword(loadConfig())).toEqual([]);
+  });
+
+  it("never reports anything for the flat form, where loadConfig already requires the key", () => {
+    process.env.CCU_HOST = "debmatic";
+    process.env.CCU_PASSWORD = "";
+    expect(targetsAwaitingPassword(loadConfig())).toEqual([]);
+  });
+
+  it("does not change what loadConfig accepts — an absent key still loads as empty", () => {
+    process.env.CCU_PROFILES = "dev";
+    process.env.CCU_DEV_HOST = "127.0.0.1";
+    const config = loadConfig();
+    expect(config.profiles[0]!.ccu.password).toBe("");
+    expect(targetsAwaitingPassword(config)).toEqual(["dev"]);
   });
 });


### PR DESCRIPTION
Fixes QA finding **F-008** (Low) — the last one open. Cheap, as asked: the rule was already in the codebase, just applied to only one of the two config forms.

## The bug

A named profile reads an absent `CCU_<NAME>_PASSWORD` as empty — a deliberate concession from #69, since an OpenCCU dev box has no password. The setup-mode gate inherited that meaning by accident: it entered setup mode **only when `loadConfig` threw**, so `setup_write_profile` writing a named target's host was enough to make the next start "configured". Reconnect before running `ccu-mcp secret` and you get the full tool set, every call failing `AUTH 501`, and no `setup_*` tools left to explain it or finish the job.

The flat form self-corrects, because `loadConfig` requires `CCU_PASSWORD` to be *present* (#209). The two forms simply disagreed on what an absent key means.

## The fix

Separate two questions that one call was answering:

| Question | Answered by | Behaviour |
| --- | --- | --- |
| Is this configuration **valid**? | `loadConfig` | **unchanged** — absent named-profile password still reads as empty, #69 contract intact |
| Is it **finished**? | `targetsAwaitingPassword()` (new) | absent key = "not entered yet"; present-but-empty = "deliberately empty" — the same distinction the flat form has drawn since #209 |

`index.ts` consults the second **only when setup mode is reachable at all** (`--stdio` with `--env`), so no other start path can turn a configuration it used to tolerate into a fatal error. HTTP starts, bare stdio starts and normal configured starts are byte-for-byte unaffected.

The message names the pending target and the exact run that completes it, built with `selfCommand` so it points at *this* build (#210):

```
no password stored yet for target prod — run: node /path/to/ccu-mcp secret prod --env /path/.env
(a CCU that genuinely has no password needs the key present but empty: CCU_PROD_PASSWORD=)
```

**Rejected** the marker-file alternative the finding suggested (a wizard-written key the `secret` CLI clears): it adds persistent state to the env file, when the presence rule already carries the meaning — the file just had two dialects of it.

## Tests

4 unit (absent key, present-but-empty, flat form, and `loadConfig`'s tolerance explicitly pinned as unchanged) and 2 e2e against the built server: F-008's exact reproduction now stays in setup mode with the naming message, and an empty-but-present key still starts fully configured.

README's caveat paragraph — which documented this bug as expected behaviour — and the error table are updated, plus a note in `.env.example`.

`npm run lint` clean; `npm test` 597 passed / 29 skipped; coverage ratchet passes.