### PR TITLE
chore(release): v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,113 +3,163 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
-## Unreleased
+## v1.11.0 — 2026-09-02
 
-- **Fixed: the guided setup could leave setup mode before a password existed.**
-  A named target reads an absent `CCU_<NAME>_PASSWORD` as empty (the #69
-  contract), so `setup_write_profile` writing a host was enough for the next
-  start to load "successfully": the setup_* tools disappeared mid-flow and
-  every real call failed with `AUTH 501`, with nothing left in the
-  conversation to explain it. The setup-mode gate now asks whether the
-  configuration is *finished*, not merely loadable — a named target with no
-  password key at all keeps the server in setup mode, and the instructions
-  name the target plus the exact `ccu-mcp secret <name>` run that completes
-  it. What a configuration *means* is unchanged: `loadConfig` still reads an
-  absent key as empty, so an OpenCCU dev target configured that way keeps
-  working, and the check applies only where setup mode is reachable at all
-  (`--stdio --env`). To declare an empty password deliberate, write the key
-  with no value (`CCU_<NAME>_PASSWORD=`) — the same distinction the flat form
-  has drawn since the previous entry.
+Setting the thing up.
+Until now, configuring ccu-mcp meant hand-writing an env file —
+`CCU_PROD_TLS_FINGERPRINT`-style variables included — and finding out at
+runtime whether the host was right, whether the certificate was the one you
+meant to trust, whether the credentials worked, and whether the user had enough
+privileges for the tools you wanted. This release adds two ways to do it
+instead: a CLI wizard (`ccu-mcp init` / `ccu-mcp doctor`) for anyone at a shell
+or over SSH, and a conversational flow (setup mode and the `setup_*` tools) for
+clients where an LLM can drive it. Both run the same probe → pin → test-login →
+write core, and neither ever puts the CCU password through the model: that step
+is always the local `ccu-mcp secret` prompt, with echo off.
 
-- **Fixed: `get_system_info` reported a failed login as a working connection.**
-  Its four ADMIN-only probes (`CCU.getVersion` and friends) treated *every*
-  failure as "not permitted", so wrong credentials or an unreachable CCU came
-  back as `version/serial/address: "N/A"`, `role: "UNKNOWN"` and **no error** —
-  while the very next read failed with `AUTH 501`. That is the tool an agent
-  reaches for to answer "did my setup work?", and it answered yes. A probe that
-  fails while the session is still valid is still a privilege denial and still
-  degrades to `"N/A"` with the USER-level note; a probe that fails with no
-  session now fails the call with the real error (`AUTH`, `UNREACHABLE`,
-  `TLS_ERROR`). `"N/A"` now means exactly one thing: connected, not permitted.
+**Nothing existing needs to change.** No new required environment variables, no
+changed tool arguments, and a server started the way you start it today behaves
+the way it does today. One tool result did change shape in a failure case, and
+it is the first entry under Behavior changes below.
 
-- **Documented multi-target setup end to end.** The README claimed
-  `ccu-mcp init` walks "one or more" targets and left it there; it now shows a
-  worked two-CCU session — wizard transcript, the profile-form env file it
-  writes, one `ccu-mcp secret <name>` run per target, a `doctor` sweep over
-  both, and the single unchanged MCP client entry that serves them. Three
-  statements that did not match the code were corrected: `--env` is accepted by
-  `secret` too (not just `init`/`doctor`); the "absent password keeps the
-  server in setup mode" rule holds for the flat single-CCU form only, since an
-  absent `CCU_<NAME>_PASSWORD` reads as empty and starts the server; and the
-  quick start now mentions that `CACHE_DIR` defaults to the Docker path
-  `/data`, which is unwritable outside a container.
-- **`ccu-mcp secret` on a profile file lists one runnable line per target**
-  instead of a `secret '<profile>'` placeholder — the placeholder's angle
-  brackets were shell-quoted, and each target needs its own run anyway.
+### Added
 
-- **Fixed: the guided setup printed commands for the wrong binary.**
-  `setup_write_profile` told the user to run `npx ccu-mcp secret …`, and
-  `secret`/`init` signed off with bare `ccu-mcp doctor …`. `npx` resolves to
-  whatever it finds in cwd or the global prefix, which for anyone with an
-  older global install is a *different* build than the one giving the advice
-  — and `secret`, `init` and `doctor` all postdate the latest published tag,
-  so that build had no such subcommand. Worse, it did not say so: an unknown
-  first argument fell through to normal server startup, and the flow died on
-  `CCU_HOST environment variable is required` — a complaint about a variable
-  the user had just configured correctly, from a file that binary never read.
-  Every printed command now invokes the running build (`process.argv[1]`),
-  falling back to a version-pinned `npx ccu-mcp@<version>`. The MCP client
-  snippet from `init` deliberately keeps plain `npx ccu-mcp`, since that entry
-  is durable and argv[1] may point into npx's collectable cache.
-- **An unknown subcommand now fails loudly** — `ccu-mcp frobnicate` exits 2
-  with `unknown command "frobnicate" (ccu-mcp X.Y.Z)` instead of starting a
-  server. The version is the point: it identifies which install a printed
+- **`ccu-mcp init` — an interactive setup wizard.** It probes the CCU, detecting
+  the port and whether HTTPS is in use; shows the certificate the box actually
+  presents and pins its SHA-256 fingerprint on confirmation; tests the login;
+  reports whether the configured user is ADMIN- or USER-level (script-based
+  tools need ADMIN, and being told that at setup time beats discovering it from
+  a failing tool call); and writes a mode-0600 env file — flat variables for a
+  single CCU, `CCU_PROFILES` for several. It ends with a ready-to-paste MCP
+  client snippet and needs no pre-existing configuration.
+
+  Re-running it on an existing file preserves every line it does not manage
+  (`LOG_LEVEL`, `CACHE_DIR`, `MCP_*`) and asks before replacing the CCU
+  settings.
+- **`ccu-mcp doctor` — validation without starting the server.** Configuration
+  errors, reachability, pinned-fingerprint match, login, privilege level, per
+  target. It exits non-zero when a check fails, so it also works in scripts;
+  run interactively, it offers to refresh the pin after a certificate rotation
+  you recognise, which is the one case where "the fingerprint changed" is not
+  an incident.
+- **`ccu-mcp secret [profile]` — the password path.** A local hidden prompt that
+  writes exactly one password key into an env file (mode 0600). It is how the
+  guided flow gets a secret without the secret passing through a conversation,
+  and it is the rotation path afterwards. It refuses a profile name against a
+  flat single-CCU file, and an unknown name against a profile file, so it
+  cannot write the wrong key.
+- **`--env <path>` for the server.** Loads a dotenv file before configuration,
+  so an MCP client entry can point at the file `init` wrote instead of inlining
+  credentials in client JSON:
+
+  ```sh
+  npx ccu-mcp --stdio --env /path/to/.env
+  ```
+
+  Already-set environment variables win, matching node's `--env-file`
+  precedence. It is deliberately not called `--env-file`: node's own CLI
+  intercepts that flag even after the script path and refuses to start when the
+  file does not exist — which is exactly the state a guided setup begins in.
+- **Setup mode — the server comes up unconfigured instead of exiting.** Started
+  with `--stdio --env <path>` and a missing or invalid configuration, it now
+  serves a minimal MCP server exposing only `setup_status`, `setup_probe`,
+  `setup_write_profile` and `setup_test`, plus instructions that carry the whole
+  flow. The point is that the client entry never changes: register the server
+  before it is configured, let the conversation walk through probing the CCU,
+  pinning the certificate and writing the file, and reconnect — the identical
+  entry then starts it fully configured.
+
+  `setup_write_profile` has no password parameter, by construction. It prints
+  the `ccu-mcp secret` command for the user to run in a terminal, and the
+  instructions tell the model to refuse the password if it is offered anyway.
+  Several CCUs work the same way: the tool takes a `name` and upserts one
+  target, preserving the others and their stored passwords.
+
+  Setup mode is stdio-only — an unconfigured, unauthenticated HTTP endpoint
+  that writes configuration files is not an acceptable surface — and a start
+  without `--env` still fails loudly rather than silently serving setup tools.
+
+### Behavior changes (read before upgrading)
+
+- **`get_system_info` now reports a failed connection as an error.** Its four
+  ADMIN-only probes treated every failure as "logged in, not permitted", so
+  wrong credentials came back as `version`/`serial`/`address` of `"N/A"`,
+  `role: "UNKNOWN"` and no error at all — while the very next read failed with
+  `AUTH 501`. This is the tool an agent reaches for to answer "did my setup
+  work?", and it answered yes. A probe that fails while the session is valid is
+  still a privilege denial and still degrades to `"N/A"` with the USER-level
+  note; a probe that fails with no session now fails the call with the real
+  error (`AUTH`, `UNREACHABLE`, `TLS_ERROR`). `"N/A"` now means one thing:
+  connected, not permitted.
+- **An empty `CCU_PASSWORD` is accepted.** A fresh OpenCCU box has no Admin
+  password, and `ccu-mcp secret` will store an empty one while saying that is
+  normal — but the flat loader then rejected it and the server would not start.
+  The rule is presence, not non-emptiness: the variable must be set, its value
+  may be empty. An absent variable is still an error, and that is what
+  distinguishes "not entered yet" from "chosen to be empty". Named profiles
+  already allowed empty and are unchanged.
+- **An unknown subcommand exits 2** with `unknown command "frobnicate"
+  (ccu-mcp X.Y.Z)` instead of falling through to a normal server start. The
+  version in the message is the point: it identifies which install a printed
   command actually reached.
 
-- **Fixed: an empty `CCU_PASSWORD` is now accepted.** A fresh OpenCCU box has
-  no Admin password, and `ccu-mcp secret` stores an empty one while telling the
-  user that is normal — but the flat single-CCU loader then rejected it with
-  `CCU_PASSWORD environment variable is required` and the server would not
-  start. The rule is now presence, not non-emptiness: the variable must be
-  set, its value may be empty. An absent key is still an error, and is what
-  distinguishes "not entered yet" from "chosen to be empty". Named profiles
-  (`CCU_<NAME>_PASSWORD`) already allowed empty and are unchanged.
-  Correspondingly, `setup_write_profile` no longer writes a `PASSWORD=""`
-  placeholder for a new target — it leaves the key out, so a setup-mode server
-  stays in setup mode until `ccu-mcp secret` has run.
-- **`ccu-mcp init`** — interactive setup wizard (#195): probes the CCU
-  (auto-detecting HTTPS/port), shows the TLS certificate and pins its SHA-256
-  fingerprint on confirmation, tests the login, reports the detected privilege
-  level (USER-level accounts get a warning that script-based tools need
-  ADMIN), and writes a mode-0600 env file — flat vars for one target,
-  `CCU_PROFILES` for several. Ends with a ready-to-paste MCP client snippet.
-  Re-running preserves every non-CCU line of an existing file and asks before
-  replacing the CCU settings.
-- **`ccu-mcp doctor`** — validates an env file end-to-end without starting the
-  server: configuration errors, reachability, pinned-fingerprint match
-  (interactive runs are offered a refresh after a legitimate certificate
-  rotation), login, privilege level. Exits non-zero when a check fails.
-- **`--env <path>`** server flag — loads a dotenv file before configuration,
-  so an MCP client entry can reference the file `init` wrote instead of
-  inlining credentials (`npx ccu-mcp --stdio --env /path/to/.env`).
-  Already-set environment variables win, matching node's `--env-file`
-  precedence. (Named `--env` because node's own CLI intercepts an
-  `--env-file` argument even after the script path and refuses to start when
-  the file does not exist yet — exactly the state `init` begins in.)
-- **LLM-guided setup (setup mode)** (#196): started with `--stdio --env
-  <path>` and a missing/invalid configuration, the server no longer exits —
-  it comes up as a minimal MCP server exposing only `setup_status`,
-  `setup_probe`, `setup_write_profile` and `setup_test`, so it can be
-  registered in an MCP client *before* it is configured and the LLM walks the
-  user through the same probe → pin → test-login → write flow in chat. The
-  password never travels through the model or the transcript:
-  `setup_write_profile` has no password parameter and hands off to the new
-  **`ccu-mcp secret [profile]`** subcommand, a local hidden prompt that
-  writes only the password key into the env file (mode 0600; also the
-  password-rotation path). After `setup_test` passes, reconnecting the server
-  with the identical client entry starts it fully configured. Setup mode is
-  stdio-only; a bare start without `--env` still fails loudly, and the HTTP
-  transport never enters it.
+### Fixed
+
+- **Printed commands now invoke the build that printed them.** The guided setup
+  told users to run `npx ccu-mcp secret …`, and `secret`/`init` signed off with
+  a bare `ccu-mcp doctor …`. `npx` resolves to whatever it finds in the working
+  directory or the global prefix — for anyone with an older global install, a
+  *different* build, and one with no such subcommand. It did not say so either:
+  an unknown first argument fell through to server startup and the flow died on
+  `CCU_HOST environment variable is required`, complaining about a variable the
+  user had just configured correctly, from a file that binary never read. Every
+  printed command now uses `process.argv[1]`, falling back to a version-pinned
+  `npx ccu-mcp@<version>`. The client snippet from `init` deliberately keeps
+  plain `npx ccu-mcp`, since that entry is durable and argv[1] may point into
+  npx's collectable cache.
+- **Setup mode no longer ends before every target has a password.** A named
+  profile reads an absent `CCU_<NAME>_PASSWORD` as empty, so writing a target's
+  host was enough for the next start to load "successfully": the `setup_*` tools
+  disappeared mid-flow and every real call failed with `AUTH 501`, with nothing
+  left in the conversation to explain it. The gate now asks whether the
+  configuration is *finished*, not merely loadable, and names the target plus
+  the exact `ccu-mcp secret` run that finishes it. What a loaded configuration
+  means is unchanged — an absent key still reads as empty, so a passwordless
+  dev target keeps working; write `CCU_<NAME>_PASSWORD=` to declare an empty
+  password deliberate.
+- **`ccu-mcp secret` on a profile file lists one runnable line per target**
+  instead of a `secret '<profile>'` placeholder — the angle brackets were
+  shell-quoted, and each target needs its own run anyway.
+- **Documentation that did not match the code.** `--env` was described as
+  accepted by `init`/`doctor`; `secret` takes it too. The error table said an
+  absent password is what keeps a setup-mode server in setup mode, which held
+  for the flat form only. The quick start omitted that `CACHE_DIR` defaults to
+  the Docker path `/data`, so an npx user gets `cache_save_failed: EACCES` and
+  never persists the device-type cache or the session. The profiles section now
+  also carries a worked two-CCU session: wizard transcript, the file it writes,
+  one `secret` run per target, a `doctor` sweep over both, and the single client
+  entry that serves them.
+
+### Dependencies
+
+- **Six advisories cleared in transitive dependencies** of
+  `@modelcontextprotocol/sdk`, which is already at its latest release — so the
+  fix is a lockfile re-resolve inside the parents' existing ranges.
+  `fast-uri` 3.1.5 → 3.1.7 closes four high advisories (host confusion via
+  percent-encoded scheme normalization and via skipped IDN canonicalization;
+  SSRF via malformed IPv6 normalization and via repeated hostname
+  percent-decoding); `qs` 6.15.2 → 6.16.0 closes two moderate ones (array-limit
+  bypass via bracket-key comma parsing, and denial of service via an
+  attacker-controlled `isBuffer`).
+- `zod` 4.4.3 → 4.5.1, plus development and CI action bumps.
+
+### Internal
+
+- **OpenSSF Scorecard runs on a schedule** and reports into code scanning.
+- The Docker base image is pinned **by digest as well as tag**, so a rebuild
+  cannot silently pick up a different base.
+- Dependabot auto-merge degrades gracefully when GitHub refuses a workflow-file
+  bump, instead of failing the run.
 
 ## v1.10.0 — 2026-08-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.10.0",
+  "version": "1.11.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -31,7 +31,7 @@
         },
         {
           "name": "CCU_PASSWORD",
-          "description": "CCU admin password (same as the WebUI login)",
+          "description": "CCU admin password (same as the WebUI login). Must be set; the value may be empty for a CCU with no password",
           "isRequired": true,
           "isSecret": true,
           "format": "string"


### PR DESCRIPTION
Version bump and release notes for **v1.11.0**. No functional change.

- `npm version minor --no-git-tag-version` — `package.json`, `package-lock.json` and both `server.json` version spots (the `version` lifecycle hook runs `scripts/sync-server-version.mjs`).
- `CHANGELOG.md` gains the `## v1.11.0 — 2026-09-02` section, which is also the GitHub Release body.
- `server.json`: `CCU_PASSWORD`'s description now states the rule the loader has followed since the empty-password fix — the variable must be set, its value may be empty.

Pre-flight, per `docs/release-runbook.md`:

| Check | Result |
| --- | --- |
| `npm run check:versions` | in sync |
| `npm publish --dry-run` | 160 files, `dist/` + README + LICENSE, nothing stray |
| `mcp-publisher validate` | `✅ server.json is valid` |
| `npm run lint` | clean |
| `npm test` | 597 passed / 29 skipped |

Documentation review against the v1.11.0 milestone: all 12 issues (#195–#207) are the `init`/`doctor` wizard and the LLM-guided setup, both documented in the README's *Command-line flags*, *LLM-guided setup* and *Setting up several targets* sections. No new environment variables, so the README config table, `docker-compose.yml` and `server.json` need no additions.