### PR TITLE
Release v1.11.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,9 @@
 # Hostname or IP of your CCU — set this to your own box (e.g. a hostname like
 # homematic-ccu3 or an IP like 192.168.1.50). Required; there is no default.
 CCU_HOST=your-ccu-hostname-or-ip
-# CCU admin password.
+# CCU admin password. The variable must be present; an empty value is a valid
+# password for a box that has none (a fresh OpenCCU), so it is accepted as-is —
+# fill it in, or `ccu-mcp secret` will prompt for it without echoing.
 CCU_PASSWORD=
 
 # ─── CCU connection (optional) ──────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,9 @@ CCU_DEFAULT_PROFILE=
 # Per-profile vars follow the pattern CCU_<PROFILE>_<SETTING> (profile name
 # upper-cased, non-alphanumerics → "_"). Each profile supports the same settings
 # as the flat ones: HOST (required), PASSWORD (may be empty — OpenCCU dev boxes
-# default to it), USER, PORT, HTTPS, TIMEOUT, SCRIPT_TIMEOUT, TLS_FINGERPRINT,
+# default to it — but keep the key: an absent one reads as "not entered yet"
+# and holds a --stdio --env server in setup mode), USER, PORT, HTTPS,
+# TIMEOUT, SCRIPT_TIMEOUT, TLS_FINGERPRINT,
 # CA_CERT, TLS_VERIFY, plus two policy flags:
 #   CCU_<NAME>_PROTECTED=true  → write tools refuse unless called with confirm:true
 #   CCU_<NAME>_READONLY=true   → write tools are refused outright

--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -47,6 +47,10 @@ src 96.3 94.8
 src/auth 96.8 94.0
 src/cache 99.2 97.7
 src/ccu 91.6 87.1
+# src/cli (init-wizard PR): seeded at measured (89.7/77.3). Interactive CLI
+# code; the uncovered remainder is TTY-only paths (raw-mode echo suppression,
+# SIGINT) that a piped test harness cannot reach.
+src/cli 89.7 77.3
 src/health 100.0 100.0
 src/http 100.0 100.0
 # src/middleware 99.2/92.2 -> 99.2/95.2 (prototype-key PR): branches RAISED,

--- a/.github/coverage-baseline.txt
+++ b/.github/coverage-baseline.txt
@@ -50,7 +50,9 @@ src/ccu 91.6 87.1
 # src/cli (init-wizard PR): seeded at measured (89.7/77.3). Interactive CLI
 # code; the uncovered remainder is TTY-only paths (raw-mode echo suppression,
 # SIGINT) that a piped test harness cannot reach.
-src/cli 89.7 77.3
+# branches 77.3 -> 78.3 (llm-setup PR): RAISED, earned by
+# test/unit/cli-secret.test.ts covering secret.ts's flat/profile/error arms.
+src/cli 89.7 78.3
 src/health 100.0 100.0
 src/http 100.0 100.0
 # src/middleware 99.2/92.2 -> 99.2/95.2 (prototype-key PR): branches RAISED,

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -83,6 +83,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -83,6 +83,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: ${{ matrix.language }}
           # No compiled languages here, so there is nothing to build: analysing

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           # No compiled languages here, so there is nothing to build: analysing

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,6 +9,29 @@ name: Dependabot auto-merge
 # the base-repo context so the token can enable auto-merge; we never check out
 # or execute the PR's code, so the untrusted-code risk of that trigger does not
 # apply here.
+#
+# Workflow-file bumps are the one case this cannot finish. GITHUB_TOKEN is a
+# GitHub App token, and an App may not create or update anything under
+# `.github/workflows/` — there is no `workflows:` key in the `permissions:`
+# block to grant, so no amount of configuration lifts it. GitHub then refuses
+# the arm with:
+#
+#   GraphQL: Pull request refusing to allow a GitHub App to create or update
+#   workflow `.github/workflows/<f>.yml` without `workflows` permission
+#   (enablePullRequestAutoMerge)
+#
+# It is not raised consistently: #185 and #186 both bumped codeql-action in the
+# same file, both were up to date with dev, and only #186 was refused. So the
+# job attempts the arm unconditionally and only degrades when GitHub actually
+# says no — skipping every workflow-touching PR up front would give up merges
+# that do succeed.
+#
+# Degrading means: comment on the PR, exit green. A maintainer merges it by
+# hand once checks pass. That is the right end state anyway — an action bump
+# rewrites a pinned SHA, which is exactly the change worth a human glance — and
+# it keeps the alternative (a long-lived PAT or App key with Workflows: write,
+# stored as a repo secret) out of a repo whose whole posture is "no credential
+# we don't need". Any other failure still fails the job.
 
 on:
   pull_request_target:
@@ -25,7 +48,44 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MARKER: '<!-- ccu-mcp:auto-merge-workflow-scope -->'
+        run: |
+          # `set +e` around the arm: the step shell is `bash -e`, which would
+          # exit on the failure before the output could be inspected.
+          set +e
+          out=$(gh pr merge --auto --squash "$PR_URL" 2>&1)
+          status=$?
+          set -e
+          printf '%s\n' "$out"
+
+          if [ "$status" -eq 0 ]; then
+            exit 0
+          fi
+
+          if ! printf '%s' "$out" | grep -qiE 'workflows.? permission'; then
+            exit "$status"
+          fi
+
+          echo "::notice::Auto-merge could not be armed: GITHUB_TOKEN may not update workflow files. Merge this PR by hand once its checks are green."
+
+          # One comment per PR, however often the job re-runs.
+          if gh pr view "$PR_URL" --json comments --jq '.comments[].body' \
+             | grep -qF "$MARKER"; then
+            echo "Already commented on this PR."
+            exit 0
+          fi
+
+          gh pr comment "$PR_URL" --body-file - <<EOF
+          $MARKER
+          Auto-merge could not be armed for this PR: it updates a file under
+          \`.github/workflows/\`, and GITHUB_TOKEN is an App token, which GitHub
+          forbids from creating or updating workflow files. There is no
+          \`permissions:\` key that grants this, so the job cannot do it itself.
+
+          **Merge this by hand once the checks are green.** Worth a look first:
+          an action bump rewrites a pinned SHA, so confirm the new one is the
+          tag it claims to be.
+          EOF

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -37,15 +37,24 @@ on:
   pull_request_target:
     branches: [dev]
 
+# Read-only at the top, writes granted to the one job that needs them. The
+# effective token is identical either way — but Scorecard's Token-Permissions
+# check scores `contents: write` at *top* level as 0 for the whole repo
+# (checks/evaluation/permissions.go applies its -10 `reduceBy` only to
+# top-level findings; a job-level write is logged and not deducted, as long as
+# the top level is declared and not itself write). This one line was the
+# repo's entire Token-Permissions score.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write        # merge the PR
+      pull-requests: write   # arm auto-merge, post the fallback comment
     steps:
       - name: Enable auto-merge
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -388,7 +388,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -510,7 +510,7 @@ jobs:
           pattern: digest-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,72 @@
+name: Scorecard
+
+# OpenSSF Scorecard, scheduled. Non-hermetic by nature — the score moves with
+# upstream check definitions and with repo settings, neither of which is a
+# function of the commit under test. So it belongs here and not in
+# `build-and-test`, and it must never become a required check, for the same
+# reason `npm audit` was taken out of CI in v1.8.1: a verdict that changes with
+# no diff cannot gate a merge.
+#
+# Runs on the default branch (`dev`) — `publish_results` requires that, and it
+# is what makes the score public and feeds the badge.
+#
+# No `repo_token`: Scorecard runs on the workflow's own GITHUB_TOKEN, which is
+# upstream's recommended default. The one thing that costs us is
+# Branch-Protection fidelity. GITHUB_TOKEN cannot read *classic* branch
+# protection (that needs an admin token), and the non-admin fallback upstream
+# provides reads Repository *Rules*, which this repo does not use. So that
+# single check scores on thin evidence: it can see that `main` is protected,
+# not that six status checks are required. Closing that gap means either a
+# fine-grained PAT with `Administration: Read-only` as secret SCORECARD_TOKEN —
+# a long-lived credential that expires yearly — or moving `main` to rulesets.
+# Deliberately deferred; see ROADMAP.md.
+
+on:
+  schedule:
+    # Mondays, 04:31 UTC. Off the hour: scheduled runs cluster there and GitHub
+    # drops them under load.
+    - cron: '31 4 * * 1'
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # Upload the SARIF to code scanning, alongside CodeQL's own results.
+      security-events: write
+      # OIDC token, which is how the published result is proven authentic.
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Keep the raw SARIF for 5 days: code scanning shows the findings but not
+      # the per-check scores, and a scheduled job has no other artifact.
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -67,6 +67,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
+- **Documented multi-target setup end to end.** The README claimed
+  `ccu-mcp init` walks "one or more" targets and left it there; it now shows a
+  worked two-CCU session — wizard transcript, the profile-form env file it
+  writes, one `ccu-mcp secret <name>` run per target, a `doctor` sweep over
+  both, and the single unchanged MCP client entry that serves them. Three
+  statements that did not match the code were corrected: `--env` is accepted by
+  `secret` too (not just `init`/`doctor`); the "absent password keeps the
+  server in setup mode" rule holds for the flat single-CCU form only, since an
+  absent `CCU_<NAME>_PASSWORD` reads as empty and starts the server; and the
+  quick start now mentions that `CACHE_DIR` defaults to the Docker path
+  `/data`, which is unwritable outside a container.
+- **`ccu-mcp secret` on a profile file lists one runnable line per target**
+  instead of a `secret '<profile>'` placeholder — the placeholder's angle
+  brackets were shell-quoted, and each target needs its own run anyway.
+
 - **Fixed: the guided setup printed commands for the wrong binary.**
   `setup_write_profile` told the user to run `npx ccu-mcp secret …`, and
   `secret`/`init` signed off with bare `ccu-mcp doctor …`. `npx` resolves to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,113 +3,163 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
-## Unreleased
+## v1.11.0 — 2026-09-02
 
-- **Fixed: the guided setup could leave setup mode before a password existed.**
-  A named target reads an absent `CCU_<NAME>_PASSWORD` as empty (the #69
-  contract), so `setup_write_profile` writing a host was enough for the next
-  start to load "successfully": the setup_* tools disappeared mid-flow and
-  every real call failed with `AUTH 501`, with nothing left in the
-  conversation to explain it. The setup-mode gate now asks whether the
-  configuration is *finished*, not merely loadable — a named target with no
-  password key at all keeps the server in setup mode, and the instructions
-  name the target plus the exact `ccu-mcp secret <name>` run that completes
-  it. What a configuration *means* is unchanged: `loadConfig` still reads an
-  absent key as empty, so an OpenCCU dev target configured that way keeps
-  working, and the check applies only where setup mode is reachable at all
-  (`--stdio --env`). To declare an empty password deliberate, write the key
-  with no value (`CCU_<NAME>_PASSWORD=`) — the same distinction the flat form
-  has drawn since the previous entry.
+Setting the thing up.
+Until now, configuring ccu-mcp meant hand-writing an env file —
+`CCU_PROD_TLS_FINGERPRINT`-style variables included — and finding out at
+runtime whether the host was right, whether the certificate was the one you
+meant to trust, whether the credentials worked, and whether the user had enough
+privileges for the tools you wanted. This release adds two ways to do it
+instead: a CLI wizard (`ccu-mcp init` / `ccu-mcp doctor`) for anyone at a shell
+or over SSH, and a conversational flow (setup mode and the `setup_*` tools) for
+clients where an LLM can drive it. Both run the same probe → pin → test-login →
+write core, and neither ever puts the CCU password through the model: that step
+is always the local `ccu-mcp secret` prompt, with echo off.
 
-- **Fixed: `get_system_info` reported a failed login as a working connection.**
-  Its four ADMIN-only probes (`CCU.getVersion` and friends) treated *every*
-  failure as "not permitted", so wrong credentials or an unreachable CCU came
-  back as `version/serial/address: "N/A"`, `role: "UNKNOWN"` and **no error** —
-  while the very next read failed with `AUTH 501`. That is the tool an agent
-  reaches for to answer "did my setup work?", and it answered yes. A probe that
-  fails while the session is still valid is still a privilege denial and still
-  degrades to `"N/A"` with the USER-level note; a probe that fails with no
-  session now fails the call with the real error (`AUTH`, `UNREACHABLE`,
-  `TLS_ERROR`). `"N/A"` now means exactly one thing: connected, not permitted.
+**Nothing existing needs to change.** No new required environment variables, no
+changed tool arguments, and a server started the way you start it today behaves
+the way it does today. One tool result did change shape in a failure case, and
+it is the first entry under Behavior changes below.
 
-- **Documented multi-target setup end to end.** The README claimed
-  `ccu-mcp init` walks "one or more" targets and left it there; it now shows a
-  worked two-CCU session — wizard transcript, the profile-form env file it
-  writes, one `ccu-mcp secret <name>` run per target, a `doctor` sweep over
-  both, and the single unchanged MCP client entry that serves them. Three
-  statements that did not match the code were corrected: `--env` is accepted by
-  `secret` too (not just `init`/`doctor`); the "absent password keeps the
-  server in setup mode" rule holds for the flat single-CCU form only, since an
-  absent `CCU_<NAME>_PASSWORD` reads as empty and starts the server; and the
-  quick start now mentions that `CACHE_DIR` defaults to the Docker path
-  `/data`, which is unwritable outside a container.
-- **`ccu-mcp secret` on a profile file lists one runnable line per target**
-  instead of a `secret '<profile>'` placeholder — the placeholder's angle
-  brackets were shell-quoted, and each target needs its own run anyway.
+### Added
 
-- **Fixed: the guided setup printed commands for the wrong binary.**
-  `setup_write_profile` told the user to run `npx ccu-mcp secret …`, and
-  `secret`/`init` signed off with bare `ccu-mcp doctor …`. `npx` resolves to
-  whatever it finds in cwd or the global prefix, which for anyone with an
-  older global install is a *different* build than the one giving the advice
-  — and `secret`, `init` and `doctor` all postdate the latest published tag,
-  so that build had no such subcommand. Worse, it did not say so: an unknown
-  first argument fell through to normal server startup, and the flow died on
-  `CCU_HOST environment variable is required` — a complaint about a variable
-  the user had just configured correctly, from a file that binary never read.
-  Every printed command now invokes the running build (`process.argv[1]`),
-  falling back to a version-pinned `npx ccu-mcp@<version>`. The MCP client
-  snippet from `init` deliberately keeps plain `npx ccu-mcp`, since that entry
-  is durable and argv[1] may point into npx's collectable cache.
-- **An unknown subcommand now fails loudly** — `ccu-mcp frobnicate` exits 2
-  with `unknown command "frobnicate" (ccu-mcp X.Y.Z)` instead of starting a
-  server. The version is the point: it identifies which install a printed
+- **`ccu-mcp init` — an interactive setup wizard.** It probes the CCU, detecting
+  the port and whether HTTPS is in use; shows the certificate the box actually
+  presents and pins its SHA-256 fingerprint on confirmation; tests the login;
+  reports whether the configured user is ADMIN- or USER-level (script-based
+  tools need ADMIN, and being told that at setup time beats discovering it from
+  a failing tool call); and writes a mode-0600 env file — flat variables for a
+  single CCU, `CCU_PROFILES` for several. It ends with a ready-to-paste MCP
+  client snippet and needs no pre-existing configuration.
+
+  Re-running it on an existing file preserves every line it does not manage
+  (`LOG_LEVEL`, `CACHE_DIR`, `MCP_*`) and asks before replacing the CCU
+  settings.
+- **`ccu-mcp doctor` — validation without starting the server.** Configuration
+  errors, reachability, pinned-fingerprint match, login, privilege level, per
+  target. It exits non-zero when a check fails, so it also works in scripts;
+  run interactively, it offers to refresh the pin after a certificate rotation
+  you recognise, which is the one case where "the fingerprint changed" is not
+  an incident.
+- **`ccu-mcp secret [profile]` — the password path.** A local hidden prompt that
+  writes exactly one password key into an env file (mode 0600). It is how the
+  guided flow gets a secret without the secret passing through a conversation,
+  and it is the rotation path afterwards. It refuses a profile name against a
+  flat single-CCU file, and an unknown name against a profile file, so it
+  cannot write the wrong key.
+- **`--env <path>` for the server.** Loads a dotenv file before configuration,
+  so an MCP client entry can point at the file `init` wrote instead of inlining
+  credentials in client JSON:
+
+  ```sh
+  npx ccu-mcp --stdio --env /path/to/.env
+  ```
+
+  Already-set environment variables win, matching node's `--env-file`
+  precedence. It is deliberately not called `--env-file`: node's own CLI
+  intercepts that flag even after the script path and refuses to start when the
+  file does not exist — which is exactly the state a guided setup begins in.
+- **Setup mode — the server comes up unconfigured instead of exiting.** Started
+  with `--stdio --env <path>` and a missing or invalid configuration, it now
+  serves a minimal MCP server exposing only `setup_status`, `setup_probe`,
+  `setup_write_profile` and `setup_test`, plus instructions that carry the whole
+  flow. The point is that the client entry never changes: register the server
+  before it is configured, let the conversation walk through probing the CCU,
+  pinning the certificate and writing the file, and reconnect — the identical
+  entry then starts it fully configured.
+
+  `setup_write_profile` has no password parameter, by construction. It prints
+  the `ccu-mcp secret` command for the user to run in a terminal, and the
+  instructions tell the model to refuse the password if it is offered anyway.
+  Several CCUs work the same way: the tool takes a `name` and upserts one
+  target, preserving the others and their stored passwords.
+
+  Setup mode is stdio-only — an unconfigured, unauthenticated HTTP endpoint
+  that writes configuration files is not an acceptable surface — and a start
+  without `--env` still fails loudly rather than silently serving setup tools.
+
+### Behavior changes (read before upgrading)
+
+- **`get_system_info` now reports a failed connection as an error.** Its four
+  ADMIN-only probes treated every failure as "logged in, not permitted", so
+  wrong credentials came back as `version`/`serial`/`address` of `"N/A"`,
+  `role: "UNKNOWN"` and no error at all — while the very next read failed with
+  `AUTH 501`. This is the tool an agent reaches for to answer "did my setup
+  work?", and it answered yes. A probe that fails while the session is valid is
+  still a privilege denial and still degrades to `"N/A"` with the USER-level
+  note; a probe that fails with no session now fails the call with the real
+  error (`AUTH`, `UNREACHABLE`, `TLS_ERROR`). `"N/A"` now means one thing:
+  connected, not permitted.
+- **An empty `CCU_PASSWORD` is accepted.** A fresh OpenCCU box has no Admin
+  password, and `ccu-mcp secret` will store an empty one while saying that is
+  normal — but the flat loader then rejected it and the server would not start.
+  The rule is presence, not non-emptiness: the variable must be set, its value
+  may be empty. An absent variable is still an error, and that is what
+  distinguishes "not entered yet" from "chosen to be empty". Named profiles
+  already allowed empty and are unchanged.
+- **An unknown subcommand exits 2** with `unknown command "frobnicate"
+  (ccu-mcp X.Y.Z)` instead of falling through to a normal server start. The
+  version in the message is the point: it identifies which install a printed
   command actually reached.
 
-- **Fixed: an empty `CCU_PASSWORD` is now accepted.** A fresh OpenCCU box has
-  no Admin password, and `ccu-mcp secret` stores an empty one while telling the
-  user that is normal — but the flat single-CCU loader then rejected it with
-  `CCU_PASSWORD environment variable is required` and the server would not
-  start. The rule is now presence, not non-emptiness: the variable must be
-  set, its value may be empty. An absent key is still an error, and is what
-  distinguishes "not entered yet" from "chosen to be empty". Named profiles
-  (`CCU_<NAME>_PASSWORD`) already allowed empty and are unchanged.
-  Correspondingly, `setup_write_profile` no longer writes a `PASSWORD=""`
-  placeholder for a new target — it leaves the key out, so a setup-mode server
-  stays in setup mode until `ccu-mcp secret` has run.
-- **`ccu-mcp init`** — interactive setup wizard (#195): probes the CCU
-  (auto-detecting HTTPS/port), shows the TLS certificate and pins its SHA-256
-  fingerprint on confirmation, tests the login, reports the detected privilege
-  level (USER-level accounts get a warning that script-based tools need
-  ADMIN), and writes a mode-0600 env file — flat vars for one target,
-  `CCU_PROFILES` for several. Ends with a ready-to-paste MCP client snippet.
-  Re-running preserves every non-CCU line of an existing file and asks before
-  replacing the CCU settings.
-- **`ccu-mcp doctor`** — validates an env file end-to-end without starting the
-  server: configuration errors, reachability, pinned-fingerprint match
-  (interactive runs are offered a refresh after a legitimate certificate
-  rotation), login, privilege level. Exits non-zero when a check fails.
-- **`--env <path>`** server flag — loads a dotenv file before configuration,
-  so an MCP client entry can reference the file `init` wrote instead of
-  inlining credentials (`npx ccu-mcp --stdio --env /path/to/.env`).
-  Already-set environment variables win, matching node's `--env-file`
-  precedence. (Named `--env` because node's own CLI intercepts an
-  `--env-file` argument even after the script path and refuses to start when
-  the file does not exist yet — exactly the state `init` begins in.)
-- **LLM-guided setup (setup mode)** (#196): started with `--stdio --env
-  <path>` and a missing/invalid configuration, the server no longer exits —
-  it comes up as a minimal MCP server exposing only `setup_status`,
-  `setup_probe`, `setup_write_profile` and `setup_test`, so it can be
-  registered in an MCP client *before* it is configured and the LLM walks the
-  user through the same probe → pin → test-login → write flow in chat. The
-  password never travels through the model or the transcript:
-  `setup_write_profile` has no password parameter and hands off to the new
-  **`ccu-mcp secret [profile]`** subcommand, a local hidden prompt that
-  writes only the password key into the env file (mode 0600; also the
-  password-rotation path). After `setup_test` passes, reconnecting the server
-  with the identical client entry starts it fully configured. Setup mode is
-  stdio-only; a bare start without `--env` still fails loudly, and the HTTP
-  transport never enters it.
+### Fixed
+
+- **Printed commands now invoke the build that printed them.** The guided setup
+  told users to run `npx ccu-mcp secret …`, and `secret`/`init` signed off with
+  a bare `ccu-mcp doctor …`. `npx` resolves to whatever it finds in the working
+  directory or the global prefix — for anyone with an older global install, a
+  *different* build, and one with no such subcommand. It did not say so either:
+  an unknown first argument fell through to server startup and the flow died on
+  `CCU_HOST environment variable is required`, complaining about a variable the
+  user had just configured correctly, from a file that binary never read. Every
+  printed command now uses `process.argv[1]`, falling back to a version-pinned
+  `npx ccu-mcp@<version>`. The client snippet from `init` deliberately keeps
+  plain `npx ccu-mcp`, since that entry is durable and argv[1] may point into
+  npx's collectable cache.
+- **Setup mode no longer ends before every target has a password.** A named
+  profile reads an absent `CCU_<NAME>_PASSWORD` as empty, so writing a target's
+  host was enough for the next start to load "successfully": the `setup_*` tools
+  disappeared mid-flow and every real call failed with `AUTH 501`, with nothing
+  left in the conversation to explain it. The gate now asks whether the
+  configuration is *finished*, not merely loadable, and names the target plus
+  the exact `ccu-mcp secret` run that finishes it. What a loaded configuration
+  means is unchanged — an absent key still reads as empty, so a passwordless
+  dev target keeps working; write `CCU_<NAME>_PASSWORD=` to declare an empty
+  password deliberate.
+- **`ccu-mcp secret` on a profile file lists one runnable line per target**
+  instead of a `secret '<profile>'` placeholder — the angle brackets were
+  shell-quoted, and each target needs its own run anyway.
+- **Documentation that did not match the code.** `--env` was described as
+  accepted by `init`/`doctor`; `secret` takes it too. The error table said an
+  absent password is what keeps a setup-mode server in setup mode, which held
+  for the flat form only. The quick start omitted that `CACHE_DIR` defaults to
+  the Docker path `/data`, so an npx user gets `cache_save_failed: EACCES` and
+  never persists the device-type cache or the session. The profiles section now
+  also carries a worked two-CCU session: wizard transcript, the file it writes,
+  one `secret` run per target, a `doctor` sweep over both, and the single client
+  entry that serves them.
+
+### Dependencies
+
+- **Six advisories cleared in transitive dependencies** of
+  `@modelcontextprotocol/sdk`, which is already at its latest release — so the
+  fix is a lockfile re-resolve inside the parents' existing ranges.
+  `fast-uri` 3.1.5 → 3.1.7 closes four high advisories (host confusion via
+  percent-encoded scheme normalization and via skipped IDN canonicalization;
+  SSRF via malformed IPv6 normalization and via repeated hostname
+  percent-decoding); `qs` 6.15.2 → 6.16.0 closes two moderate ones (array-limit
+  bypass via bracket-key comma parsing, and denial of service via an
+  attacker-controlled `isBuffer`).
+- `zod` 4.4.3 → 4.5.1, plus development and CI action bumps.
+
+### Internal
+
+- **OpenSSF Scorecard runs on a schedule** and reports into code scanning.
+- The Docker base image is pinned **by digest as well as tag**, so a rebuild
+  cannot silently pick up a different base.
+- Dependabot auto-merge degrades gracefully when GitHub refuses a workflow-file
+  bump, instead of failing the run.
 
 ## v1.10.0 — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
+- **Fixed: an empty `CCU_PASSWORD` is now accepted.** A fresh OpenCCU box has
+  no Admin password, and `ccu-mcp secret` stores an empty one while telling the
+  user that is normal — but the flat single-CCU loader then rejected it with
+  `CCU_PASSWORD environment variable is required` and the server would not
+  start. The rule is now presence, not non-emptiness: the variable must be
+  set, its value may be empty. An absent key is still an error, and is what
+  distinguishes "not entered yet" from "chosen to be empty". Named profiles
+  (`CCU_<NAME>_PASSWORD`) already allowed empty and are unchanged.
+  Correspondingly, `setup_write_profile` no longer writes a `PASSWORD=""`
+  placeholder for a new target — it leaves the key out, so a setup-mode server
+  stays in setup mode until `ccu-mcp secret` has run.
 - **`ccu-mcp init`** — interactive setup wizard (#195): probes the CCU
   (auto-detecting HTTPS/port), shows the TLS certificate and pins its SHA-256
   fingerprint on confirmation, tests the login, reports the detected privilege

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to ccu-mcp are documented here. Each release is a tag
 `vX.Y.Z` on `main`.
 
+## Unreleased
+
+- **`ccu-mcp init`** — interactive setup wizard (#195): probes the CCU
+  (auto-detecting HTTPS/port), shows the TLS certificate and pins its SHA-256
+  fingerprint on confirmation, tests the login, reports the detected privilege
+  level (USER-level accounts get a warning that script-based tools need
+  ADMIN), and writes a mode-0600 env file — flat vars for one target,
+  `CCU_PROFILES` for several. Ends with a ready-to-paste MCP client snippet.
+  Re-running preserves every non-CCU line of an existing file and asks before
+  replacing the CCU settings.
+- **`ccu-mcp doctor`** — validates an env file end-to-end without starting the
+  server: configuration errors, reachability, pinned-fingerprint match
+  (interactive runs are offered a refresh after a legitimate certificate
+  rotation), login, privilege level. Exits non-zero when a check fails.
+- **`--env <path>`** server flag — loads a dotenv file before configuration,
+  so an MCP client entry can reference the file `init` wrote instead of
+  inlining credentials (`npx ccu-mcp --stdio --env /path/to/.env`).
+  Already-set environment variables win, matching node's `--env-file`
+  precedence. (Named `--env` because node's own CLI intercepts an
+  `--env-file` argument even after the script path and refuses to start when
+  the file does not exist yet — exactly the state `init` begins in.)
+
 ## v1.10.0 — 2026-08-19
 
 Container images, a release that publishes itself, and a pass over the MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
+- **Fixed: the guided setup printed commands for the wrong binary.**
+  `setup_write_profile` told the user to run `npx ccu-mcp secret …`, and
+  `secret`/`init` signed off with bare `ccu-mcp doctor …`. `npx` resolves to
+  whatever it finds in cwd or the global prefix, which for anyone with an
+  older global install is a *different* build than the one giving the advice
+  — and `secret`, `init` and `doctor` all postdate the latest published tag,
+  so that build had no such subcommand. Worse, it did not say so: an unknown
+  first argument fell through to normal server startup, and the flow died on
+  `CCU_HOST environment variable is required` — a complaint about a variable
+  the user had just configured correctly, from a file that binary never read.
+  Every printed command now invokes the running build (`process.argv[1]`),
+  falling back to a version-pinned `npx ccu-mcp@<version>`. The MCP client
+  snippet from `init` deliberately keeps plain `npx ccu-mcp`, since that entry
+  is durable and argv[1] may point into npx's collectable cache.
+- **An unknown subcommand now fails loudly** — `ccu-mcp frobnicate` exits 2
+  with `unknown command "frobnicate" (ccu-mcp X.Y.Z)` instead of starting a
+  server. The version is the point: it identifies which install a printed
+  command actually reached.
+
 - **Fixed: an empty `CCU_PASSWORD` is now accepted.** A fresh OpenCCU box has
   no Admin password, and `ccu-mcp secret` stores an empty one while telling the
   user that is normal — but the flat single-CCU loader then rejected it with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
   precedence. (Named `--env` because node's own CLI intercepts an
   `--env-file` argument even after the script path and refuses to start when
   the file does not exist yet — exactly the state `init` begins in.)
+- **LLM-guided setup (setup mode)** (#196): started with `--stdio --env
+  <path>` and a missing/invalid configuration, the server no longer exits —
+  it comes up as a minimal MCP server exposing only `setup_status`,
+  `setup_probe`, `setup_write_profile` and `setup_test`, so it can be
+  registered in an MCP client *before* it is configured and the LLM walks the
+  user through the same probe → pin → test-login → write flow in chat. The
+  password never travels through the model or the transcript:
+  `setup_write_profile` has no password parameter and hands off to the new
+  **`ccu-mcp secret [profile]`** subcommand, a local hidden prompt that
+  writes only the password key into the env file (mode 0600; also the
+  password-rotation path). After `setup_test` passes, reconnecting the server
+  with the identical client entry starts it fully configured. Setup mode is
+  stdio-only; a bare start without `--env` still fails loudly, and the HTTP
+  transport never enters it.
 
 ## v1.10.0 — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
+- **Fixed: `get_system_info` reported a failed login as a working connection.**
+  Its four ADMIN-only probes (`CCU.getVersion` and friends) treated *every*
+  failure as "not permitted", so wrong credentials or an unreachable CCU came
+  back as `version/serial/address: "N/A"`, `role: "UNKNOWN"` and **no error** —
+  while the very next read failed with `AUTH 501`. That is the tool an agent
+  reaches for to answer "did my setup work?", and it answered yes. A probe that
+  fails while the session is still valid is still a privilege denial and still
+  degrades to `"N/A"` with the USER-level note; a probe that fails with no
+  session now fails the call with the real error (`AUTH`, `UNREACHABLE`,
+  `TLS_ERROR`). `"N/A"` now means exactly one thing: connected, not permitted.
+
 - **Documented multi-target setup end to end.** The README claimed
   `ccu-mcp init` walks "one or more" targets and left it there; it now shows a
   worked two-CCU session — wizard transcript, the profile-form env file it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to ccu-mcp are documented here. Each release is a tag
 
 ## Unreleased
 
+- **Fixed: the guided setup could leave setup mode before a password existed.**
+  A named target reads an absent `CCU_<NAME>_PASSWORD` as empty (the #69
+  contract), so `setup_write_profile` writing a host was enough for the next
+  start to load "successfully": the setup_* tools disappeared mid-flow and
+  every real call failed with `AUTH 501`, with nothing left in the
+  conversation to explain it. The setup-mode gate now asks whether the
+  configuration is *finished*, not merely loadable — a named target with no
+  password key at all keeps the server in setup mode, and the instructions
+  name the target plus the exact `ccu-mcp secret <name>` run that completes
+  it. What a configuration *means* is unchanged: `loadConfig` still reads an
+  absent key as empty, so an OpenCCU dev target configured that way keeps
+  working, and the check applies only where setup mode is reachable at all
+  (`--stdio --env`). To declare an empty password deliberate, write the key
+  with no value (`CCU_<NAME>_PASSWORD=`) — the same distinction the flat form
+  has drawn since the previous entry.
+
 - **Fixed: `get_system_info` reported a failed login as a working connection.**
   Its four ADMIN-only probes (`CCU.getVersion` and friends) treated *every*
   failure as "not permitted", so wrong credentials or an unreachable CCU came

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,14 @@
 # 2026). It is also the only major the test suite ever executes on, so a base
 # image ahead of it would ship users a configuration nothing here has run.
 # scripts/check-node-version.mjs fails the build if these four drift apart.
-FROM node:24-alpine AS builder
+#
+# Pinned by digest as well as tag, the same contract the SHA-pinned actions get:
+# `node:24-alpine` is a moving target, so without this a rebuild of an old
+# commit is not the image that commit produced. The digest is the OCI *index*,
+# not a per-arch manifest, so the multi-arch build in publish.yml still resolves
+# linux/amd64 and linux/arm64 from it. Dependabot bumps digest and tag together
+# (majors are held back — see .github/dependabot.yml), so the pin will not rot.
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -23,7 +30,7 @@ ENV BUILD_COMMIT=${BUILD_COMMIT} \
     BUILD_TAG=${BUILD_TAG}
 RUN npm run build
 
-FROM node:24-alpine
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43
 # `image.source` is not decoration: GHCR links a package to a repository by this
 # label, and that link is what carries the README, the licence and the "published
 # by" provenance on the package page. Without it the image floats unattached.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # not a per-arch manifest, so the multi-arch build in publish.yml still resolves
 # linux/amd64 and linux/arm64 from it. Dependabot bumps digest and tag together
 # (majors are held back — see .github/dependabot.yml), so the pin will not rot.
-FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS builder
+FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -30,7 +30,7 @@ ENV BUILD_COMMIT=${BUILD_COMMIT} \
     BUILD_TAG=${BUILD_TAG}
 RUN npm run build
 
-FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43
+FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf
 # `image.source` is not decoration: GHCR links a package to a repository by this
 # label, and that link is what carries the README, the licence and the "published
 # by" provenance on the package page. Without it the image floats unattached.

--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ ccu-mcp init           # interactive setup: probe the CCU, pin its TLS cert,
                        #   test the login, write an env file (default ./.env)
 ccu-mcp doctor         # validate an env file end-to-end: reachability,
                        #   certificate pin, login, privilege level
+ccu-mcp secret [prof]  # store the CCU password into an env file via a local
+                       #   hidden prompt (used by the LLM-guided setup below;
+                       #   also the password-rotation path)
 ccu-mcp --stdio        # serve over stdin/stdout (overrides MCP_TRANSPORT)
 ccu-mcp --http         # serve over HTTP (default)
 ccu-mcp --env <path>   # load configuration from a dotenv file (already-set
@@ -282,6 +285,38 @@ tools need ADMIN), and ends with a ready-to-paste MCP client snippet. It
 needs no pre-existing configuration. `ccu-mcp doctor` exits non-zero when any
 check fails, so it also works in scripts; run it interactively to be offered
 a pin refresh when the CCU's certificate legitimately rotated.
+
+### LLM-guided setup (setup mode)
+
+The wizard has a conversational twin: register the server in an MCP client
+**before** configuring it. Started with `--stdio --env <path>` and a missing or
+incomplete configuration, the server comes up in **setup mode** — a minimal MCP
+server exposing only four `setup_*` tools (`setup_status`, `setup_probe`,
+`setup_write_profile`, `setup_test`) plus instructions that let the LLM walk
+you through the same probe → pin → test-login → write flow in plain chat.
+
+```json
+{
+  "mcpServers": {
+    "ccu-mcp": {
+      "command": "npx",
+      "args": ["ccu-mcp", "--stdio", "--env", "/path/to/.env"]
+    }
+  }
+}
+```
+
+Then just ask: *"set up my CCU connection"*. One deliberate exception: **the
+password never travels through the model or the chat transcript**.
+`setup_write_profile` has no password parameter; instead the assistant hands
+you a one-liner to run in a terminal — `ccu-mcp secret <profile> --env
+/path/to/.env` — which prompts locally with echo off and writes only the
+password into the file (mode 0600). Once `setup_test` reports green, reconnect
+the MCP server and the identical client entry starts it fully configured.
+
+Setup mode is stdio-only (an unconfigured HTTP endpoint that writes config
+files would be an unacceptable surface), and a bare start without `--env`
+still fails loudly instead of silently serving setup tools.
 
 `--version` and `--help` need no configuration — use them to check what an
 installed copy actually is, e.g. after updating:
@@ -372,7 +407,10 @@ without switching.
 Some mistakes stop the server at startup instead of being ignored. Each of these
 would otherwise fail *silently* and much later, so the exit is deliberate.
 `ccu-mcp doctor` reports the same errors against an env file without starting
-the server, alongside its live checks (reachability, certificate pin, login):
+the server, alongside its live checks (reachability, certificate pin, login).
+One exception: started with `--stdio --env <path>`, a failing configuration
+enters [setup mode](#llm-guided-setup-setup-mode) (with the error in the
+server's instructions) instead of exiting, so it can be fixed conversationally:
 
 | Message | Cause and why it's fatal |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ npx ccu-mcp --stdio
 
 If it prints `server_ready` to stderr, it's working. Press Ctrl+C to stop. Now set it up in your MCP client — see below.
 
+Prefer a guided setup? `npx ccu-mcp init` probes your CCU, pins its TLS
+certificate, tests the login, writes a ready-to-use `.env` file, and prints the
+matching MCP client config — see [Command-line flags](#command-line-flags).
+
 ## Installation
 
 There are two ways to run this: **stdio** (the server runs as a subprocess of your MCP client) or **HTTP** (the server runs standalone in Docker and clients connect over the network). Pick one.
@@ -213,6 +217,11 @@ The server accepts self-signed certificates automatically — certificate verifi
 
 `CCU_TLS_FINGERPRINT` takes precedence over `CCU_CA_CERT`, which takes precedence over `CCU_TLS_VERIFY`.
 
+`ccu-mcp init` does the pinning for you: it shows the certificate the CCU
+presents and writes the fingerprint into the env file on confirmation, and
+`ccu-mcp doctor` re-checks the pin later (offering a refresh after a
+legitimate certificate rotation).
+
 ## Configuration
 
 All configuration is via environment variables:
@@ -254,11 +263,25 @@ below.
 ### Command-line flags
 
 ```sh
+ccu-mcp init           # interactive setup: probe the CCU, pin its TLS cert,
+                       #   test the login, write an env file (default ./.env)
+ccu-mcp doctor         # validate an env file end-to-end: reachability,
+                       #   certificate pin, login, privilege level
 ccu-mcp --stdio        # serve over stdin/stdout (overrides MCP_TRANSPORT)
 ccu-mcp --http         # serve over HTTP (default)
+ccu-mcp --env <path>   # load configuration from a dotenv file (already-set
+                       #   environment variables win); also accepted by
+                       #   init/doctor to pick the file they write/check
 ccu-mcp --version      # print the installed version and exit
 ccu-mcp --help         # print usage and exit
 ```
+
+`ccu-mcp init` walks through one or more CCU targets ([profiles](#multiple-ccu-targets-profiles)),
+detects whether the configured user is ADMIN- or USER-level (script-based
+tools need ADMIN), and ends with a ready-to-paste MCP client snippet. It
+needs no pre-existing configuration. `ccu-mcp doctor` exits non-zero when any
+check fails, so it also works in scripts; run it interactively to be offered
+a pin refresh when the CCU's certificate legitimately rotated.
 
 `--version` and `--help` need no configuration — use them to check what an
 installed copy actually is, e.g. after updating:
@@ -280,19 +303,24 @@ variables**. Provide them in whichever of these you prefer — you need just one
 - **Inline in `.mcp.json`** — the `env` block shown in [Option A](#option-a-stdio-direct-simplest)
   above. Simplest; self-contained.
 - **Shell `export`** — as in [Quick start](#quick-start) above.
-- **A `.env` file** — keeps secrets out of `.mcp.json`. The server does not read
-  `.env` on its own, so load it with Node's built-in flag (Node ≥ 20.6):
+- **A `.env` file** — keeps secrets out of `.mcp.json`. Pass it with the
+  server's own `--env` flag (this is also what `ccu-mcp init` writes and the
+  snippet it prints):
 
   ```json
   {
     "mcpServers": {
       "ccu-mcp": {
-        "command": "node",
-        "args": ["--env-file=/path/to/.env", "/path/to/ccu-mcp/dist/index.js", "--stdio"]
+        "command": "npx",
+        "args": ["ccu-mcp", "--stdio", "--env", "/path/to/.env"]
       }
     }
   }
   ```
+
+  (Node's own `--env-file=` flag before the script path works too, but node
+  refuses to start when that file doesn't exist yet, and it needs the full
+  path to `dist/index.js`.)
 
   Copy [`.env.example`](.env.example) to `.env` and fill it in (it documents every
   variable). Docker users can pass the same file with `docker run --env-file .env`
@@ -342,7 +370,9 @@ without switching.
 ### Configuration errors
 
 Some mistakes stop the server at startup instead of being ignored. Each of these
-would otherwise fail *silently* and much later, so the exit is deliberate:
+would otherwise fail *silently* and much later, so the exit is deliberate.
+`ccu-mcp doctor` reports the same errors against an env file without starting
+the server, alongside its live checks (reachability, certificate pin, login):
 
 | Message | Cause and why it's fatal |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ npx ccu-mcp --stdio
 
 If it prints `server_ready` to stderr, it's working. Press Ctrl+C to stop. Now set it up in your MCP client — see below.
 
+A `cache_save_failed … mkdir '/data'` line alongside it is harmless here but
+worth fixing for real use: `CACHE_DIR` defaults to `/data` (the Docker layout),
+so outside a container the device-type cache and the CCU session are never
+persisted between runs. Point it somewhere writable:
+`export CACHE_DIR="$HOME/.cache/ccu-mcp"` (or the same key in your `.env` /
+`env` block).
+
 Prefer a guided setup? `npx ccu-mcp init` probes your CCU, pins its TLS
 certificate, tests the login, writes a ready-to-use `.env` file, and prints the
 matching MCP client config — see [Command-line flags](#command-line-flags).
@@ -267,24 +274,30 @@ ccu-mcp init           # interactive setup: probe the CCU, pin its TLS cert,
                        #   test the login, write an env file (default ./.env)
 ccu-mcp doctor         # validate an env file end-to-end: reachability,
                        #   certificate pin, login, privilege level
-ccu-mcp secret [prof]  # store the CCU password into an env file via a local
-                       #   hidden prompt (used by the LLM-guided setup below;
-                       #   also the password-rotation path)
+ccu-mcp secret [prof]  # store ONE CCU password into an env file via a local
+                       #   hidden prompt — name the target when the file
+                       #   defines profiles, omit it for a single CCU (used by
+                       #   the LLM-guided setup below; also the rotation path)
 ccu-mcp --stdio        # serve over stdin/stdout (overrides MCP_TRANSPORT)
 ccu-mcp --http         # serve over HTTP (default)
 ccu-mcp --env <path>   # load configuration from a dotenv file (already-set
                        #   environment variables win); also accepted by
-                       #   init/doctor to pick the file they write/check
+                       #   init/doctor/secret to pick the file they
+                       #   write/check/update (default ./.env)
 ccu-mcp --version      # print the installed version and exit
 ccu-mcp --help         # print usage and exit
 ```
 
-`ccu-mcp init` walks through one or more CCU targets ([profiles](#multiple-ccu-targets-profiles)),
-detects whether the configured user is ADMIN- or USER-level (script-based
-tools need ADMIN), and ends with a ready-to-paste MCP client snippet. It
-needs no pre-existing configuration. `ccu-mcp doctor` exits non-zero when any
-check fails, so it also works in scripts; run it interactively to be offered
-a pin refresh when the CCU's certificate legitimately rotated.
+`ccu-mcp init` walks through one or more CCU targets ([profiles](#multiple-ccu-targets-profiles)) —
+it asks up front whether you want several, then loops over name, endpoint,
+certificate pin, credentials and the two policy flags per target and asks
+which one starts active. It detects whether each configured user is ADMIN- or
+USER-level (script-based tools need ADMIN), and ends with a ready-to-paste MCP
+client snippet. It needs no pre-existing configuration. `ccu-mcp doctor` exits
+non-zero when any check fails, so it also works in scripts; run it
+interactively to be offered a pin refresh when the CCU's certificate
+legitimately rotated. Worked example:
+[Setting up several targets](#setting-up-several-targets).
 
 ### LLM-guided setup (setup mode)
 
@@ -316,6 +329,17 @@ Copy the command the tool prints rather than this one: it names the build that
 printed it, so it cannot land on an older install that lacks the subcommand.
 Once `setup_test` reports green, reconnect the MCP server and the identical
 client entry starts it fully configured.
+
+Several CCUs work here too — say so ("*I have a prod and a dev CCU*") and the
+assistant repeats probe → write → secret per target: `setup_write_profile`
+takes a `name` (plus `protected`, `readonly` and `makeDefault`) and upserts
+that one target, preserving the others and their already-stored passwords.
+Each target needs its own `ccu-mcp secret <name>` run. One caveat while the
+conversation is still in progress: as soon as a **named** target has a host,
+the configuration loads, so the next restart leaves setup mode even if no
+password has been stored yet (an absent `CCU_<NAME>_PASSWORD` reads as empty).
+Finish with `setup_test` — it reports the failing login — rather than
+reconnecting early.
 
 Setup mode is stdio-only (an unconfigured HTTP endpoint that writes config
 files would be an unacceptable surface), and a bare start without `--env`
@@ -388,8 +412,10 @@ CCU_DEV_PASSWORD=                  # may be empty (e.g. an OpenCCU dev box)
 
 Each profile takes the same settings as the flat vars, prefixed
 `CCU_<NAME>_` (name upper-cased, non-alphanumerics → `_`): `HOST` (required),
-`PASSWORD` (may be empty), `USER`, `PORT`, `HTTPS`, `TIMEOUT`, `SCRIPT_TIMEOUT`,
-`TLS_FINGERPRINT`, `CA_CERT`, `TLS_VERIFY` — plus two policy flags:
+`PASSWORD` (may be empty — and, unlike the flat `CCU_PASSWORD`, may also be
+left out entirely, which reads as empty), `USER`, `PORT`, `HTTPS`, `TIMEOUT`,
+`SCRIPT_TIMEOUT`, `TLS_FINGERPRINT`, `CA_CERT`, `TLS_VERIFY` — plus two policy
+flags:
 
 - `CCU_<NAME>_PROTECTED=true` — write tools refuse unless called with
   `confirm: true`, which unlocks writes to that target for the rest of the session.
@@ -405,6 +431,152 @@ profile (unchanged behavior). At runtime, `list_ccu_targets` shows the targets,
 tools also accept an optional `target` to read from another CCU for a single call
 without switching.
 
+#### Setting up several targets
+
+**With the wizard.** `ccu-mcp init` asks up front, then loops over name →
+endpoint → certificate pin → credentials → policy flags per target, and ends
+by asking which one starts active:
+
+```console
+$ npx ccu-mcp init --env ~/.config/ccu-mcp/.env
+ccu-mcp setup — probes your CCU, pins its TLS certificate, tests the
+login, and writes the result to /home/you/.config/ccu-mcp/.env.
+
+Set up multiple CCU targets (e.g. prod/dev)? [y/N]: y
+Profile name [prod]: prod
+CCU hostname or IP: ccu.example
+Probing ccu.example ...
+  Found the CCU API on port 443 (HTTPS).
+Use HTTPS? [Y/n]: y
+Port [443]: 443
+The CCU presents this TLS certificate:
+  Subject: ccu.example
+  Issuer:  ccu.example
+  Valid:   Jun 19 21:37:09 2026 GMT — Jun 16 21:37:09 2036 GMT
+  SHA-256: 90:0C:4C:F2:53:22:E7:78:...:40:ED:16:95:6E:BB:B1:53
+Pin this certificate's fingerprint (recommended)? [Y/n]: y
+CCU user [Admin]: ai
+CCU password (input hidden):
+Testing login ...
+  Login OK (CCU 3.87.6.20260614) — privilege level ADMIN: all tools available.
+Protect this target (write tools then require confirm:true)? [y/N]: y
+Make this target read-only (write tools refused entirely)? [y/N]: n
+Add another CCU target? [y/N]: y
+Profile name: dev
+CCU hostname or IP: 192.168.1.50
+Probing 192.168.1.50 ...
+  Found the CCU API on port 80 (HTTP).
+Use HTTPS? [Y/n]: n
+Port [80]: 80
+CCU user [Admin]: Admin
+CCU password (input hidden):
+Testing login ...
+  Login OK (CCU 3.87.6.20260614) — privilege level ADMIN: all tools available.
+Protect this target (write tools then require confirm:true)? [y/N]: n
+Make this target read-only (write tools refused entirely)? [y/N]: n
+Add another CCU target? [y/N]: n
+Default target (prod/dev) [prod]: prod
+
+Wrote /home/you/.config/ccu-mcp/.env (mode 0600).
+```
+
+The file it writes is the profile form, one commented block per target — and
+the wizard rewrites only these keys, so anything else in the file (`LOG_LEVEL`,
+`CACHE_DIR`, `MCP_*`) survives:
+
+```sh
+# Written by ccu-mcp setup — https://github.com/claymore666/ccu-mcp#configuration
+CCU_PROFILES=prod,dev
+CCU_DEFAULT_PROFILE=prod
+
+# --- target: prod ---
+CCU_PROD_HOST=ccu.example
+CCU_PROD_PORT=443
+CCU_PROD_HTTPS=true
+CCU_PROD_USER=ai
+CCU_PROD_PASSWORD="..."
+CCU_PROD_TLS_FINGERPRINT=90:0C:4C:F2:53:22:E7:78:...:40:ED:16:95:6E:BB:B1:53
+CCU_PROD_PROTECTED=true
+
+# --- target: dev ---
+CCU_DEV_HOST=192.168.1.50
+CCU_DEV_PORT=80
+CCU_DEV_HTTPS=false
+CCU_DEV_USER=Admin
+CCU_DEV_PASSWORD=""
+```
+
+Rerunning `init` on an existing file offers to replace those settings; adding a
+third target means walking the whole list again, so for a one-off addition edit
+the file (or use `setup_write_profile`, which upserts a single target) and then
+run `doctor`.
+
+**One password per target.** `ccu-mcp secret` writes exactly one key, so it
+takes the target name — `init` prompts for passwords inline, but the
+[LLM-guided flow](#llm-guided-setup-setup-mode) and every later rotation go
+through `secret`. Called without a name on a profile file it lists the runs you
+need:
+
+```console
+$ ccu-mcp secret --env ~/.config/ccu-mcp/.env
+This file configures named targets (prod, dev) — one password each:
+  node /home/you/.local/bin/ccu-mcp secret prod --env /home/you/.config/ccu-mcp/.env
+  node /home/you/.local/bin/ccu-mcp secret dev --env /home/you/.config/ccu-mcp/.env
+
+$ ccu-mcp secret prod --env ~/.config/ccu-mcp/.env
+CCU password for ai@ccu.example (input hidden):
+Wrote CCU_PROD_PASSWORD to /home/you/.config/ccu-mcp/.env (mode 0600).
+```
+
+Those hints come out as `node <path>` rather than `ccu-mcp` on purpose: the
+path is the build that printed them, so copying the line cannot land on some
+older copy that lacks the subcommand. `secret` refuses a name against a flat
+single-CCU file, and refuses an unknown one against a profile file, so it can
+never write the wrong key.
+
+**Verify everything at once.** `doctor` walks every target — configuration,
+reachability, pin, login and privilege level — and exits non-zero if any check
+fails:
+
+```console
+$ ccu-mcp doctor --env ~/.config/ccu-mcp/.env
+ccu-mcp doctor — checking /home/you/.config/ccu-mcp/.env
+  ✓ configuration loads: 2 target(s), default "prod"
+
+Target "prod" — ccu.example:443 (HTTPS)
+  ✓ CCU API reachable
+  ✓ pinned TLS fingerprint matches the presented certificate
+  ✓ login OK as "ai" (CCU 3.87.6.20260614) — privilege level ADMIN
+
+Target "dev" — 192.168.1.50:80 (HTTP)
+  ✓ CCU API reachable
+  ✓ login OK as "Admin" (CCU 3.87.6.20260614) — privilege level ADMIN
+
+All checks passed.
+```
+
+**In the client.** One MCP server entry serves all targets — the `--env` file
+carries the roster, so nothing about the client config changes when you add a
+CCU:
+
+```json
+{
+  "mcpServers": {
+    "ccu-mcp": {
+      "command": "npx",
+      "args": ["ccu-mcp", "--stdio", "--env", "/home/you/.config/ccu-mcp/.env"]
+    }
+  }
+}
+```
+
+Then, in chat: *"which CCUs are configured?"* (`list_ccu_targets`), *"read the
+living-room temperature on dev"* (a one-call `target: "dev"`), *"switch to
+dev"* (`use_ccu`). With `CCU_PROD_PROTECTED=true` as above, the first write
+against prod comes back asking for `confirm: true` and unlocks that target for
+the rest of the session — except `run_script` and `delete_system_variable`,
+which ask every time.
+
 ### Configuration errors
 
 Some mistakes stop the server at startup instead of being ignored. Each of these
@@ -418,7 +590,7 @@ server's instructions) instead of exiting, so it can be fixed conversationally:
 | Message | Cause and why it's fatal |
 |---|---|
 | `CCU_HOST environment variable is required` | No CCU configured (and no `CCU_PROFILES`). |
-| `CCU_PASSWORD environment variable is required` | The variable is **absent**. An empty value is accepted — a fresh OpenCCU box has no Admin password — so this means "not set yet", which is also what keeps a setup-mode server in setup mode until `ccu-mcp secret` stores one. |
+| `CCU_PASSWORD environment variable is required` | The variable is **absent**. An empty value is accepted — a fresh OpenCCU box has no Admin password — so this means "not set yet", which is what keeps a single-CCU setup-mode server in setup mode until `ccu-mcp secret` stores one. Named profiles are deliberately laxer: an absent `CCU_<NAME>_PASSWORD` reads as empty and the server starts, so on that path a missing password surfaces as a failed login (`setup_test` / `doctor` report it) rather than as this error. |
 | `CCU_DEFAULT_PROFILE is set but CCU_PROFILES is not` | A leftover from a profile setup. Ignoring it would point writes at the flat `CCU_HOST` box while the env file suggests a named target. |
 | `CCU_PROFILES is set but lists no profile names` | Empty or comma-only value. |
 | `CCU_PROFILES lists "<name>" more than once` | Duplicate profile name. |

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
-# ccu-mcp
-
-Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
-
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919/badge)](https://www.bestpractices.dev/projects/13919)
-<!-- Scorecard's own badge endpoint redirects to shields' `ossf-scorecard`
-     route, which reads the LEGACY api.securityscorecards.dev — that host 404s
-     for this repo, so the badge renders "invalid repo path" (with HTTP 200, so
-     a status check does not catch it). The current api.scorecard.dev does
-     serve our result, hence the dynamic/json badge below. Switch back to
+<!-- Both badges stay on ONE source line: a block-level HTML comment between
+     them would end the paragraph and stack them, which is what this used to
+     do. The Scorecard badge reads api.scorecard.dev through shields'
+     dynamic/json route, because Scorecard's own badge endpoint redirects to
+     shields' `ossf-scorecard` route, which reads the LEGACY
+     api.securityscorecards.dev — and that host 404s for this repo, rendering
+     "invalid repo path" (as HTTP 200, so a status check does not catch it).
+     Switch back to
      `https://api.scorecard.dev/projects/github.com/claymore666/ccu-mcp/badge`
      once `curl -sS -o /dev/null -w '%{http_code}'
      https://api.securityscorecards.dev/projects/github.com/claymore666/ccu-mcp`
      returns 200. -->
-[![OpenSSF Scorecard](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fclaymore666%2Fccu-mcp&query=%24.score&label=openssf%20scorecard&suffix=%20%2F%2010)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919/badge)](https://www.bestpractices.dev/projects/13919) [![OpenSSF Scorecard](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fclaymore666%2Fccu-mcp&query=%24.score&label=openssf%20scorecard&suffix=%20%2F%2010)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
+
+# ccu-mcp
+
+Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
 
 <a href="https://glama.ai/mcp/servers/claymore666/ccu-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/claymore666/ccu-mcp/badge" alt="ccu-mcp MCP server" />

--- a/README.md
+++ b/README.md
@@ -334,12 +334,12 @@ Several CCUs work here too — say so ("*I have a prod and a dev CCU*") and the
 assistant repeats probe → write → secret per target: `setup_write_profile`
 takes a `name` (plus `protected`, `readonly` and `makeDefault`) and upserts
 that one target, preserving the others and their already-stored passwords.
-Each target needs its own `ccu-mcp secret <name>` run. One caveat while the
-conversation is still in progress: as soon as a **named** target has a host,
-the configuration loads, so the next restart leaves setup mode even if no
-password has been stored yet (an absent `CCU_<NAME>_PASSWORD` reads as empty).
-Finish with `setup_test` — it reports the failing login — rather than
-reconnecting early.
+Each target needs its own `ccu-mcp secret <name>` run, and the server stays in
+setup mode until every configured target has one: reconnecting halfway through
+lands you back in setup mode, naming the target still missing a password and
+the exact `secret` command that finishes it. A CCU that genuinely has no
+password is not a missing one — write the key with an empty value
+(`CCU_<NAME>_PASSWORD=`) to say so deliberately.
 
 Setup mode is stdio-only (an unconfigured HTTP endpoint that writes config
 files would be an unacceptable surface), and a bare start without `--env`
@@ -590,7 +590,8 @@ server's instructions) instead of exiting, so it can be fixed conversationally:
 | Message | Cause and why it's fatal |
 |---|---|
 | `CCU_HOST environment variable is required` | No CCU configured (and no `CCU_PROFILES`). |
-| `CCU_PASSWORD environment variable is required` | The variable is **absent**. An empty value is accepted — a fresh OpenCCU box has no Admin password — so this means "not set yet", which is what keeps a single-CCU setup-mode server in setup mode until `ccu-mcp secret` stores one. Named profiles are deliberately laxer: an absent `CCU_<NAME>_PASSWORD` reads as empty and the server starts, so on that path a missing password surfaces as a failed login (`setup_test` / `doctor` report it) rather than as this error. |
+| `CCU_PASSWORD environment variable is required` | The variable is **absent**. An empty value is accepted — a fresh OpenCCU box has no Admin password — so this means "not set yet", which is what keeps a single-CCU setup-mode server in setup mode until `ccu-mcp secret` stores one. |
+| `no password stored yet for target <name>` | The profile-form equivalent, and setup-mode only: `CCU_<NAME>_PASSWORD` is absent. A *loaded* configuration still reads an absent key as empty (unchanged, so an OpenCCU dev target keeps working) — but for deciding whether setup is finished, absent means "not entered yet", so the server stays in setup mode and prints the `ccu-mcp secret <name>` run that completes it. Write `CCU_<NAME>_PASSWORD=` to declare an empty password deliberate. |
 | `CCU_DEFAULT_PROFILE is set but CCU_PROFILES is not` | A leftover from a profile setup. Ignoring it would point writes at the flat `CCU_HOST` box while the env file suggests a named target. |
 | `CCU_PROFILES is set but lists no profile names` | Empty or comma-only value. |
 | `CCU_PROFILES lists "<name>" more than once` | Duplicate profile name. |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919/badge)](https://www.bestpractices.dev/projects/13919)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/claymore666/ccu-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
 
 <a href="https://glama.ai/mcp/servers/claymore666/ccu-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/claymore666/ccu-mcp/badge" alt="ccu-mcp MCP server" />

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ All configuration is via environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CCU_HOST` | required | Hostname or IP of your CCU |
-| `CCU_PASSWORD` | required | CCU admin password |
+| `CCU_PASSWORD` | required | CCU admin password. Must be set, but may be empty for a box without one (a fresh OpenCCU) |
 | `CCU_USER` | `Admin` | CCU username |
 | `CCU_PORT` | `80` | API port (`443` when using HTTPS) |
 | `CCU_HTTPS` | `false` | Connect via HTTPS (self-signed certs supported) |
@@ -415,7 +415,7 @@ server's instructions) instead of exiting, so it can be fixed conversationally:
 | Message | Cause and why it's fatal |
 |---|---|
 | `CCU_HOST environment variable is required` | No CCU configured (and no `CCU_PROFILES`). |
-| `CCU_PASSWORD environment variable is required` | Unset **or empty**. Note the asymmetry: a *profile* password may be empty (`CCU_<NAME>_PASSWORD=`, e.g. an OpenCCU dev box), the flat one may not. |
+| `CCU_PASSWORD environment variable is required` | The variable is **absent**. An empty value is accepted — a fresh OpenCCU box has no Admin password — so this means "not set yet", which is also what keeps a setup-mode server in setup mode until `ccu-mcp secret` stores one. |
 | `CCU_DEFAULT_PROFILE is set but CCU_PROFILES is not` | A leftover from a profile setup. Ignoring it would point writes at the flat `CCU_HOST` box while the env file suggests a named target. |
 | `CCU_PROFILES is set but lists no profile names` | Empty or comma-only value. |
 | `CCU_PROFILES lists "<name>" more than once` | Duplicate profile name. |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,16 @@
 Talk to your HomeMatic smart home from Claude, Cursor, or any MCP client.
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13919/badge)](https://www.bestpractices.dev/projects/13919)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/claymore666/ccu-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
+<!-- Scorecard's own badge endpoint redirects to shields' `ossf-scorecard`
+     route, which reads the LEGACY api.securityscorecards.dev — that host 404s
+     for this repo, so the badge renders "invalid repo path" (with HTTP 200, so
+     a status check does not catch it). The current api.scorecard.dev does
+     serve our result, hence the dynamic/json badge below. Switch back to
+     `https://api.scorecard.dev/projects/github.com/claymore666/ccu-mcp/badge`
+     once `curl -sS -o /dev/null -w '%{http_code}'
+     https://api.securityscorecards.dev/projects/github.com/claymore666/ccu-mcp`
+     returns 200. -->
+[![OpenSSF Scorecard](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fclaymore666%2Fccu-mcp&query=%24.score&label=openssf%20scorecard&suffix=%20%2F%2010)](https://scorecard.dev/viewer/?uri=github.com/claymore666/ccu-mcp)
 
 <a href="https://glama.ai/mcp/servers/claymore666/ccu-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/claymore666/ccu-mcp/badge" alt="ccu-mcp MCP server" />

--- a/README.md
+++ b/README.md
@@ -309,10 +309,13 @@ you through the same probe → pin → test-login → write flow in plain chat.
 Then just ask: *"set up my CCU connection"*. One deliberate exception: **the
 password never travels through the model or the chat transcript**.
 `setup_write_profile` has no password parameter; instead the assistant hands
-you a one-liner to run in a terminal — `ccu-mcp secret <profile> --env
-/path/to/.env` — which prompts locally with echo off and writes only the
-password into the file (mode 0600). Once `setup_test` reports green, reconnect
-the MCP server and the identical client entry starts it fully configured.
+you a one-liner to run in a terminal — `npx ccu-mcp secret <profile> --env
+/path/to/.env`, or the equivalent for however you installed it — which prompts
+locally with echo off and writes only the password into the file (mode 0600).
+Copy the command the tool prints rather than this one: it names the build that
+printed it, so it cannot land on an older install that lacks the subcommand.
+Once `setup_test` reports green, reconnect the MCP server and the identical
+client entry starts it fully configured.
 
 Setup mode is stdio-only (an unconfigured HTTP endpoint that writes config
 files would be an unacceptable surface), and a bare start without `--env`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,16 @@ making it safer and more predictable rather than larger.
   migration note, and a clear error that names the fix. Until then this is a
   documented gap, not a hidden one — see
   [docs/assurance-case.md](docs/assurance-case.md).
-- **OpenSSF Scorecard** in CI ([#153](https://github.com/claymore666/ccu-mcp/issues/153)).
+- **Give OpenSSF Scorecard a real Branch-Protection reading.** Scorecard now
+  runs weekly ([#153](https://github.com/claymore666/ccu-mcp/issues/153)) on
+  the workflow's own `GITHUB_TOKEN`, which cannot read classic branch
+  protection — so that one check scores on thin evidence while the rest of the
+  report is accurate. Two ways to close it: a fine-grained PAT with
+  `Administration: Read-only` as secret `SCORECARD_TOKEN`, which is a
+  long-lived credential plus a yearly rotation when it expires; or move
+  `main`'s protection to rulesets, which non-admin tokens can read and which
+  would need its six required checks and the deliberate `enforce_admins: false`
+  bypass rebuilt as bypass actors.
 
 Delivered in v1.10.0, kept here because the reasoning is still the record:
 CodeQL moved off GitHub's default setup into a workflow file, so the query

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,14 +58,16 @@ discarding it each night wasted most of the value of running the fuzzer.
      privilege level (USER vs ADMIN), writes a valid `.env`, and emits
      ready-to-paste client config snippets. Works over SSH, adds no attack
      surface.
-  2. **LLM-guided setup on the same core.** Register the server with an empty
-     config (it already starts without one) and let a `setup` tool walk the
-     conversation through the same probe/pin/validate steps. One deliberate
-     exception: the password never travels through the model or the chat
-     transcript — the setup tool hands off to `ccu-mcp secret <profile>`, a
-     one-line local prompt that writes just the secret. MCP elicitation could
-     replace the chat round-trips where clients support it, but the spec
-     forbids eliciting secrets, so the CLI hand-off stays either way.
+  2. **LLM-guided setup on the same core.** Started with `--stdio --env
+     <path>` and a missing/invalid config, the server enters a stdio-only
+     *setup mode* exposing just `setup_*` tools, so it can be registered in an
+     MCP client before it is configured and the conversation walks through the
+     same probe/pin/validate steps. One deliberate exception: the password
+     never travels through the model or the chat transcript — the setup flow
+     hands off to `ccu-mcp secret <profile>`, a one-line local prompt that
+     writes just the secret. MCP elicitation could replace the chat
+     round-trips where clients support it, but the spec forbids eliciting
+     secrets, so the CLI hand-off stays either way.
   3. Maybe later, `ccu-mcp config --ui` — a browser form bound to 127.0.0.1
      with a one-time token, process exits when closed. Only if the above turns
      out not to be enough.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,6 +47,34 @@ corpus now carries between nightly runs
 found nothing in 60s where a seeded one found planted defects in under 20, so
 discarding it each night wasted most of the value of running the fuzzer.
 
+### Configuration experience
+
+- **Guided setup instead of hand-edited `.env`.** Configuring profiles today
+  means writing `CCU_PROD_TLS_FINGERPRINT`-style variables by hand and finding
+  out at runtime whether the credentials work or the user has enough
+  privileges. The plan, in order:
+  1. `ccu-mcp init` / `ccu-mcp doctor` — an interactive CLI wizard that probes
+     the host, pins the TLS fingerprint, tests the login, reports the detected
+     privilege level (USER vs ADMIN), writes a valid `.env`, and emits
+     ready-to-paste client config snippets. Works over SSH, adds no attack
+     surface.
+  2. **LLM-guided setup on the same core.** Register the server with an empty
+     config (it already starts without one) and let a `setup` tool walk the
+     conversation through the same probe/pin/validate steps. One deliberate
+     exception: the password never travels through the model or the chat
+     transcript — the setup tool hands off to `ccu-mcp secret <profile>`, a
+     one-line local prompt that writes just the secret. MCP elicitation could
+     replace the chat round-trips where clients support it, but the spec
+     forbids eliciting secrets, so the CLI hand-off stays either way.
+  3. Maybe later, `ccu-mcp config --ui` — a browser form bound to 127.0.0.1
+     with a one-time token, process exits when closed. Only if the above turns
+     out not to be enough.
+
+  Non-goal: a persistent web admin panel. A standing HTTP surface that holds
+  every CCU password is exactly what this project's security posture says not
+  to build. Also a non-goal: controlling devices from it — the CCU WebUI and
+  the MCP client already do that.
+
 ### Project continuity
 
 - **Reduce the bus factor from 1.** Either a second maintainer with publish
@@ -71,7 +99,9 @@ Saying no is most of what keeps this maintainable.
   JSON-RPC to a CCU on your network, nothing else.
 - **No addon or XML-API dependency.** The built-in `/api/homematic.cgi`
   endpoint is the only interface used, and that stays true.
-- **No web UI or dashboard.** The MCP client is the interface.
+- **No web UI or dashboard.** The MCP client is the interface. (The
+  run-and-exit localhost config form under Configuration experience is not
+  this: no standing server, no device control.)
 - **No multi-user model or per-user permissions.** The server holds one
   credential per configured CCU and acts as that user. Authorisation belongs to
   the CCU.

--- a/package-lock.json
+++ b/package-lock.json
@@ -530,9 +530,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.79.0.tgz",
-      "integrity": "sha512-TebFaaMklO/RXzTv7PucaCq9l3X6D1gA+C8H6K4njtjFOV+zWE9MKLpulcJZN9bzytbUbQIY0mZuz12nQ5Kv4Q==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.80.0.tgz",
+      "integrity": "sha512-RM3Plj+biQpxa5d1GOOX6ciDlcUROmm4OZ/pLTpitkQt2mJv4jhtY4cbgaetOm5UKWZe05/TGQ6o1Vl8EOHkrA==",
       "cpu": [
         "arm"
       ],
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.79.0.tgz",
-      "integrity": "sha512-KqqnOtAVgNsPPF0YSodkFZA1O80jcKoCZCTu3bgsszxA+MrMP9TLzfXitKjEj1FmrPprKDMdRDMmY3weESO9sg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.80.0.tgz",
+      "integrity": "sha512-YlO5JEf0Yr2bUUlu8O8daVcUxtcGGbcSmyV7E7nSbJbfAdxTE0PFPwgnIlw7wXJaTYjb+qs5hI5q3jxUkI7cAw==",
       "cpu": [
         "arm64"
       ],
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.79.0.tgz",
-      "integrity": "sha512-BVC2nsMzqQzRDPc5RhixkZ+m1p7iH4bxRRvqkbwDXX0PlQKm1BPy8J8cRjnAFafOq2QzI+BfO3vE8w2GZ3CBag==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.80.0.tgz",
+      "integrity": "sha512-BULDOyO3AhsmdWfQeIUCykDt3dd7XZBGLhp1eIh56skRv01O+cNjNPwXMIbeW1x4+pxcln5if72wcRgViVo7PA==",
       "cpu": [
         "arm64"
       ],
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.79.0.tgz",
-      "integrity": "sha512-p6Lm+snmhGuLKL1+CpCV8L6ijkE/qJzK2H2jG9+eKJT0n31RbY4FLsdhexekgP3bLpw4Kgde+9DZuDZQ4yIInA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.80.0.tgz",
+      "integrity": "sha512-YJ4JzLw7N5TDSQFlA0hAQGHvnDZgyypm1yunObVWcWiF9KM7eGCJKYKLgTC2Fi/57OdnBhbj4OkzPGdFQJ6HyA==",
       "cpu": [
         "x64"
       ],
@@ -598,9 +598,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.79.0.tgz",
-      "integrity": "sha512-qDMm0dXZnoHyRqSL4N4xUq82T4sqK5cbKSjvd/dF/YbMUXc2R1wEPf+vmA5S0qUmi0nwXfNbjXBtZaIqzQLIMg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.80.0.tgz",
+      "integrity": "sha512-AYUIk5QnL0s8oWAYsREZwkRYy1SupJTXALo93J1TgzHywxQtdM99FecRMQ87MXEdPQ0j1TmEpeeq3fGNkpvMqg==",
       "cpu": [
         "x64"
       ],
@@ -615,9 +615,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.79.0.tgz",
-      "integrity": "sha512-2od7s0nuKPzqyUZAWk9KkCyGg7eI9dwFPZg+20lB15fKFkVZ0c9ZFxqPfiBAyDTlTkh9stPI0t+JlPCqMbItVA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.80.0.tgz",
+      "integrity": "sha512-9hBZVANupQ89W9dXyE0n8doCyaW5pDyGn3y6XlIMPZ+rIKuyqkr3SNUXmVJIhuvUq0NBU3RBiSXXE69l4XI6KA==",
       "cpu": [
         "arm"
       ],
@@ -632,9 +632,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.79.0.tgz",
-      "integrity": "sha512-ZOQUjkzDnvlhSE3+tWC3YXx94MMl+sYMlwH+u1+YGApGHOJP/YAc8ZBRFOXZ6eOBmxtXAWuS/fBcdZr8qqNO1A==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.80.0.tgz",
+      "integrity": "sha512-SvS2uKqzY+pbfuvAHzH4338R6Zwo805GAwrIMVvK1KxoOWCIjZUdfzTCvilD7z6JK91v011+zYMryabhDo2AsQ==",
       "cpu": [
         "arm"
       ],
@@ -649,9 +649,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.79.0.tgz",
-      "integrity": "sha512-lu158FR4nGqGeRS3BQvtG85wRgU/Fy4MD5Cxp1hzJXizGiLo6u2742wJSCDKh8cFcZntvX7fcxlq4mMmfryH1g==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.80.0.tgz",
+      "integrity": "sha512-tCLadyqRVL3pQTRPNg7cjXKvcvS4fbyXeQHhKk5BTJ1oftQln5/yIIWbu/Xom/DX41zv2P9QGt6+D/TtQVtY3A==",
       "cpu": [
         "arm64"
       ],
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.79.0.tgz",
-      "integrity": "sha512-mbpKQeE2aflTjddaHK7MP8KP/OFbUM++lt5M635ENM8IyIdK0jm2t9pb+2v9mVVIvhF6TqA4l7F79Pll1mi+uw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.80.0.tgz",
+      "integrity": "sha512-XfpCNRlOPcLlJl4Bn/FUhjqlR6BVavEykERBf/MV7YA9VZDa5g5znVqYhyviMafcxS9Pe/i/kPvHNO0U6svEHQ==",
       "cpu": [
         "arm64"
       ],
@@ -689,9 +689,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.79.0.tgz",
-      "integrity": "sha512-WpGNua7gaxaHnpSDeog2ji8IDHn/QLPl9LPzwkR/FvVv58vT5BcXjRXnU+wbu3N75cpeha8CdC7ho/U2OIsB4g==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.80.0.tgz",
+      "integrity": "sha512-3I4yMwcFG9NeO8ioY6JBBuKsIm5GL/x7MATt1S4tVWaxPu5HcJ+XnLUbcVBTxG8q2Wu56HSj+NmXQiVYb1lp6A==",
       "cpu": [
         "ppc64"
       ],
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.79.0.tgz",
-      "integrity": "sha512-tK1E93A5LVzISg4ngpKJnfTs7EqtIUceGI7MQ4GyDjJiLi8wPCkEyKlj2xkyKWZ1yzkDJyLHTBJ5/iFWRdnJvg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.80.0.tgz",
+      "integrity": "sha512-E1wAKymkpe1/E8helzBKdm81OBOF+ezxRyXRMEuik3ZpWDER5CPOKZwF66RsdwW98uwZv8UTFremUQtC1CzdJA==",
       "cpu": [
         "riscv64"
       ],
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.79.0.tgz",
-      "integrity": "sha512-qhQvUIrngXivA2A9pQ+xPCychztn/5qUv7yS3gDwXv3w7Rag+eTeeXWmRyx+t7XsW5x6LuY/8AsTq36UgFIblg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.80.0.tgz",
+      "integrity": "sha512-+gLRGD4sIo3+VA++iham5UxD9tKSoJ/VOrROCEXIcknrYtQg6iIQgvjN0cpiRF7N6UYC7pJbvHJlDnMge5LRpQ==",
       "cpu": [
         "riscv64"
       ],
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.79.0.tgz",
-      "integrity": "sha512-sv6AaVgU/eE6u+6WFiQVDcPPwTxP6IJMSB9k701W2r/r6Tx465e8vPvVyRxquNH4Vy6KwRNu90mVbxXJN8+5gg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.80.0.tgz",
+      "integrity": "sha512-aR0PrzHj9leW3NmzBAAP4EzdoBNoJcs9sjnIQPIwyRnBGYrRbXUIpEB5Q39AqK3PLY5JK5uEhDQDiUa1QSAstw==",
       "cpu": [
         "s390x"
       ],
@@ -769,9 +769,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.79.0.tgz",
-      "integrity": "sha512-iFZL02deziHslb3jEX9KdqlAkYoo4fGyotchKDzdfK1f5mxlIBeiQeHhvK3iFpuEJSB4ma/qeFn9oxPiwnhUPQ==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.80.0.tgz",
+      "integrity": "sha512-vSVh5cSo3Xxs6ghBCcFJlpbkbENzDog1qXtoXLa/HC3aCrR4XO76GZbXmQoCPHnu99nQpdCeC3H9tdNICfDh7A==",
       "cpu": [
         "x64"
       ],
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.79.0.tgz",
-      "integrity": "sha512-3DtZR2raqObnh7wXZoFYFd0Fw7skBvcb3f7A+/lkEiDuh8hrE6vv9b/62Qxao1a9/OeHLw/FcXlXzgsW9wTRFg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.80.0.tgz",
+      "integrity": "sha512-FfzBXpNQ8u7/ZI/p8bl73MeZ508Ax3hxWp3SiJpEFiC+BB9XcXy5FAZHTLKDPSzrUpxQZSZJAVdDmuJp/+HDBQ==",
       "cpu": [
         "x64"
       ],
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.79.0.tgz",
-      "integrity": "sha512-Oatt4GuA1WJkqzk2ozx4HrWROOi7opV3AKDw/U8qDIqeTqzsjn5K2x3REJMNjU3/KU/Bkq96Zi3CknaiDTaC/Q==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.80.0.tgz",
+      "integrity": "sha512-zMzbkumtmprCgRwoYNzcB3iC39fXdJIMLMU33KdCjEGLlJGOEt1+LwQ4LF8ndLzAEKVz4BR0y3V6Xrkk3Nm3yA==",
       "cpu": [
         "arm64"
       ],
@@ -826,9 +826,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.79.0.tgz",
-      "integrity": "sha512-NAgZr9Qp8nIA9rpo0JEvwiabTF/2UVqBNnupBG9X4kxXcQoScJUTi+qHhvabb9s/thgj5wQ4XcIaJvb+ZMgoKw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.80.0.tgz",
+      "integrity": "sha512-ib6iRcrXsk4t1fm3iKcwksyWh1ZkZXC/2mEzakl0ai2+6HZunf1WWMZ/xP9EJAvw9g9K4UVTC3NF/+G2qLrbTQ==",
       "cpu": [
         "arm64"
       ],
@@ -843,9 +843,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.79.0.tgz",
-      "integrity": "sha512-+KyXjIvcpaXmWW/j9NNY5yWjrIVxaX18VyIheQy3jwc2GSYgpCr7MGI/HxIGQ/shAL5IWEKbhsqoMpAO5Stiog==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.80.0.tgz",
+      "integrity": "sha512-xhRWBMpLxZvgKAH6+DJZmpP+W8Y8UdQOSU1JfxSWNXsaBaRGW77j+1hCuNHlzj7OH4SPN8fYd1q0o2qrDtoVyw==",
       "cpu": [
         "ia32"
       ],
@@ -860,9 +860,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.79.0.tgz",
-      "integrity": "sha512-mEelcCMMBS57sIXh2veGMNy+pQwuGtcMxHxGIZWQ5Ba9pJ5jCCUFOZB9E2JhBaxGsURe+WGe0zJp4RVre52gpQ==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.80.0.tgz",
+      "integrity": "sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q==",
       "cpu": [
         "x64"
       ],
@@ -3424,9 +3424,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.79.0.tgz",
-      "integrity": "sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.80.0.tgz",
+      "integrity": "sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3439,25 +3439,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.79.0",
-        "@oxlint/binding-android-arm64": "1.79.0",
-        "@oxlint/binding-darwin-arm64": "1.79.0",
-        "@oxlint/binding-darwin-x64": "1.79.0",
-        "@oxlint/binding-freebsd-x64": "1.79.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.79.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.79.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.79.0",
-        "@oxlint/binding-linux-arm64-musl": "1.79.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.79.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.79.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.79.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.79.0",
-        "@oxlint/binding-linux-x64-gnu": "1.79.0",
-        "@oxlint/binding-linux-x64-musl": "1.79.0",
-        "@oxlint/binding-openharmony-arm64": "1.79.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.79.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.79.0",
-        "@oxlint/binding-win32-x64-msvc": "1.79.0"
+        "@oxlint/binding-android-arm-eabi": "1.80.0",
+        "@oxlint/binding-android-arm64": "1.80.0",
+        "@oxlint/binding-darwin-arm64": "1.80.0",
+        "@oxlint/binding-darwin-x64": "1.80.0",
+        "@oxlint/binding-freebsd-x64": "1.80.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.80.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.80.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.80.0",
+        "@oxlint/binding-linux-arm64-musl": "1.80.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.80.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.80.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.80.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.80.0",
+        "@oxlint/binding-linux-x64-gnu": "1.80.0",
+        "@oxlint/binding-linux-x64-musl": "1.80.0",
+        "@oxlint/binding-openharmony-arm64": "1.80.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.80.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.80.0",
+        "@oxlint/binding-win32-x64-msvc": "1.80.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4542,9 +4542,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.1.tgz",
+      "integrity": "sha512-P3GqeAEOEDqKvafVGLezbg+39YW/ze4xrD4qdS0adOY8eoI3zfjv1PQM4UwQzgT8mZKXEbqtVt8K+ZKGqkMFKg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2263,9 +2263,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2431,9 +2431,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -2648,9 +2648,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3608,12 +3608,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -3833,14 +3834,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3852,13 +3853,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccu-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccu-mcp",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -583,9 +583,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.78.0.tgz",
-      "integrity": "sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.79.0.tgz",
+      "integrity": "sha512-TebFaaMklO/RXzTv7PucaCq9l3X6D1gA+C8H6K4njtjFOV+zWE9MKLpulcJZN9bzytbUbQIY0mZuz12nQ5Kv4Q==",
       "cpu": [
         "arm"
       ],
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.78.0.tgz",
-      "integrity": "sha512-CDfxZgB61B7buRdY2FJoAYYPPXCZ1EoC1LKscnC5dg3kjobdxiconvAvvN1BmHyW4PyFT3jRLDag/BY/roSNBQ==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.79.0.tgz",
+      "integrity": "sha512-KqqnOtAVgNsPPF0YSodkFZA1O80jcKoCZCTu3bgsszxA+MrMP9TLzfXitKjEj1FmrPprKDMdRDMmY3weESO9sg==",
       "cpu": [
         "arm64"
       ],
@@ -617,9 +617,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.78.0.tgz",
-      "integrity": "sha512-2Y2U9Ahrz+OO0Ej88f9SJYq51/jUBp1Mc7iZu0ukrbeeZ3gpRGfzIFnoqfHDY96xr0GEfNrPUBFEy0nN5aD7HA==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.79.0.tgz",
+      "integrity": "sha512-BVC2nsMzqQzRDPc5RhixkZ+m1p7iH4bxRRvqkbwDXX0PlQKm1BPy8J8cRjnAFafOq2QzI+BfO3vE8w2GZ3CBag==",
       "cpu": [
         "arm64"
       ],
@@ -634,9 +634,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.78.0.tgz",
-      "integrity": "sha512-rpych6eJq6m9jDRypTEaPD1xysaEW5h9+xuxhGK/QhOg+/xaqPZrCrTNoIl/f3nEjuJeCEmstNDlrE9rJi/3/g==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.79.0.tgz",
+      "integrity": "sha512-p6Lm+snmhGuLKL1+CpCV8L6ijkE/qJzK2H2jG9+eKJT0n31RbY4FLsdhexekgP3bLpw4Kgde+9DZuDZQ4yIInA==",
       "cpu": [
         "x64"
       ],
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.78.0.tgz",
-      "integrity": "sha512-IcMGrQT3QizkOESUJd5et+rOhVqSkNDfNik1cvrKDqIbzqx9KMtRswpFgkCuNTSwylCFLKhGUu8KmqY1ZnC0Dg==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.79.0.tgz",
+      "integrity": "sha512-qDMm0dXZnoHyRqSL4N4xUq82T4sqK5cbKSjvd/dF/YbMUXc2R1wEPf+vmA5S0qUmi0nwXfNbjXBtZaIqzQLIMg==",
       "cpu": [
         "x64"
       ],
@@ -668,9 +668,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.78.0.tgz",
-      "integrity": "sha512-/uLdoJ0IXE6vo/0f0LKjinQAp+re+VMaCWaNT8ENIv2EOCkSsc8SGaflXAuW0Jua2dq5+GLVWm1NQK7P3UFSNQ==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.79.0.tgz",
+      "integrity": "sha512-2od7s0nuKPzqyUZAWk9KkCyGg7eI9dwFPZg+20lB15fKFkVZ0c9ZFxqPfiBAyDTlTkh9stPI0t+JlPCqMbItVA==",
       "cpu": [
         "arm"
       ],
@@ -685,9 +685,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.78.0.tgz",
-      "integrity": "sha512-7xi4Wb/O8NRJhLoUXmDJMUVpNYvB5kefdhFU1Jb8rtae4QoXlTiLwI14X4YvAXVZLNZChP8m5qO9SQAlWQTbkQ==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.79.0.tgz",
+      "integrity": "sha512-ZOQUjkzDnvlhSE3+tWC3YXx94MMl+sYMlwH+u1+YGApGHOJP/YAc8ZBRFOXZ6eOBmxtXAWuS/fBcdZr8qqNO1A==",
       "cpu": [
         "arm"
       ],
@@ -702,9 +702,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.78.0.tgz",
-      "integrity": "sha512-4hFW0+fVXa3OIh1Y4A5SPkmvI4wuuBSrCVKzOyE7PTjhc7yEqZ1pmvEEeS5Lj/MaqvegFxXyF33N+6jkehxdyg==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.79.0.tgz",
+      "integrity": "sha512-lu158FR4nGqGeRS3BQvtG85wRgU/Fy4MD5Cxp1hzJXizGiLo6u2742wJSCDKh8cFcZntvX7fcxlq4mMmfryH1g==",
       "cpu": [
         "arm64"
       ],
@@ -722,9 +722,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.78.0.tgz",
-      "integrity": "sha512-oC0mvsgBJjlMijSDEhx9KuvR9zYeHXceA9MjbuXB1F8NSR78Yj2unOBrstEvTVaq+pko+kuue6DajC00eqvTdg==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.79.0.tgz",
+      "integrity": "sha512-mbpKQeE2aflTjddaHK7MP8KP/OFbUM++lt5M635ENM8IyIdK0jm2t9pb+2v9mVVIvhF6TqA4l7F79Pll1mi+uw==",
       "cpu": [
         "arm64"
       ],
@@ -742,9 +742,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.78.0.tgz",
-      "integrity": "sha512-XAllT5SUZS+ohjuZ3/5S0cwe0r7eboiuigeStCZ5DXRYx/2KVM2UvQXvAfyzXEimtQjAB7cDQ2YxDe2Zl2WNQQ==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.79.0.tgz",
+      "integrity": "sha512-WpGNua7gaxaHnpSDeog2ji8IDHn/QLPl9LPzwkR/FvVv58vT5BcXjRXnU+wbu3N75cpeha8CdC7ho/U2OIsB4g==",
       "cpu": [
         "ppc64"
       ],
@@ -762,9 +762,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.78.0.tgz",
-      "integrity": "sha512-trucMER/0QtecoXvc1y/UVqE3kwJipDwrx4oHfj+nNm3dq2zjP44WT0CfHNDPM3G1DXIkx/gY6lAD21NSCZVhA==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.79.0.tgz",
+      "integrity": "sha512-tK1E93A5LVzISg4ngpKJnfTs7EqtIUceGI7MQ4GyDjJiLi8wPCkEyKlj2xkyKWZ1yzkDJyLHTBJ5/iFWRdnJvg==",
       "cpu": [
         "riscv64"
       ],
@@ -782,9 +782,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.78.0.tgz",
-      "integrity": "sha512-cm3O4F/HQbdzOUX5mKHqG5KDL6E5w0pnlZ+fbBy2rmLryPOowkuLagFHTopQsEIpjcaZoPOrL+BmmAytAG9HFg==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.79.0.tgz",
+      "integrity": "sha512-qhQvUIrngXivA2A9pQ+xPCychztn/5qUv7yS3gDwXv3w7Rag+eTeeXWmRyx+t7XsW5x6LuY/8AsTq36UgFIblg==",
       "cpu": [
         "riscv64"
       ],
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.78.0.tgz",
-      "integrity": "sha512-33wRf6HqGNsybJ3qX4cGaQN2ODPxNmc1rMa0mrTmx3eFq1VzOnvQooi9bIGVYakW8a/wmqVx1mgsUm8R2xfTiw==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.79.0.tgz",
+      "integrity": "sha512-sv6AaVgU/eE6u+6WFiQVDcPPwTxP6IJMSB9k701W2r/r6Tx465e8vPvVyRxquNH4Vy6KwRNu90mVbxXJN8+5gg==",
       "cpu": [
         "s390x"
       ],
@@ -822,9 +822,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.78.0.tgz",
-      "integrity": "sha512-rRdISSYegj6VganMZ9tjRjijowfHJ09IZU01i0toBAqr6n5LEtwHq2IeS4FjW2RoskOHlb6efB26H5izYb3GEQ==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.79.0.tgz",
+      "integrity": "sha512-iFZL02deziHslb3jEX9KdqlAkYoo4fGyotchKDzdfK1f5mxlIBeiQeHhvK3iFpuEJSB4ma/qeFn9oxPiwnhUPQ==",
       "cpu": [
         "x64"
       ],
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.78.0.tgz",
-      "integrity": "sha512-GmsP4rW0xTL6u5CVdcDsaN5Fbc7hBc382Wmar1kttbnwSEviM+rSINKOMQ+UQ6iH+AGwC+8gaAiwu134Tgh6Lg==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.79.0.tgz",
+      "integrity": "sha512-3DtZR2raqObnh7wXZoFYFd0Fw7skBvcb3f7A+/lkEiDuh8hrE6vv9b/62Qxao1a9/OeHLw/FcXlXzgsW9wTRFg==",
       "cpu": [
         "x64"
       ],
@@ -862,9 +862,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.78.0.tgz",
-      "integrity": "sha512-sy9yeYuADc8a+n4TLBayzMCZiHPW78DcIFVpOXTmdKHWQeM9xe5uzkqIIZmi326D5hY9XVwacipEB1p7tQjPAg==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.79.0.tgz",
+      "integrity": "sha512-Oatt4GuA1WJkqzk2ozx4HrWROOi7opV3AKDw/U8qDIqeTqzsjn5K2x3REJMNjU3/KU/Bkq96Zi3CknaiDTaC/Q==",
       "cpu": [
         "arm64"
       ],
@@ -879,9 +879,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.78.0.tgz",
-      "integrity": "sha512-rjc2hF1KfMi8fZj1X/m3AmnHbdsF3rL0v6KQg0Uc880Yb2khjz+3U14sfdZ7jWTpRnN1m1NQa/TT7uU9lJWPrA==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.79.0.tgz",
+      "integrity": "sha512-NAgZr9Qp8nIA9rpo0JEvwiabTF/2UVqBNnupBG9X4kxXcQoScJUTi+qHhvabb9s/thgj5wQ4XcIaJvb+ZMgoKw==",
       "cpu": [
         "arm64"
       ],
@@ -896,9 +896,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.78.0.tgz",
-      "integrity": "sha512-zcuXFVrEFHIafRfkCQT8w/Xe41o07ozl/vwHq7p94vB29xVzsB0sZGYORU1jhcYKv3Lr0J3HbJ2T4fHH5rWmvA==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.79.0.tgz",
+      "integrity": "sha512-+KyXjIvcpaXmWW/j9NNY5yWjrIVxaX18VyIheQy3jwc2GSYgpCr7MGI/HxIGQ/shAL5IWEKbhsqoMpAO5Stiog==",
       "cpu": [
         "ia32"
       ],
@@ -913,9 +913,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.78.0.tgz",
-      "integrity": "sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.79.0.tgz",
+      "integrity": "sha512-mEelcCMMBS57sIXh2veGMNy+pQwuGtcMxHxGIZWQ5Ba9pJ5jCCUFOZB9E2JhBaxGsURe+WGe0zJp4RVre52gpQ==",
       "cpu": [
         "x64"
       ],
@@ -3490,9 +3490,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.78.0.tgz",
-      "integrity": "sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.79.0.tgz",
+      "integrity": "sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3505,25 +3505,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.78.0",
-        "@oxlint/binding-android-arm64": "1.78.0",
-        "@oxlint/binding-darwin-arm64": "1.78.0",
-        "@oxlint/binding-darwin-x64": "1.78.0",
-        "@oxlint/binding-freebsd-x64": "1.78.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.78.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.78.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.78.0",
-        "@oxlint/binding-linux-arm64-musl": "1.78.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.78.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.78.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.78.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.78.0",
-        "@oxlint/binding-linux-x64-gnu": "1.78.0",
-        "@oxlint/binding-linux-x64-musl": "1.78.0",
-        "@oxlint/binding-openharmony-arm64": "1.78.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.78.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.78.0",
-        "@oxlint/binding-win32-x64-msvc": "1.78.0"
+        "@oxlint/binding-android-arm-eabi": "1.79.0",
+        "@oxlint/binding-android-arm64": "1.79.0",
+        "@oxlint/binding-darwin-arm64": "1.79.0",
+        "@oxlint/binding-darwin-x64": "1.79.0",
+        "@oxlint/binding-freebsd-x64": "1.79.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.79.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.79.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.79.0",
+        "@oxlint/binding-linux-arm64-musl": "1.79.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.79.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.79.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.79.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.79.0",
+        "@oxlint/binding-linux-x64-gnu": "1.79.0",
+        "@oxlint/binding-linux-x64-musl": "1.79.0",
+        "@oxlint/binding-openharmony-arm64": "1.79.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.79.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.79.0",
+        "@oxlint/binding-win32-x64-msvc": "1.79.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,40 +306,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@hono/node-server": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
@@ -553,29 +519,10 @@
         }
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -929,10 +876,27 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
       "cpu": [
         "arm64"
       ],
@@ -947,9 +911,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
       "cpu": [
         "arm64"
       ],
@@ -964,9 +928,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
       "cpu": [
         "x64"
       ],
@@ -981,9 +945,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
       "cpu": [
         "x64"
       ],
@@ -998,9 +962,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
       "cpu": [
         "arm"
       ],
@@ -1015,9 +979,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
       "cpu": [
         "arm64"
       ],
@@ -1035,9 +999,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
       ],
@@ -1055,9 +1019,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
       "cpu": [
         "ppc64"
       ],
@@ -1075,9 +1039,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
       ],
@@ -1095,9 +1059,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
       "cpu": [
         "x64"
       ],
@@ -1115,9 +1079,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
       ],
@@ -1135,9 +1099,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
       "cpu": [
         "arm64"
       ],
@@ -1151,29 +1115,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
       "cpu": [
         "arm64"
       ],
@@ -1188,9 +1133,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
       "cpu": [
         "x64"
       ],
@@ -1217,17 +1162,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1605,14 +1539,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
-      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1626,8 +1560,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.10",
-        "vitest": "4.1.10"
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1636,16 +1570,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1654,13 +1588,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1681,9 +1615,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1694,13 +1628,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1708,14 +1642,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1724,9 +1658,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1734,13 +1668,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2967,9 +2901,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -2983,23 +2917,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -3018,9 +2952,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -3039,9 +2973,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -3060,9 +2994,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -3081,9 +3015,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -3102,9 +3036,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -3126,9 +3060,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -3150,9 +3084,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -3174,9 +3108,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -3198,9 +3132,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -3219,9 +3153,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -3382,9 +3316,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3603,9 +3537,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
-      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -3623,7 +3557,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3758,13 +3692,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.138.0",
+        "@oxc-project/types": "=0.146.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3774,21 +3708,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.4",
-        "@rolldown/binding-darwin-arm64": "1.1.4",
-        "@rolldown/binding-darwin-x64": "1.1.4",
-        "@rolldown/binding-freebsd-x64": "1.1.4",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-        "@rolldown/binding-linux-arm64-musl": "1.1.4",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-musl": "1.1.4",
-        "@rolldown/binding-openharmony-arm64": "1.1.4",
-        "@rolldown/binding-wasm32-wasi": "1.1.4",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
     "node_modules/router": {
@@ -4189,14 +4123,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -4346,16 +4272,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.3",
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -4372,7 +4298,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -4424,19 +4350,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4464,12 +4390,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccu-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
   "mcpName": "io.github.claymore666/ccu-mcp",
   "type": "module",

--- a/scripts/coverage-ratchet.mjs
+++ b/scripts/coverage-ratchet.mjs
@@ -229,10 +229,10 @@ for (const [dir, want] of [...floors].sort()) {
   }
 }
 
-if (process.env.CCU_HOST) {
+if (process.env.CCU_HOST || process.env.CCU_DEV_HOST) {
   console.log(
-    "\nNOTE: CCU_HOST is set, so the live-integration suites ran and these " +
-      "numbers are HIGHER than CI will measure. Do not raise floors from this run.",
+    "\nNOTE: CCU_HOST/CCU_DEV_HOST is set, so live-integration suites ran and " +
+      "these numbers are HIGHER than CI will measure. Do not raise floors from this run.",
   );
 }
 

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/claymore666/ccu-mcp",
     "source": "github"
   },
-  "version": "1.10.0",
+  "version": "1.11.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ccu-mcp",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -31,7 +31,7 @@
         },
         {
           "name": "CCU_PASSWORD",
-          "description": "CCU admin password (same as the WebUI login)",
+          "description": "CCU admin password (same as the WebUI login). Must be set; the value may be empty for a CCU with no password",
           "isRequired": true,
           "isSecret": true,
           "format": "string"

--- a/src/ccu/client.ts
+++ b/src/ccu/client.ts
@@ -5,7 +5,7 @@ import { CcuError, mapCcuError, mapNetworkError } from "../middleware/error-mapp
 import type { Logger } from "../logger.js";
 
 /** Normalize a SHA-256 fingerprint for comparison: drop colons, lowercase. */
-function normalizeFingerprint(fp: string): string {
+export function normalizeFingerprint(fp: string): string {
   return fp.replace(/:/g, "").toLowerCase();
 }
 

--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -1,5 +1,35 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { parseEnv } from "node:util";
+import { VERSION } from "../utils.js";
+
+/** Quote a shell argument only when it needs it, so the common case stays readable. */
+function shellArg(value: string): string {
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * A copy-pasteable command that runs THIS build — the one printing the hint.
+ *
+ * The guided setup used to print a bare `npx ccu-mcp …`, which resolves to
+ * whatever npx finds in cwd or the global prefix. For anyone with an older
+ * global install that is a DIFFERENT binary than the one giving the advice,
+ * and the subcommand may not exist there at all: `secret`, `init` and
+ * `doctor` all postdate the latest published tag, so `npx ccu-mcp secret`
+ * reached a build that fell through to server startup and died with
+ * "CCU_HOST environment variable is required" — a complaint about a variable
+ * the user had just configured, from a file that binary never read.
+ *
+ * `process.argv[1]` is the entry point node actually loaded, so it always
+ * names the running build. The npx form stays as a fallback for the case
+ * where argv[1] is missing or no longer on disk, and is version-pinned so it
+ * cannot silently resolve to something older.
+ */
+export function selfCommand(...args: string[]): string {
+  const rendered = args.map(shellArg).join(" ");
+  const entry = process.argv[1];
+  if (entry && existsSync(entry)) return `node ${shellArg(entry)} ${rendered}`;
+  return `npx ccu-mcp@${VERSION} ${rendered}`;
+}
 
 /**
  * Value of `--env <path>` in argv, defaulting to ./.env. Deliberately NOT

--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { parseEnv } from "node:util";
+
+/**
+ * Value of `--env <path>` in argv, defaulting to ./.env. Deliberately NOT
+ * named `--env-file`: node's own CLI intercepts that flag even when it
+ * appears after the script path and aborts when the file does not exist —
+ * which is precisely the state `ccu-mcp init` starts from.
+ */
+export function envFileArg(argv: string[], def = ".env"): string {
+  const i = argv.indexOf("--env");
+  if (i !== -1) {
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error("--env requires a path argument");
+    }
+    return value;
+  }
+  return def;
+}
+
+/** Parse a dotenv file into key/value pairs. Throws when unreadable. */
+export function loadEnvFile(path: string): Record<string, string> {
+  const content = readFileSync(path, "utf-8");
+  return parseEnv(content) as Record<string, string>;
+}
+
+/**
+ * Apply parsed env-file vars to process.env with the same precedence as
+ * node's own `--env-file`: variables already present in the environment win.
+ */
+export function applyEnvVars(vars: Record<string, string>): void {
+  for (const [key, value] of Object.entries(vars)) {
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
+}
+
+/** Display form of a SHA-256 fingerprint: colon-separated uppercase pairs. */
+export function displayFingerprint(fp: string): string {
+  const bare = fp.replace(/:/g, "").toUpperCase();
+  return bare.match(/.{1,2}/g)?.join(":") ?? bare;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,142 @@
+import { resolve } from "node:path";
+import { Prompter, type PromptIo } from "./prompt.js";
+import { envFileArg, applyEnvVars, loadEnvFile, displayFingerprint } from "./common.js";
+import { readEnvFile, replaceEnvKey, writeEnvFile } from "./env-writer.js";
+import { probeApi, fetchCert, fingerprintMatches, testLogin } from "./probe.js";
+import { loadConfig, envPrefix } from "../config.js";
+import type { CcuProfile } from "../ccu/types.js";
+
+interface Report {
+  say: (text: string) => void;
+  failures: number;
+}
+
+function pass(r: Report, text: string): void {
+  r.say(`  ✓ ${text}`);
+}
+
+function fail(r: Report, text: string): void {
+  r.failures++;
+  r.say(`  ✗ ${text}`);
+}
+
+/** The env key holding this profile's pin, for the refresh offer. */
+function fingerprintKey(p: CcuProfile): string {
+  return p.isFlat ? "CCU_TLS_FINGERPRINT" : `CCU_${envPrefix(p.name)}_TLS_FINGERPRINT`;
+}
+
+/** Returns false when the login test can't succeed anyway (pin mismatch / cert unreadable). */
+async function checkPin(
+  r: Report,
+  p: CcuProfile,
+  envPath: string,
+  ui: Prompter | undefined,
+): Promise<boolean> {
+  if (!p.ccu.https) return true;
+  if (!p.ccu.tlsFingerprint) {
+    r.say("  - no TLS fingerprint pinned (connection is encrypted but unverified)");
+    return true;
+  }
+  let presented: string;
+  try {
+    presented = (await fetchCert(p.ccu.host, p.ccu.port)).fingerprint256;
+  } catch (err) {
+    fail(r, `could not read the TLS certificate: ${(err as Error).message}`);
+    return false;
+  }
+  if (fingerprintMatches(p.ccu.tlsFingerprint, presented)) {
+    pass(r, "pinned TLS fingerprint matches the presented certificate");
+    return true;
+  }
+  fail(r, "pinned TLS fingerprint does NOT match the presented certificate");
+  r.say(`      pinned:    ${displayFingerprint(p.ccu.tlsFingerprint)}`);
+  r.say(`      presented: ${displayFingerprint(presented)}`);
+  r.say("      If the CCU's certificate was legitimately renewed, refresh the pin;");
+  r.say("      if not, this could be an interception attempt — investigate first.");
+  if (ui && (await ui.askYesNo(`    Update ${fingerprintKey(p)} in ${envPath} to the presented one?`, false))) {
+    const existing = readEnvFile(envPath);
+    if (existing === undefined) {
+      r.say(`    Could not re-read ${envPath} — pin left unchanged.`);
+      return false;
+    }
+    writeEnvFile(envPath, replaceEnvKey(existing, fingerprintKey(p), presented));
+    r.say("    Pin updated. Re-run doctor to verify.");
+  }
+  return false;
+}
+
+async function checkProfile(r: Report, p: CcuProfile, envPath: string, ui: Prompter | undefined): Promise<void> {
+  r.say(`Target "${p.name}" — ${p.ccu.host}:${p.ccu.port} (${p.ccu.https ? "HTTPS" : "HTTP"})`);
+  const outcome = await probeApi(p.ccu);
+  if (outcome.kind !== "ccu") {
+    fail(r, `CCU API not reachable: ${outcome.detail}`);
+    return;
+  }
+  pass(r, "CCU API reachable");
+  if (!(await checkPin(r, p, envPath, ui))) {
+    r.say("  - skipping the login test until the certificate check passes");
+    return;
+  }
+  const login = await testLogin(p.ccu);
+  if (!login.ok) {
+    fail(r, `login failed: ${login.error.message}`);
+    if (login.error.hint) r.say(`      ${login.error.hint}`);
+    return;
+  }
+  const version = login.version ? ` (CCU ${login.version})` : "";
+  pass(r, `login OK as "${p.ccu.user}"${version} — privilege level ${login.role}`);
+  if (login.role === "USER") {
+    r.say("      Note: script-based tools (run_script, create_system_variable,");
+    r.say("      acknowledge_service_messages) need an ADMIN-level CCU user.");
+  }
+}
+
+/** Entry point for `ccu-mcp doctor`. Returns the process exit code. */
+export async function run(argv: string[], io?: PromptIo): Promise<number> {
+  const out = io?.output ?? process.stdout;
+  const r: Report = { say: (text) => out.write(text + "\n"), failures: 0 };
+  let envPath: string;
+  try {
+    envPath = envFileArg(argv);
+    r.say(`ccu-mcp doctor — checking ${resolve(envPath)}`);
+    applyEnvVars(loadEnvFile(envPath));
+  } catch (err) {
+    r.say(`  ✗ ${(err as Error).message}`);
+    return 1;
+  }
+
+  let config;
+  try {
+    config = loadConfig();
+  } catch (err) {
+    r.say(`  ✗ configuration invalid: ${(err as Error).message}`);
+    r.say("    (See README → Configuration errors for what each message means.)");
+    return 1;
+  }
+  r.say(
+    `  ✓ configuration loads: ${config.profiles.length} target(s), default "${config.defaultProfile}"`,
+  );
+
+  // The interactive pin-refresh offer needs someone at a terminal; with piped
+  // stdin (CI, scripts) doctor only reports. Tests opt in by stamping
+  // isTTY=true on their injected input stream.
+  const input = io?.input ?? process.stdin;
+  const ui =
+    input.isTTY === true ? new Prompter(io ?? { input: process.stdin, output: process.stdout }) : undefined;
+  try {
+    for (const p of config.profiles) {
+      r.say("");
+      await checkProfile(r, p, envPath, ui);
+    }
+  } finally {
+    ui?.close();
+  }
+
+  r.say("");
+  if (r.failures > 0) {
+    r.say(`${r.failures} check(s) failed.`);
+    return 1;
+  }
+  r.say("All checks passed.");
+  return 0;
+}

--- a/src/cli/env-writer.ts
+++ b/src/cli/env-writer.ts
@@ -9,7 +9,13 @@ export interface WizardProfile {
   https: boolean;
   tlsFingerprint?: string;
   user: string;
-  password: string;
+  /**
+   * Undefined means "no password decided yet" — the key is then left out of
+   * the file entirely, so loading fails and the server stays in setup mode
+   * until `ccu-mcp secret` writes one. An empty string is a real choice (a
+   * fresh OpenCCU box has no Admin password) and IS written.
+   */
+  password?: string;
   protected: boolean;
   readonly: boolean;
 }
@@ -60,7 +66,7 @@ export function buildEnvContent(
     lines.push(`CCU_${prefix}PORT=${p.port}`);
     lines.push(`CCU_${prefix}HTTPS=${p.https}`);
     lines.push(`CCU_${prefix}USER=${quoteEnvValue(p.user)}`);
-    lines.push(`CCU_${prefix}PASSWORD=${quoteEnvValue(p.password)}`);
+    if (p.password !== undefined) lines.push(`CCU_${prefix}PASSWORD=${quoteEnvValue(p.password)}`);
     if (p.tlsFingerprint) lines.push(`CCU_${prefix}TLS_FINGERPRINT=${p.tlsFingerprint}`);
     if (p.protected) lines.push(`CCU_${prefix}PROTECTED=true`);
     if (p.readonly) lines.push(`CCU_${prefix}READONLY=true`);

--- a/src/cli/env-writer.ts
+++ b/src/cli/env-writer.ts
@@ -1,0 +1,125 @@
+import { readFileSync, writeFileSync, renameSync } from "node:fs";
+import { envPrefix } from "../config.js";
+
+/** What the wizard collects per CCU target. */
+export interface WizardProfile {
+  name: string;
+  host: string;
+  port: number;
+  https: boolean;
+  tlsFingerprint?: string;
+  user: string;
+  password: string;
+  protected: boolean;
+  readonly: boolean;
+}
+
+// The connection-defining keys the wizard owns inside the .env file — flat,
+// profile-scoped (ANY prefix, so a removed profile's leftovers don't linger and
+// break the next load), plus the profile roster itself. Everything else in the
+// file (MCP_*, LOG_LEVEL, rate limits, timeouts) belongs to the operator and
+// survives a rewrite — same contract as the auth-token persistence.
+const MANAGED_SUFFIXES = "HOST|PORT|HTTPS|USER|PASSWORD|TLS_FINGERPRINT|TLS_VERIFY|CA_CERT|PROTECTED|READONLY";
+export const MANAGED_KEY_RE = new RegExp(
+  `^CCU_(PROFILES|DEFAULT_PROFILE|(${MANAGED_SUFFIXES})|[A-Z0-9_]+_(${MANAGED_SUFFIXES}))=`,
+);
+
+/**
+ * Quote a value if the dotenv format needs it. Node's env-file parser (and
+ * util.parseEnv, which doctor uses to read the file back) treats an unquoted
+ * `#` as a comment start and trims whitespace — and it does NOT process
+ * escape sequences inside quotes, so the only way to represent a value is to
+ * pick a quote character (", ', or `) that the value itself doesn't contain.
+ */
+export function quoteEnvValue(value: string): string {
+  if (value !== "" && !/[\s#"'`]/.test(value)) return value;
+  for (const q of ['"', "'", "`"]) {
+    if (!value.includes(q)) return `${q}${value}${q}`;
+  }
+  throw new Error(
+    'value contains all three quote characters (", \' and `) and cannot be stored in a dotenv file',
+  );
+}
+
+/** Render the managed block: flat vars for one target, CCU_PROFILES for more. */
+export function buildEnvContent(profiles: WizardProfile[], defaultProfile: string): string {
+  const lines: string[] = [
+    "# Written by `ccu-mcp init` — https://github.com/claymore666/ccu-mcp#configuration",
+  ];
+  const emit = (prefix: string, p: WizardProfile): void => {
+    lines.push(`CCU_${prefix}HOST=${quoteEnvValue(p.host)}`);
+    lines.push(`CCU_${prefix}PORT=${p.port}`);
+    lines.push(`CCU_${prefix}HTTPS=${p.https}`);
+    lines.push(`CCU_${prefix}USER=${quoteEnvValue(p.user)}`);
+    lines.push(`CCU_${prefix}PASSWORD=${quoteEnvValue(p.password)}`);
+    if (p.tlsFingerprint) lines.push(`CCU_${prefix}TLS_FINGERPRINT=${p.tlsFingerprint}`);
+    if (p.protected) lines.push(`CCU_${prefix}PROTECTED=true`);
+    if (p.readonly) lines.push(`CCU_${prefix}READONLY=true`);
+  };
+  if (profiles.length === 1) {
+    emit("", profiles[0]);
+  } else {
+    lines.push(`CCU_PROFILES=${profiles.map((p) => p.name).join(",")}`);
+    lines.push(`CCU_DEFAULT_PROFILE=${defaultProfile}`);
+    for (const p of profiles) {
+      lines.push("");
+      lines.push(`# --- target: ${p.name} ---`);
+      emit(`${envPrefix(p.name)}_`, p);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Merge the managed block into an existing file's content: managed keys are
+ * replaced, everything else (operator vars, comments) is preserved verbatim.
+ * Returns the keys that were replaced so the wizard can ask before clobbering.
+ */
+export function mergeEnvContent(existing: string, managed: string): { content: string; replaced: string[] } {
+  const foreign: string[] = [];
+  const replaced: string[] = [];
+  for (const line of existing.split(/\r?\n/)) {
+    if (MANAGED_KEY_RE.test(line)) {
+      replaced.push(line.slice(0, line.indexOf("=")));
+      continue;
+    }
+    if (line.trim() === "") continue;
+    foreign.push(line);
+  }
+  const content = managed + (foreign.length > 0 ? "\n" + foreign.join("\n") + "\n" : "");
+  return { content, replaced };
+}
+
+/** Replace (or append) one KEY=value line in existing file content. */
+export function replaceEnvKey(content: string, key: string, value: string): string {
+  const lines = content.split(/\r?\n/);
+  let done = false;
+  const out = lines.map((line) => {
+    if (!done && line.startsWith(`${key}=`)) {
+      done = true;
+      return `${key}=${value}`;
+    }
+    return line;
+  });
+  if (!done) {
+    while (out.length > 0 && out[out.length - 1] === "") out.pop();
+    out.push(`${key}=${value}`, "");
+  }
+  return out.join("\n");
+}
+
+/** Read an existing env file; undefined when it doesn't exist. */
+export function readEnvFile(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+/** Write mode 0600 via tmp+rename: the file holds the CCU password. */
+export function writeEnvFile(path: string, content: string): void {
+  const tmpPath = path + ".tmp";
+  writeFileSync(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
+  renameSync(tmpPath, path);
+}

--- a/src/cli/env-writer.ts
+++ b/src/cli/env-writer.ts
@@ -41,10 +41,19 @@ export function quoteEnvValue(value: string): string {
   );
 }
 
-/** Render the managed block: flat vars for one target, CCU_PROFILES for more. */
-export function buildEnvContent(profiles: WizardProfile[], defaultProfile: string): string {
+/**
+ * Render the managed block: flat vars for one target, CCU_PROFILES for more.
+ * `forceProfileForm` keeps the CCU_PROFILES form even for a single target —
+ * the setup tool needs it when the one profile has a real name (a flat write
+ * would silently drop the name the conversation established).
+ */
+export function buildEnvContent(
+  profiles: WizardProfile[],
+  defaultProfile: string,
+  forceProfileForm = false,
+): string {
   const lines: string[] = [
-    "# Written by `ccu-mcp init` — https://github.com/claymore666/ccu-mcp#configuration",
+    "# Written by ccu-mcp setup — https://github.com/claymore666/ccu-mcp#configuration",
   ];
   const emit = (prefix: string, p: WizardProfile): void => {
     lines.push(`CCU_${prefix}HOST=${quoteEnvValue(p.host)}`);
@@ -56,7 +65,7 @@ export function buildEnvContent(profiles: WizardProfile[], defaultProfile: strin
     if (p.protected) lines.push(`CCU_${prefix}PROTECTED=true`);
     if (p.readonly) lines.push(`CCU_${prefix}READONLY=true`);
   };
-  if (profiles.length === 1) {
+  if (profiles.length === 1 && !forceProfileForm) {
     emit("", profiles[0]);
   } else {
     lines.push(`CCU_PROFILES=${profiles.map((p) => p.name).join(",")}`);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,262 @@
+import { resolve } from "node:path";
+import { Prompter, type PromptIo } from "./prompt.js";
+import { envFileArg, displayFingerprint } from "./common.js";
+import {
+  buildEnvContent,
+  mergeEnvContent,
+  readEnvFile,
+  writeEnvFile,
+  type WizardProfile,
+} from "./env-writer.js";
+import { probeApi, probeConfig, fetchCert, testLogin, type CertInfo } from "./probe.js";
+import { envPrefix } from "../config.js";
+import type { CcuConfig } from "../ccu/types.js";
+
+const DETECT_TIMEOUT = 3_000;
+
+interface Detected {
+  port: number;
+  https: boolean;
+}
+
+/** Try the two stock CCU ports to pre-fill defaults. Never asks anything. */
+async function detectEndpoint(host: string): Promise<Detected | undefined> {
+  for (const candidate of [
+    { port: 443, https: true },
+    { port: 80, https: false },
+  ]) {
+    const outcome = await probeApi(probeConfig(host, candidate.port, candidate.https, DETECT_TIMEOUT));
+    if (outcome.kind === "ccu") return candidate;
+  }
+  return undefined;
+}
+
+function toCcuConfig(p: WizardProfile): CcuConfig {
+  return {
+    host: p.host,
+    port: p.port,
+    https: p.https,
+    tlsVerify: false,
+    tlsFingerprint: p.tlsFingerprint,
+    user: p.user,
+    password: p.password,
+    timeout: 10_000,
+    scriptTimeout: 30_000,
+  };
+}
+
+function describeCert(cert: CertInfo): string[] {
+  const lines: string[] = [];
+  if (cert.subjectCN) lines.push(`  Subject: ${cert.subjectCN}`);
+  if (cert.issuerCN) lines.push(`  Issuer:  ${cert.issuerCN}`);
+  if (cert.validFrom && cert.validTo) lines.push(`  Valid:   ${cert.validFrom} — ${cert.validTo}`);
+  lines.push(`  SHA-256: ${displayFingerprint(cert.fingerprint256)}`);
+  return lines;
+}
+
+/** Host/port/HTTPS for one target, looping until reachable or accepted as-is. */
+async function askEndpoint(ui: Prompter): Promise<{ host: string; port: number; https: boolean }> {
+  for (;;) {
+    const host = await ui.ask("CCU hostname or IP", {
+      validate: (v) => (v === "" ? "A hostname or IP is required." : null),
+    });
+    ui.say(`Probing ${host} ...`);
+    const detected = await detectEndpoint(host);
+    if (detected) {
+      ui.say(`  Found the CCU API on port ${detected.port} (${detected.https ? "HTTPS" : "HTTP"}).`);
+    } else {
+      ui.say("  No CCU API on the standard ports (443/80) — enter the port manually.");
+    }
+    const https = await ui.askYesNo("Use HTTPS?", detected ? detected.https : true);
+    const port = Number(
+      await ui.ask("Port", {
+        def: detected && detected.https === https ? String(detected.port) : https ? "443" : "80",
+        validate: (v) =>
+          /^\d+$/.test(v) && Number(v) >= 1 && Number(v) <= 65535 ? null : "Port must be 1-65535.",
+      }),
+    );
+    if (detected && detected.port === port && detected.https === https) {
+      return { host, port, https };
+    }
+    const outcome = await probeApi(probeConfig(host, port, https, DETECT_TIMEOUT));
+    if (outcome.kind === "ccu") {
+      ui.say("  CCU API found.");
+      return { host, port, https };
+    }
+    ui.say(`  No CCU API there: ${outcome.detail}`);
+    if (await ui.askYesNo("Continue with these settings anyway?", false)) {
+      return { host, port, https };
+    }
+  }
+}
+
+/** Credentials + test-login loop for one target. Returns null on abort. */
+async function askCredentials(
+  ui: Prompter,
+  base: Omit<WizardProfile, "user" | "password">,
+): Promise<{ user: string; password: string } | null> {
+  for (;;) {
+    const user = await ui.ask("CCU user", { def: "Admin" });
+    const password = await ui.askHidden("CCU password (input hidden)");
+    ui.say("Testing login ...");
+    const result = await testLogin(toCcuConfig({ ...base, user, password }));
+    if (result.ok) {
+      const version = result.version ? ` (CCU ${result.version})` : "";
+      if (result.role === "ADMIN") {
+        ui.say(`  Login OK${version} — privilege level ADMIN: all tools available.`);
+      } else if (result.role === "USER") {
+        ui.say(`  Login OK${version} — privilege level USER.`);
+        ui.say(
+          "  Note: script-based tools (run_script, create_system_variable, " +
+            "acknowledge_service_messages) need an ADMIN-level CCU user and will fail for this one.",
+        );
+      } else {
+        ui.say(`  Login OK${version} — privilege level could not be determined.`);
+      }
+      return { user, password };
+    }
+    ui.say(`  Login failed: ${result.error.message}`);
+    if (result.error.hint) ui.say(`  ${result.error.hint}`);
+    if (await ui.askYesNo("Re-enter user/password?", true)) continue;
+    if (await ui.askYesNo("Save this target with untested credentials anyway?", false)) {
+      return { user, password };
+    }
+    return null;
+  }
+}
+
+async function runWizard(ui: Prompter, envPath: string): Promise<number> {
+  ui.say("ccu-mcp setup — probes your CCU, pins its TLS certificate, tests the");
+  ui.say(`login, and writes the result to ${envPath}.`);
+  ui.say("");
+
+  const multi = await ui.askYesNo("Set up multiple CCU targets (e.g. prod/dev)?", false);
+  const profiles: WizardProfile[] = [];
+
+  for (;;) {
+    let name = "default";
+    if (multi) {
+      name = await ui.ask("Profile name", {
+        def: profiles.length === 0 ? "prod" : undefined,
+        validate: (v) => {
+          if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(v)) {
+            return "Use letters, digits, dot, dash or underscore.";
+          }
+          if (profiles.some((p) => envPrefix(p.name) === envPrefix(v))) {
+            return `Collides with already-configured "${profiles.find((p) => envPrefix(p.name) === envPrefix(v))?.name}".`;
+          }
+          return null;
+        },
+      });
+    }
+
+    const endpoint = await askEndpoint(ui);
+
+    let tlsFingerprint: string | undefined;
+    if (endpoint.https) {
+      try {
+        const cert = await fetchCert(endpoint.host, endpoint.port);
+        ui.say("The CCU presents this TLS certificate:");
+        for (const line of describeCert(cert)) ui.say(line);
+        if (await ui.askYesNo("Pin this certificate's fingerprint (recommended)?", true)) {
+          tlsFingerprint = cert.fingerprint256;
+        } else {
+          ui.say("  Not pinned — the connection will be encrypted but UNVERIFIED (MITM-exposed).");
+        }
+      } catch (err) {
+        ui.say(`  Could not read the certificate: ${(err as Error).message}`);
+        ui.say("  Continuing without a pin — the connection will be unverified.");
+      }
+    }
+
+    const base: Omit<WizardProfile, "user" | "password"> = {
+      name,
+      host: endpoint.host,
+      port: endpoint.port,
+      https: endpoint.https,
+      tlsFingerprint,
+      protected: false,
+      readonly: false,
+    };
+    const creds = await askCredentials(ui, base);
+    if (creds === null) {
+      ui.say("Aborted — nothing written.");
+      return 1;
+    }
+
+    let prot = false;
+    let ro = false;
+    if (multi) {
+      prot = await ui.askYesNo("Protect this target (write tools then require confirm:true)?", false);
+      ro = await ui.askYesNo("Make this target read-only (write tools refused entirely)?", false);
+    }
+    profiles.push({ ...base, ...creds, protected: prot, readonly: ro });
+
+    if (!multi || !(await ui.askYesNo("Add another CCU target?", false))) break;
+  }
+
+  let defaultProfile = profiles[0].name;
+  if (profiles.length > 1) {
+    const names = profiles.map((p) => p.name);
+    defaultProfile = await ui.askChoice("Default target", names, names[0]);
+  }
+
+  const managed = buildEnvContent(profiles, defaultProfile);
+  const existing = readEnvFile(envPath);
+  let content = managed;
+  if (existing !== undefined) {
+    const merged = mergeEnvContent(existing, managed);
+    if (merged.replaced.length > 0) {
+      ui.say(`${envPath} already configures a CCU (${[...new Set(merged.replaced)].join(", ")}).`);
+      if (!(await ui.askYesNo("Replace those settings? Everything else in the file is kept.", true))) {
+        ui.say("Nothing written.");
+        return 1;
+      }
+    }
+    content = merged.content;
+  }
+  writeEnvFile(envPath, content);
+  const absPath = resolve(envPath);
+  ui.say("");
+  ui.say(`Wrote ${absPath} (mode 0600).`);
+
+  ui.say("");
+  ui.say("Add the server to an MCP client — .mcp.json (Claude Code) or");
+  ui.say("claude_desktop_config.json (Claude Desktop):");
+  ui.say("");
+  ui.say(
+    JSON.stringify(
+      {
+        mcpServers: {
+          "ccu-mcp": { command: "npx", args: ["ccu-mcp", "--stdio", "--env", absPath] },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  ui.say("");
+  ui.say("Or via the Claude Code CLI:");
+  ui.say(`  claude mcp add ccu-mcp -- npx ccu-mcp --stdio --env ${absPath}`);
+  ui.say("");
+  ui.say(`Re-check this configuration anytime with: ccu-mcp doctor --env ${absPath}`);
+  return 0;
+}
+
+/** Entry point for `ccu-mcp init`. Returns the process exit code. */
+export async function run(argv: string[], io?: PromptIo): Promise<number> {
+  const envPath = envFileArg(argv);
+  const ui = new Prompter(io ?? { input: process.stdin, output: process.stdout });
+  try {
+    return await runWizard(ui, envPath);
+  } catch (err) {
+    if ((err as Error).message === "input closed") {
+      process.stderr.write("ccu-mcp init: input closed — nothing written.\n");
+      return 130;
+    }
+    process.stderr.write(`ccu-mcp init: ${(err as Error).message}\n`);
+    return 1;
+  } finally {
+    ui.close();
+  }
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -39,7 +39,9 @@ function toCcuConfig(p: WizardProfile): CcuConfig {
     tlsVerify: false,
     tlsFingerprint: p.tlsFingerprint,
     user: p.user,
-    password: p.password,
+    // The file-level "not decided yet" distinction has no meaning on the wire:
+    // a login attempt sends an empty password either way.
+    password: p.password ?? "",
     timeout: 10_000,
     scriptTimeout: 30_000,
   };

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import { Prompter, type PromptIo } from "./prompt.js";
-import { envFileArg, displayFingerprint } from "./common.js";
+import { envFileArg, displayFingerprint, selfCommand } from "./common.js";
 import {
   buildEnvContent,
   mergeEnvContent,
@@ -239,9 +239,13 @@ async function runWizard(ui: Prompter, envPath: string): Promise<number> {
   );
   ui.say("");
   ui.say("Or via the Claude Code CLI:");
+  // Stays `npx ccu-mcp` on purpose, unlike the next-step hints below: this
+  // line goes into a DURABLE client config. argv[1] may point inside npx's
+  // cache (~/.npm/_npx/<hash>/…), which is garbage-collected — fine for a
+  // command to run now, wrong to bake into a permanent MCP server entry.
   ui.say(`  claude mcp add ccu-mcp -- npx ccu-mcp --stdio --env ${absPath}`);
   ui.say("");
-  ui.say(`Re-check this configuration anytime with: ccu-mcp doctor --env ${absPath}`);
+  ui.say(`Re-check this configuration anytime with: ${selfCommand("doctor", "--env", absPath)}`);
   return 0;
 }
 

--- a/src/cli/probe.ts
+++ b/src/cli/probe.ts
@@ -1,0 +1,170 @@
+import { connect as tlsConnect } from "node:tls";
+import { isIP } from "node:net";
+import { tmpdir } from "node:os";
+import { CcuClient, normalizeFingerprint } from "../ccu/client.js";
+import { SessionManager } from "../ccu/session.js";
+import { CcuError } from "../middleware/error-mapper.js";
+import type { CcuConfig, StructuredError } from "../ccu/types.js";
+import { Logger } from "../logger.js";
+
+/**
+ * The wizard talks to the user on stdout itself; the structured JSON logger
+ * the client/session classes expect would only interleave noise. Expected
+ * failures (unreachable probe, wrong password) are reported by the wizard.
+ */
+class SilentLogger extends Logger {
+  override error(): void {}
+  override warn(): void {}
+  override info(): void {}
+  override debug(): void {}
+}
+
+export const silentLogger: Logger = new SilentLogger();
+
+/** A CcuConfig for probing: no TLS verification, short timeout. */
+export function probeConfig(host: string, port: number, https: boolean, timeout = 5000): CcuConfig {
+  return {
+    host,
+    port,
+    https,
+    tlsVerify: false,
+    user: "",
+    password: "",
+    timeout,
+    scriptTimeout: 30_000,
+  };
+}
+
+export type ProbeKind = "ccu" | "not-ccu" | "tls" | "timeout" | "unreachable";
+
+export interface ProbeOutcome {
+  kind: ProbeKind;
+  detail: string;
+}
+
+/**
+ * Classify what answers at ${host}:${port}/api/homematic.cgi. Sends a bogus
+ * JSON-RPC method: a CCU replies with a JSON-RPC error envelope (proof of the
+ * API without needing credentials); anything else is classified by how it
+ * fails. TLS settings on `ccu` are ignored — reachability is the question
+ * here, pin verification is the doctor's separate check.
+ */
+export async function probeApi(ccu: CcuConfig): Promise<ProbeOutcome> {
+  const client = new CcuClient(
+    { ...ccu, tlsFingerprint: undefined, caCert: undefined, tlsVerify: false },
+    silentLogger,
+  );
+  try {
+    await client.call("CCU.probe", {}, ccu.timeout);
+    return { kind: "ccu", detail: "JSON-RPC endpoint answered" };
+  } catch (err) {
+    if (!(err instanceof CcuError)) throw err;
+    const s = err.structured;
+    if (s.error === "TIMEOUT") return { kind: "timeout", detail: s.message };
+    if (s.error === "TLS_ERROR") return { kind: "tls", detail: s.message };
+    if (s.error === "UNREACHABLE") return { kind: "unreachable", detail: s.message };
+    if (s.message.includes("Invalid JSON response") || s.message.includes("no JSON-RPC error in body")) {
+      return { kind: "not-ccu", detail: s.message };
+    }
+    // The endpoint answered with a JSON-RPC error envelope — it IS a CCU API.
+    return { kind: "ccu", detail: s.message };
+  }
+}
+
+export interface CertInfo {
+  /** SHA-256 fingerprint as Node reports it: colon-separated uppercase hex. */
+  fingerprint256: string;
+  subjectCN?: string;
+  issuerCN?: string;
+  validFrom?: string;
+  validTo?: string;
+}
+
+/**
+ * Fetch the peer certificate without verifying it — the whole point is to
+ * show the operator what the CCU presents so they can decide to pin it.
+ */
+export function fetchCert(host: string, port: number, timeoutMs = 5000): Promise<CertInfo> {
+  return new Promise((resolve, reject) => {
+    const socket = tlsConnect({
+      host,
+      port,
+      rejectUnauthorized: false,
+      // SNI must be a hostname; tls.connect throws on an IP literal.
+      ...(isIP(host) === 0 ? { servername: host } : {}),
+    });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`TLS handshake timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    socket.once("secureConnect", () => {
+      clearTimeout(timer);
+      const cert = socket.getPeerCertificate();
+      socket.destroy();
+      if (!cert || !cert.fingerprint256) {
+        reject(new Error("Peer presented no certificate"));
+        return;
+      }
+      // subject/issuer CN can be a string array for multi-valued RDNs.
+      const first = (v: string | string[] | undefined): string | undefined =>
+        Array.isArray(v) ? v[0] : v;
+      resolve({
+        fingerprint256: cert.fingerprint256,
+        subjectCN: first(cert.subject?.CN),
+        issuerCN: first(cert.issuer?.CN),
+        validFrom: cert.valid_from,
+        validTo: cert.valid_to,
+      });
+    });
+    socket.once("error", (err) => {
+      clearTimeout(timer);
+      socket.destroy();
+      reject(err);
+    });
+  });
+}
+
+/** True when the presented fingerprint matches the pinned one (colon/case-insensitive). */
+export function fingerprintMatches(pinned: string, presented: string): boolean {
+  return normalizeFingerprint(pinned) === normalizeFingerprint(presented);
+}
+
+export type CcuRole = "ADMIN" | "USER" | "UNKNOWN";
+
+export type LoginResult =
+  | { ok: true; role: CcuRole; version?: string }
+  | { ok: false; error: StructuredError };
+
+/**
+ * Log in with the profile's real TLS settings, detect the privilege level,
+ * log out again. Role detection is the same capability probe get_system_info
+ * uses: `CCU.getVersion` is ADMIN-only per the OCCU method table, so a result
+ * means ADMIN and an access denial means USER.
+ */
+export async function testLogin(ccu: CcuConfig): Promise<LoginResult> {
+  // Unique throwaway session file: never touch (or restore) the running
+  // server's persisted session, and leave nothing behind — logout clears it.
+  const sessionFile = `ccu-mcp-cli-${process.pid}-${Date.now()}.json`;
+  const session = new SessionManager(ccu, silentLogger, tmpdir(), sessionFile);
+  try {
+    await session.login();
+  } catch (err) {
+    if (err instanceof CcuError) return { ok: false, error: err.structured };
+    throw err;
+  }
+  try {
+    const version = await session.call("CCU.getVersion");
+    if (typeof version === "string" && version !== "") {
+      return { ok: true, role: "ADMIN", version };
+    }
+    return { ok: true, role: "USER" };
+  } catch (err) {
+    if (err instanceof CcuError && err.structured.error === "AUTH") {
+      return { ok: true, role: "USER" };
+    }
+    // Login itself worked; the role probe failed for some other reason.
+    return { ok: true, role: "UNKNOWN" };
+  } finally {
+    await session.logout();
+  }
+}

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,0 +1,132 @@
+import { createInterface, type Interface } from "node:readline";
+
+export interface PromptIo {
+  input: NodeJS.ReadableStream & { isTTY?: boolean };
+  output: NodeJS.WritableStream;
+}
+
+/**
+ * Minimal interactive prompter over injected streams, so tests can script a
+ * whole wizard run through a PassThrough. One persistent readline interface
+ * for the prompter's lifetime: a fresh interface per question would buffer a
+ * piped multi-line answer chunk internally and discard the rest on close.
+ */
+export class Prompter {
+  private readonly rl: Interface;
+  private readonly output: NodeJS.WritableStream;
+  private muted = false;
+  private closed = false;
+  // Piped input can deliver many answers in one chunk; readline emits them as
+  // `line` events whether or not a question is pending, so unconsumed lines
+  // must be queued — rl.question() would silently drop them between prompts.
+  private readonly lines: string[] = [];
+  private waiter: { resolve: (line: string) => void; reject: (err: Error) => void } | null = null;
+
+  constructor(io: PromptIo) {
+    this.output = io.output;
+    this.rl = createInterface({
+      input: io.input,
+      output: io.output,
+      terminal: io.input.isTTY === true,
+    });
+    // Echo suppression for askHidden(): in terminal mode readline echoes every
+    // keystroke through this internal hook; while muted, swallow it. Non-TTY
+    // input never echoes, so the hook being absent there is fine.
+    const rlInternal = this.rl as unknown as { _writeToOutput?: (s: string) => void };
+    const original = rlInternal._writeToOutput?.bind(this.rl);
+    if (original) {
+      rlInternal._writeToOutput = (s: string): void => {
+        if (!this.muted) original(s);
+      };
+    }
+    this.rl.on("line", (line) => {
+      if (this.waiter) {
+        const w = this.waiter;
+        this.waiter = null;
+        w.resolve(line);
+      } else {
+        this.lines.push(line);
+      }
+    });
+    this.rl.on("close", () => {
+      this.closed = true;
+      if (this.waiter) {
+        const w = this.waiter;
+        this.waiter = null;
+        w.reject(new Error("input closed"));
+      }
+    });
+    // Ctrl-C during a question: end the wizard instead of leaving readline in
+    // its default paused state. question() below rejects via the close event.
+    this.rl.on("SIGINT", () => {
+      this.output.write("\n");
+      this.rl.close();
+    });
+  }
+
+  say(text: string): void {
+    this.output.write(text + "\n");
+  }
+
+  private question(prompt: string): Promise<string> {
+    this.output.write(prompt);
+    const queued = this.lines.shift();
+    if (queued !== undefined) return Promise.resolve(queued);
+    if (this.closed) return Promise.reject(new Error("input closed"));
+    return new Promise((resolve, reject) => {
+      this.waiter = { resolve, reject };
+    });
+  }
+
+  /**
+   * Ask for a line of input. An empty answer returns `def` when one is given
+   * (shown in brackets). Re-asks while `validate` returns an error string.
+   */
+  async ask(
+    label: string,
+    opts: { def?: string; validate?: (value: string) => string | null } = {},
+  ): Promise<string> {
+    for (;;) {
+      const suffix = opts.def ? ` [${opts.def}]` : "";
+      const raw = (await this.question(`${label}${suffix}: `)).trim();
+      const value = raw === "" && opts.def !== undefined ? opts.def : raw;
+      const error = opts.validate?.(value) ?? null;
+      if (error === null) return value;
+      this.say(`  ${error}`);
+    }
+  }
+
+  /** Ask without echoing the typed input (passwords). */
+  async askHidden(label: string): Promise<string> {
+    this.output.write(`${label}: `);
+    this.muted = true;
+    try {
+      return await this.question("");
+    } finally {
+      this.muted = false;
+      this.output.write("\n");
+    }
+  }
+
+  async askYesNo(label: string, def: boolean): Promise<boolean> {
+    const hint = def ? "Y/n" : "y/N";
+    for (;;) {
+      const raw = (await this.question(`${label} [${hint}]: `)).trim().toLowerCase();
+      if (raw === "") return def;
+      if (raw === "y" || raw === "yes") return true;
+      if (raw === "n" || raw === "no") return false;
+      this.say("  Please answer y or n.");
+    }
+  }
+
+  async askChoice(label: string, choices: string[], def: string): Promise<string> {
+    return this.ask(`${label} (${choices.join("/")})`, {
+      def,
+      validate: (v) => (choices.includes(v) ? null : `Must be one of: ${choices.join(", ")}`),
+    });
+  }
+
+  close(): void {
+    this.rl.close();
+  }
+}

--- a/src/cli/secret.ts
+++ b/src/cli/secret.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import { Prompter, type PromptIo } from "./prompt.js";
-import { envFileArg, loadEnvFile } from "./common.js";
+import { envFileArg, loadEnvFile, selfCommand } from "./common.js";
 import { quoteEnvValue, readEnvFile, replaceEnvKey, writeEnvFile } from "./env-writer.js";
 import { envPrefix } from "../config.js";
 
@@ -20,7 +20,7 @@ export async function run(argv: string[], io?: PromptIo): Promise<number> {
     envPath = envFileArg(argv);
     content = readEnvFile(envPath);
     if (content === undefined) {
-      say(`ccu-mcp secret: ${resolve(envPath)} does not exist — run \`ccu-mcp init\` or the MCP setup flow first.`);
+      say(`ccu-mcp secret: ${resolve(envPath)} does not exist — run \`${selfCommand("init", "--env", envPath)}\` or the MCP setup flow first.`);
       return 1;
     }
     vars = loadEnvFile(envPath);
@@ -38,7 +38,7 @@ export async function run(argv: string[], io?: PromptIo): Promise<number> {
   if (names.length > 0) {
     if (!profileArg) {
       say(`This file configures named targets (${names.join(", ")}) — say which one:`);
-      say(`  ccu-mcp secret <profile> --env ${envPath}`);
+      say(`  ${selfCommand("secret", "<profile>", "--env", envPath)}`);
       return 1;
     }
     const match = names.find((n) => n.toLowerCase() === profileArg.toLowerCase());
@@ -51,7 +51,7 @@ export async function run(argv: string[], io?: PromptIo): Promise<number> {
   } else {
     if (profileArg) {
       say(`ccu-mcp secret: this file uses the single-CCU form — no profile name needed:`);
-      say(`  ccu-mcp secret --env ${envPath}`);
+      say(`  ${selfCommand("secret", "--env", envPath)}`);
       return 1;
     }
     key = "CCU_PASSWORD";
@@ -66,7 +66,7 @@ export async function run(argv: string[], io?: PromptIo): Promise<number> {
     }
     writeEnvFile(envPath, replaceEnvKey(content, key, quoteEnvValue(password)));
     ui.say(`Wrote ${key} to ${resolve(envPath)} (mode 0600).`);
-    ui.say(`Verify with: ccu-mcp doctor --env ${envPath}`);
+    ui.say(`Verify with: ${selfCommand("doctor", "--env", envPath)}`);
     return 0;
   } catch (err) {
     if ((err as Error).message === "input closed") {

--- a/src/cli/secret.ts
+++ b/src/cli/secret.ts
@@ -37,8 +37,12 @@ export async function run(argv: string[], io?: PromptIo): Promise<number> {
   let target: string;
   if (names.length > 0) {
     if (!profileArg) {
-      say(`This file configures named targets (${names.join(", ")}) — say which one:`);
-      say(`  ${selfCommand("secret", "<profile>", "--env", envPath)}`);
+      // One ready-to-run line per target rather than a `<profile>` placeholder:
+      // selfCommand shell-quotes anything with metacharacters, so the
+      // placeholder came out as `secret '<profile>'` — and each target needs
+      // its own invocation anyway, which the list makes obvious.
+      say(`This file configures named targets (${names.join(", ")}) — one password each:`);
+      for (const n of names) say(`  ${selfCommand("secret", n, "--env", envPath)}`);
       return 1;
     }
     const match = names.find((n) => n.toLowerCase() === profileArg.toLowerCase());

--- a/src/cli/secret.ts
+++ b/src/cli/secret.ts
@@ -1,0 +1,81 @@
+import { resolve } from "node:path";
+import { Prompter, type PromptIo } from "./prompt.js";
+import { envFileArg, loadEnvFile } from "./common.js";
+import { quoteEnvValue, readEnvFile, replaceEnvKey, writeEnvFile } from "./env-writer.js";
+import { envPrefix } from "../config.js";
+
+/**
+ * `ccu-mcp secret [profile]` — store ONE value, the CCU password, into the env
+ * file via a local hidden prompt. This is the hand-off the MCP setup flow
+ * (tools/setup.ts) prints so the password never travels through the model or
+ * the chat transcript; it is also the documented rotation path.
+ */
+export async function run(argv: string[], io?: PromptIo): Promise<number> {
+  const out = io?.output ?? process.stdout;
+  const say = (text: string): void => void out.write(text + "\n");
+  let envPath: string;
+  let vars: Record<string, string>;
+  let content: string | undefined;
+  try {
+    envPath = envFileArg(argv);
+    content = readEnvFile(envPath);
+    if (content === undefined) {
+      say(`ccu-mcp secret: ${resolve(envPath)} does not exist — run \`ccu-mcp init\` or the MCP setup flow first.`);
+      return 1;
+    }
+    vars = loadEnvFile(envPath);
+  } catch (err) {
+    say(`ccu-mcp secret: ${(err as Error).message}`);
+    return 1;
+  }
+
+  // The profile name is the first bare positional argument (skip --env's value).
+  const profileArg = argv.find((a, i) => !a.startsWith("--") && argv[i - 1] !== "--env");
+
+  const names = vars.CCU_PROFILES?.split(",").map((s) => s.trim()).filter(Boolean) ?? [];
+  let key: string;
+  let target: string;
+  if (names.length > 0) {
+    if (!profileArg) {
+      say(`This file configures named targets (${names.join(", ")}) — say which one:`);
+      say(`  ccu-mcp secret <profile> --env ${envPath}`);
+      return 1;
+    }
+    const match = names.find((n) => n.toLowerCase() === profileArg.toLowerCase());
+    if (!match) {
+      say(`ccu-mcp secret: "${profileArg}" is not one of the configured targets (${names.join(", ")}).`);
+      return 1;
+    }
+    key = `CCU_${envPrefix(match)}_PASSWORD`;
+    target = `${vars[`CCU_${envPrefix(match)}_USER`] || "Admin"}@${vars[`CCU_${envPrefix(match)}_HOST`] || match}`;
+  } else {
+    if (profileArg) {
+      say(`ccu-mcp secret: this file uses the single-CCU form — no profile name needed:`);
+      say(`  ccu-mcp secret --env ${envPath}`);
+      return 1;
+    }
+    key = "CCU_PASSWORD";
+    target = `${vars.CCU_USER || "Admin"}@${vars.CCU_HOST || "CCU"}`;
+  }
+
+  const ui = new Prompter(io ?? { input: process.stdin, output: process.stdout });
+  try {
+    const password = await ui.askHidden(`CCU password for ${target} (input hidden)`);
+    if (password === "") {
+      ui.say("  Storing an EMPTY password (normal for a fresh OpenCCU dev box).");
+    }
+    writeEnvFile(envPath, replaceEnvKey(content, key, quoteEnvValue(password)));
+    ui.say(`Wrote ${key} to ${resolve(envPath)} (mode 0600).`);
+    ui.say(`Verify with: ccu-mcp doctor --env ${envPath}`);
+    return 0;
+  } catch (err) {
+    if ((err as Error).message === "input closed") {
+      process.stderr.write("ccu-mcp secret: input closed — nothing written.\n");
+      return 130;
+    }
+    process.stderr.write(`ccu-mcp secret: ${(err as Error).message}\n`);
+    return 1;
+  } finally {
+    ui.close();
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,7 +91,7 @@ export interface AppConfig {
  * the actual prefix, once in the duplicate-detection loop, and once inside an
  * error message that had to agree with both (issue #124).
  */
-function envPrefix(name: string): string {
+export function envPrefix(name: string): string {
   return name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -204,10 +204,24 @@ export function loadConfig(): AppConfig {
     }
   };
 
+  // The flat form's password must be PRESENT, but may be empty: a fresh OpenCCU
+  // box has no Admin password, and rejecting "" left it unconfigurable — the
+  // setup wizard's own `ccu-mcp secret` writes an empty value and says it is
+  // normal, then the server refused to start on it. Absence stays an error: it
+  // is what distinguishes "not entered yet" from "chosen to be empty", and so
+  // is what holds the server in setup mode until the secret has been stored.
+  const requirePasswordEnv = (envName: string): string => {
+    const value = process.env[envName];
+    if (value === undefined) {
+      throw new Error(`${envName} environment variable is required — run \`ccu-mcp secret\` to store one (an empty password is allowed)`);
+    }
+    return value;
+  };
+
   // Build one named profile from CCU_<PREFIX>_* env vars (issue #69). These are
   // read DYNAMICALLY (template-literal keys), so the env-example-sync test's
   // literal scan doesn't see them — intentional; they're documented as comments
-  // in .env.example. Password may be empty (OpenCCU dev boxes default to it).
+  // in .env.example.
   const buildProfile = (name: string): CcuProfile => {
     const p = envPrefix(name);
     const get = (suffix: string): string | undefined => process.env[`CCU_${p}_${suffix}`]?.trim() || undefined;
@@ -226,6 +240,9 @@ export function loadConfig(): AppConfig {
         tlsFingerprint: get("TLS_FINGERPRINT"),
         caCert: readCaCert(`CCU_${p}_CA_CERT`, get("CA_CERT")),
         user: get("USER") || "Admin",
+        // Absent means empty here, unlike the flat form below — a named
+        // profile has never required the key (issue #69) and OpenCCU dev
+        // targets are configured exactly that way.
         password: process.env[`CCU_${p}_PASSWORD`] ?? "",
         timeout: parseIntEnv(`CCU_${p}_TIMEOUT`, "10000"),
         scriptTimeout: parseIntEnv(`CCU_${p}_SCRIPT_TIMEOUT`, "30000"),
@@ -250,8 +267,7 @@ export function loadConfig(): AppConfig {
     }
     const host = process.env.CCU_HOST;
     if (!host) throw new Error("CCU_HOST environment variable is required");
-    const password = process.env.CCU_PASSWORD;
-    if (!password) throw new Error("CCU_PASSWORD environment variable is required");
+    const password = requirePasswordEnv("CCU_PASSWORD");
     const flatHttps = parseBoolEnv("CCU_HTTPS");
     profiles = [{
       name: "default",

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,6 +95,30 @@ export function envPrefix(name: string): string {
   return name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
 }
 
+/**
+ * Named targets that have no `CCU_<NAME>_PASSWORD` key at all — "not entered
+ * yet", as opposed to `CCU_<NAME>_PASSWORD=` which says "deliberately empty".
+ *
+ * Deliberately NOT enforced in `loadConfig`: a named profile has never
+ * required the key (issue #69), and an OpenCCU dev box configured that way
+ * must keep working. It is enforced only where the distinction decides
+ * something — the setup-mode gate in index.ts (issue #196, QA F-008). Without
+ * it, `setup_write_profile` writing a named target's host was enough for the
+ * next start to load "successfully" with an empty password, dropping the
+ * setup_* tools the flow still needs and failing every real call with
+ * AUTH 501. The flat form self-corrects because loadConfig requires
+ * CCU_PASSWORD to be present (issue #209); this gives the profile form the
+ * same behavior without changing what a configuration means.
+ */
+export function targetsAwaitingPassword(config: AppConfig): string[] {
+  // Flat form only ever has the one implicit target, and loadConfig already
+  // rejects a missing CCU_PASSWORD there.
+  if (!process.env.CCU_PROFILES?.trim()) return [];
+  return config.profiles
+    .filter((p) => process.env[`CCU_${envPrefix(p.name)}_PASSWORD`] === undefined)
+    .map((p) => p.name);
+}
+
 export function loadConfig(): AppConfig {
   // CLI flags override env vars for transport. Validate the env value: a typo
   // ("STDIO", "Stdio") must fail loudly, not silently select HTTP and leave a

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,22 @@ async function main(): Promise<void> {
     return;
   }
 
+  // A bare first word is always a subcommand attempt — server mode is entered
+  // with flags (--stdio/--http/--env). Falling through to startup instead made
+  // an OLDER binary answer `ccu-mcp secret …` with "CCU_HOST environment
+  // variable is required": a complaint about configuration, for what is really
+  // "this build predates that command". Name the version, so the next person
+  // who runs a printed command against the wrong install can see which one it
+  // reached.
+  if (argv[0] !== undefined && !argv[0].startsWith("-")) {
+    process.stderr.write(
+      `ccu-mcp: unknown command "${argv[0]}" (ccu-mcp ${VERSION}).\n` +
+        `Known commands: init, doctor, secret. Run \`ccu-mcp --help\` for usage.\n`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+
   if (handleInfoFlags(argv)) return;
 
   // `--env` for server mode: lets an MCP client entry reference the file

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ Usage:
   ccu-mcp [--stdio | --http] [--env <path>]
   ccu-mcp init   [--env <path>]
   ccu-mcp doctor [--env <path>]
+  ccu-mcp secret [<profile>] [--env <path>]
   ccu-mcp --version
   ccu-mcp --help
 
@@ -37,9 +38,14 @@ Subcommands:
                    test the login, and write an env file (default: ./.env)
   doctor           Validate an existing env file end-to-end: reachability,
                    certificate pin, login, privilege level
+  secret           Store the CCU password into the env file via a local hidden
+                   prompt (used by the LLM-guided setup; also for rotation)
 
 Options:
-  --stdio          Serve MCP over stdin/stdout (overrides MCP_TRANSPORT)
+  --stdio          Serve MCP over stdin/stdout (overrides MCP_TRANSPORT).
+                   With --env and a missing/incomplete configuration the server
+                   starts in SETUP MODE, exposing only setup_* tools that let
+                   an LLM configure it conversationally
   --http           Serve MCP over HTTP (default)
   --env <path>     Load configuration from this dotenv file (already-set
                    environment variables win, like node's own --env-file)
@@ -96,8 +102,13 @@ async function main(): Promise<void> {
   // Subcommands run in the same no-environment-needed early path as the info
   // flags (issue #112): `ccu-mcp init` exists precisely because there is no
   // valid configuration yet. Dynamic import keeps server startup unaffected.
-  if (argv[0] === "init" || argv[0] === "doctor") {
-    const mod = argv[0] === "init" ? await import("./cli/init.js") : await import("./cli/doctor.js");
+  if (argv[0] === "init" || argv[0] === "doctor" || argv[0] === "secret") {
+    const mod =
+      argv[0] === "init"
+        ? await import("./cli/init.js")
+        : argv[0] === "doctor"
+          ? await import("./cli/doctor.js")
+          : await import("./cli/secret.js");
     process.exitCode = await mod.run(argv.slice(1));
     return;
   }
@@ -107,13 +118,50 @@ async function main(): Promise<void> {
   // `--env` for server mode: lets an MCP client entry reference the file
   // `ccu-mcp init` wrote instead of inlining credentials in its JSON config.
   // Same precedence as node's own flag: already-set environment wins.
+  let envPath: string | undefined;
   if (argv.includes("--env")) {
     const { envFileArg, loadEnvFile, applyEnvVars } = await import("./cli/common.js");
-    applyEnvVars(loadEnvFile(envFileArg(argv)));
+    envPath = envFileArg(argv); // throws on a missing value — always fatal
+    try {
+      applyEnvVars(loadEnvFile(envPath));
+    } catch (err) {
+      // A missing/unreadable env file is exactly the state the LLM-guided
+      // setup starts from (issue #196) — over stdio it leads into setup mode
+      // below. Everywhere else it stays fatal, as before.
+      if (!argv.includes("--stdio")) throw err;
+    }
   }
 
   const logger = createLogger();
-  const config = loadConfig();
+  let config: ReturnType<typeof loadConfig>;
+  try {
+    config = loadConfig();
+  } catch (err) {
+    // Setup mode (issue #196): started for stdio with an explicit --env file
+    // but no loadable configuration, serve only the setup_* tools so an LLM
+    // can walk the user through writing that file. Strictly stdio — an
+    // unconfigured, unauthenticated HTTP endpoint that writes config files is
+    // not an acceptable surface. A bare start still fails loudly.
+    if (envPath === undefined || !argv.includes("--stdio")) throw err;
+    const { resolve } = await import("node:path");
+    const { createSetupServer } = await import("./setup-server.js");
+    const setupServer = createSetupServer(resolve(envPath), (err as Error).message, logger);
+    await setupServer.connect(new StdioServerTransport());
+    logger.info("server_ready", { transport: "stdio", mode: "setup" });
+    let closing = false;
+    const closeSetup = (): void => {
+      if (closing) return;
+      closing = true;
+      void setupServer.close().finally(() => process.exit(0));
+    };
+    process.on("SIGTERM", closeSetup);
+    process.on("SIGINT", closeSetup);
+    // Same stdin-EOF hook as the configured stdio server below: the client
+    // terminates by closing the pipe, not by signaling.
+    process.stdin.on("end", closeSetup);
+    process.stdin.on("close", closeSetup);
+    return;
+  }
 
   logger.info("starting", {
     transport: config.mcp.transport,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { randomUUID } from "node:crypto";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { loadConfig } from "./config.js";
+import { loadConfig, targetsAwaitingPassword, envPrefix } from "./config.js";
 import { createLogger } from "./logger.js";
 import { RateLimiter } from "./middleware/rate-limiter.js";
 import { TargetRegistry, TargetSelection } from "./ccu/target-registry.js";
@@ -149,9 +149,32 @@ async function main(): Promise<void> {
   }
 
   const logger = createLogger();
+  // Setup mode is only reachable from a stdio start that named an env file;
+  // computing it here keeps the extra completeness check below from turning a
+  // tolerated configuration into a fatal error on any other start path.
+  const setupEligible = envPath !== undefined && argv.includes("--stdio");
   let config: ReturnType<typeof loadConfig>;
   try {
     config = loadConfig();
+    // A loadable configuration is not necessarily a finished one. A named
+    // target whose password key was never written (QA F-008) loads with an
+    // empty password, so the server would leave setup mode mid-flow and then
+    // fail every call with AUTH 501 — with the setup_* tools gone, the model
+    // has no way to finish or explain it. Treat it as not-yet-configured, and
+    // say exactly which command completes it.
+    if (setupEligible) {
+      const pending = targetsAwaitingPassword(config);
+      if (pending.length > 0) {
+        const { selfCommand } = await import("./cli/common.js");
+        const runs = pending.map((n) => selfCommand("secret", n, "--env", envPath!)).join("  |  ");
+        throw new Error(
+          `no password stored yet for target${pending.length > 1 ? "s" : ""} ` +
+          `${pending.join(", ")} — run: ${runs}  ` +
+          `(a CCU that genuinely has no password needs the key present but empty: ` +
+          `CCU_${envPrefix(pending[0]!)}_PASSWORD=)`,
+        );
+      }
+    }
   } catch (err) {
     // Setup mode (issue #196): started for stdio with an explicit --env file
     // but no loadable configuration, serve only the setup_* tools so an LLM

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,13 +26,23 @@ import { extractBearerToken, normalizeClientIp, VERSION, loadBuildInfo } from ".
 const USAGE = `ccu-mcp — MCP server for a HomeMatic CCU (debmatic, CCU3, OpenCCU/RaspberryMatic)
 
 Usage:
-  ccu-mcp [--stdio | --http]
+  ccu-mcp [--stdio | --http] [--env <path>]
+  ccu-mcp init   [--env <path>]
+  ccu-mcp doctor [--env <path>]
   ccu-mcp --version
   ccu-mcp --help
+
+Subcommands:
+  init             Interactive setup: probe the CCU, pin its TLS certificate,
+                   test the login, and write an env file (default: ./.env)
+  doctor           Validate an existing env file end-to-end: reachability,
+                   certificate pin, login, privilege level
 
 Options:
   --stdio          Serve MCP over stdin/stdout (overrides MCP_TRANSPORT)
   --http           Serve MCP over HTTP (default)
+  --env <path>     Load configuration from this dotenv file (already-set
+                   environment variables win, like node's own --env-file)
   -v, --version    Print the version and exit
   -h, --help       Print this help and exit
 
@@ -81,7 +91,26 @@ function handleInfoFlags(argv: string[]): boolean {
 }
 
 async function main(): Promise<void> {
-  if (handleInfoFlags(process.argv.slice(2))) return;
+  const argv = process.argv.slice(2);
+
+  // Subcommands run in the same no-environment-needed early path as the info
+  // flags (issue #112): `ccu-mcp init` exists precisely because there is no
+  // valid configuration yet. Dynamic import keeps server startup unaffected.
+  if (argv[0] === "init" || argv[0] === "doctor") {
+    const mod = argv[0] === "init" ? await import("./cli/init.js") : await import("./cli/doctor.js");
+    process.exitCode = await mod.run(argv.slice(1));
+    return;
+  }
+
+  if (handleInfoFlags(argv)) return;
+
+  // `--env` for server mode: lets an MCP client entry reference the file
+  // `ccu-mcp init` wrote instead of inlining credentials in its JSON config.
+  // Same precedence as node's own flag: already-set environment wins.
+  if (argv.includes("--env")) {
+    const { envFileArg, loadEnvFile, applyEnvVars } = await import("./cli/common.js");
+    applyEnvVars(loadEnvFile(envFileArg(argv)));
+  }
 
   const logger = createLogger();
   const config = loadConfig();

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,23 @@ export interface ServerDeps {
 export const serverSubscriptions = new WeakMap<McpServer, Set<string>>();
 
 /**
+ * The server's `Implementation` identity, shared between the configured server
+ * and the setup-mode server (setup-server.ts) so a client listing either shows
+ * the same name/title. `description` mirrors server.json's, so the registry
+ * entry and the live handshake say the same thing.
+ */
+export const SERVER_IDENTITY = {
+  name: "ccu-mcp",
+  // title/description/websiteUrl are the human-facing half of
+  // `Implementation`: a client listing servers shows these rather than the
+  // package name.
+  title: "HomeMatic CCU",
+  description: "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
+  websiteUrl: "https://github.com/claymore666/ccu-mcp",
+  version: VERSION,
+};
+
+/**
  * Sent to the client in the `initialize` result and, in most clients, put in
  * front of the model before it calls anything. It is the one piece of guidance
  * that arrives without the model choosing to ask for it — `help` only helps a
@@ -90,17 +107,7 @@ function invalidParams(message: string): McpError {
 
 export function createMcpServer(deps: ServerDeps): McpServer {
   const server = new McpServer(
-    {
-      name: "ccu-mcp",
-      // title/description/websiteUrl are the human-facing half of
-      // `Implementation`: a client listing servers shows these rather than the
-      // package name. `description` mirrors server.json's, so the registry
-      // entry and the live handshake say the same thing.
-      title: "HomeMatic CCU",
-      description: "MCP server for controlling HomeMatic smart home devices via the CCU JSON-RPC API",
-      websiteUrl: "https://github.com/claymore666/ccu-mcp",
-      version: VERSION,
-    },
+    SERVER_IDENTITY,
     {
       instructions: INSTRUCTIONS,
       capabilities: {

--- a/src/setup-server.ts
+++ b/src/setup-server.ts
@@ -1,0 +1,48 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SERVER_IDENTITY } from "./server.js";
+import { registerSetupTools } from "./tools/setup.js";
+import type { Logger } from "./logger.js";
+
+/**
+ * Instructions for setup mode. Unlike the configured server's, these must
+ * carry the whole flow: the client has never seen this server work, so the
+ * model's only guidance is what arrives with the initialize result. The
+ * password rule is stated twice on purpose — it is the one step where the
+ * model doing the "helpful" thing (asking for the password in chat) would be
+ * wrong.
+ */
+function setupInstructions(envPath: string, configError: string): string {
+  return `This ccu-mcp server is NOT configured yet — it started in setup mode because loading \
+its configuration failed (${configError}). Only the setup_* tools are available; they write to \
+${envPath}.
+
+Walk the user through configuring their HomeMatic CCU connection:
+1. setup_status shows what the env file already contains.
+2. Ask for the CCU's hostname or IP; setup_probe finds the port/HTTPS and fetches the TLS \
+certificate. On HTTPS, recommend pinning the certificate fingerprint.
+3. setup_write_profile writes the connection settings. It has no password parameter.
+4. The password must NEVER travel through this conversation — do not ask for it, and refuse it \
+if offered. Instead have the user run the \`ccu-mcp secret\` command printed by \
+setup_write_profile in a terminal; it prompts locally with echo off and stores only the password.
+5. setup_test verifies reachability, the certificate pin and the login.
+6. When every check passes, tell the user to reconnect this MCP server (restart the client or \
+its MCP connection) — it will start fully configured with the normal tool set.
+
+Multiple CCUs (e.g. prod and dev) are supported: repeat steps 2-5 with a name per target \
+("default" means a single unnamed CCU).`;
+}
+
+/**
+ * The minimal MCP server the process runs when started with --stdio --env
+ * <path> and an invalid/missing configuration (see index.ts). Same identity as
+ * the configured server, but only the four setup tools — no resources, no
+ * prompts, no CCU-backed anything.
+ */
+export function createSetupServer(envPath: string, configError: string, logger: Logger): McpServer {
+  const server = new McpServer(SERVER_IDENTITY, {
+    instructions: setupInstructions(envPath, configError),
+    capabilities: { tools: {}, logging: {} },
+  });
+  registerSetupTools(server, { envPath, configError, logger });
+  return server;
+}

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -290,8 +290,10 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       description:
         "Get CCU system information: firmware version, serial number, addresses. Reports the active " +
         "login user and inferred role (ADMIN/USER) — note that version/serial/address are ADMIN-only " +
-        "on the CCU, so they show \"N/A\" for a non-admin (USER) login. Also reports the running " +
-        "server's build identification (git branch/commit/tag and build time) under `build`.",
+        "on the CCU, so they show \"N/A\" for a non-admin (USER) login. A CCU that cannot be reached " +
+        "or logged into fails with that error instead — \"N/A\" always means \"connected, not permitted\". " +
+        "Also reports the running server's build identification (git branch/commit/tag and build time) " +
+        "under `build`.",
       inputSchema: {
         target: targetField,
       },
@@ -300,7 +302,7 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
         target: z.string().optional().describe("Active CCU target name"),
         user: z.string().optional().describe("Configured login user for the active target"),
         role: z.enum(["ADMIN", "USER", "UNKNOWN"]).optional()
-          .describe("Access role inferred from which CCU methods answer: ADMIN if admin-only calls succeed, USER if logged in without admin rights, UNKNOWN if not connected"),
+          .describe("Access role inferred from which CCU methods answer: ADMIN if admin-only calls succeed, USER if logged in without admin rights. A CCU that cannot be reached or logged into raises that error instead of reporting a role"),
         version: z.unknown().optional().describe("Firmware version, or \"N/A\" if unavailable (ADMIN-only)"),
         serial: z.unknown().optional().describe("Serial number, or \"N/A\" if unavailable (ADMIN-only)"),
         address: z.unknown().optional().describe("BidCos address, or \"N/A\" if unavailable (ADMIN-only)"),
@@ -340,6 +342,14 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
       ];
 
       let anyAdminOk = false;
+      // A failure while the session is still valid is a privilege denial (the
+      // USER case this tool exists to degrade for). A failure with NO session
+      // is something else entirely — wrong credentials, an unreachable CCU, a
+      // pin mismatch — and reporting that as N/A + role UNKNOWN told the
+      // caller "connected, probably USER-level" when nothing had connected at
+      // all. Keep the first such error and fail with it: this is the tool
+      // people reach for to answer "did my setup work?".
+      let noSessionErr: unknown = null;
       for (const { key, method } of calls) {
         try {
           await rateLimiter.acquire();
@@ -350,13 +360,17 @@ function registerGetSystemInfo(server: McpServer, deps: ServerDeps): void {
           } else {
             results[key] = "N/A"; // empty/no value rather than null
           }
-        } catch {
+        } catch (err) {
           results[key] = "N/A"; // permission denied or call failed
+          if (noSessionErr === null && !session.isLoggedIn()) noSessionErr = err;
         }
       }
+      if (noSessionErr !== null) throw noSessionErr;
 
       // Infer role: admin-only calls answered => ADMIN; otherwise logged in but
-      // without those rights => USER; not logged in / unreachable => UNKNOWN.
+      // without those rights => USER. UNKNOWN remains for the case no call
+      // threw yet none answered — a connection failure now throws above rather
+      // than arriving here dressed as a role.
       const loggedIn = active.session.isLoggedIn();
       results.role = anyAdminOk ? "ADMIN" : (loggedIn ? "USER" : "UNKNOWN");
       if (!anyAdminOk && loggedIn) {

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -183,7 +183,9 @@ NOT_FOUND if no active message matches; the warning reappears if its condition p
 Args: target? (CCU target name)
 Returns: {serverVersion, target, user, role (ADMIN|USER|UNKNOWN), version, serial, address, hmipAddress,
   accessNote? (present when ADMIN-only fields are unavailable), cacheTypes, cacheWarming, build {branch, commit, tag, describe, dirty, builtAt}}
-version/serial/address/hmipAddress are ADMIN-only on the CCU and show "N/A" for a USER-level login.`,
+version/serial/address/hmipAddress are ADMIN-only on the CCU and show "N/A" for a USER-level login.
+"N/A" therefore means "connected, not permitted": a CCU that cannot be reached or logged into fails with
+that error (AUTH/UNREACHABLE/TLS_ERROR) instead, so this tool is a safe "did my setup work?" check.`,
 
   get_rssi: `Radio link quality (RSSI, dBm) per device, plus BidCos interface health.
 Args: name? (substring filter on device name/address), target? (CCU target name)

--- a/src/tools/setup.ts
+++ b/src/tools/setup.ts
@@ -63,7 +63,9 @@ export function profilesFromVars(vars: Record<string, string>): {
       https,
       tlsFingerprint: g("TLS_FINGERPRINT")?.trim() || undefined,
       user: g("USER")?.trim() || "Admin",
-      password: g("PASSWORD") ?? "",
+      // Undefined (key absent) and "" (deliberately empty) must stay distinct
+      // here — a rewrite has to preserve which of the two the file recorded.
+      password: g("PASSWORD"),
       protected: boolVar(g("PROTECTED")),
       readonly: boolVar(g("READONLY")),
     };
@@ -313,11 +315,14 @@ function registerWriteProfile(server: McpServer, deps: SetupDeps): void {
           tlsFingerprint: args.tlsFingerprint,
           user,
           // Same endpoint: a stored password stays valid, keep it. New or
-          // moved target: never carry a secret over to a different box.
+          // moved target: never carry a secret over to a different box — and
+          // leave the key out rather than writing an empty placeholder, which
+          // would look like a deliberately empty password and let the server
+          // start before `ccu-mcp secret` has run.
           password:
             previous && previous.host === args.host && previous.port === args.port
               ? previous.password
-              : "",
+              : undefined,
           protected: args.protected ?? previous?.protected ?? false,
           readonly: args.readonly ?? previous?.readonly ?? false,
         };
@@ -335,7 +340,7 @@ function registerWriteProfile(server: McpServer, deps: SetupDeps): void {
         const content = existing === undefined ? managed : mergeEnvContent(existing, managed).content;
         writeEnvFile(deps.envPath, content);
 
-        const nextStep = updated.password === ""
+        const nextStep = updated.password === undefined
           ? `Ask the user to run this in a terminal (the password is typed there, hidden — never in this chat):\n  ${secretCommand(deps, updated.name)}\nThen call setup_test.`
           : "The stored password was kept. Call setup_test to verify the target.";
         return structuredResult({

--- a/src/tools/setup.ts
+++ b/src/tools/setup.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Logger } from "../logger.js";
 import { loadConfig, envPrefix, type AppConfig } from "../config.js";
-import { loadEnvFile, displayFingerprint } from "../cli/common.js";
+import { loadEnvFile, displayFingerprint, selfCommand } from "../cli/common.js";
 import {
   buildEnvContent,
   mergeEnvContent,
@@ -131,8 +131,8 @@ function certResult(cert: CertInfo): Record<string, unknown> {
 }
 
 function secretCommand(deps: SetupDeps, profileName: string): string {
-  const profileArg = profileName === "default" ? "" : ` ${profileName}`;
-  return `npx ccu-mcp secret${profileArg} --env ${deps.envPath}`;
+  const profileArg = profileName === "default" ? [] : [profileName];
+  return selfCommand("secret", ...profileArg, "--env", deps.envPath);
 }
 
 function registerStatus(server: McpServer, deps: SetupDeps): void {

--- a/src/tools/setup.ts
+++ b/src/tools/setup.ts
@@ -1,0 +1,495 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Logger } from "../logger.js";
+import { loadConfig, envPrefix, type AppConfig } from "../config.js";
+import { loadEnvFile, displayFingerprint } from "../cli/common.js";
+import {
+  buildEnvContent,
+  mergeEnvContent,
+  readEnvFile,
+  writeEnvFile,
+  type WizardProfile,
+} from "../cli/env-writer.js";
+import {
+  probeApi,
+  probeConfig,
+  fetchCert,
+  fingerprintMatches,
+  testLogin,
+  type CertInfo,
+} from "../cli/probe.js";
+import { runTool } from "../middleware/tool-handler.js";
+import { structuredResult } from "../utils.js";
+
+/**
+ * Dependencies of the setup-mode toolset. Deliberately tiny: setup mode exists
+ * BECAUSE there is no valid config, so none of the usual ServerDeps
+ * (targets/session/resolver) can exist yet. The env-file path comes from the
+ * server's own --env flag, never from a tool argument — the model must not be
+ * able to point the writer at an arbitrary file.
+ */
+export interface SetupDeps {
+  /** Absolute path of the env file named by --env. */
+  envPath: string;
+  /** Why loadConfig() rejected the current state, verbatim. */
+  configError: string;
+  logger: Logger;
+}
+
+const PROBE_TIMEOUT = 5_000;
+
+/** True-ish dotenv boolean; garbage reads as false (status is advisory only). */
+function boolVar(v: string | undefined): boolean {
+  return v?.trim().toLowerCase() === "true";
+}
+
+/**
+ * Read the wizard-managed profiles back OUT of a dotenv key/value map, so
+ * setup_write_profile can upsert one profile while preserving the others
+ * (including their already-secret-stored passwords, which never surface in
+ * any tool result).
+ */
+export function profilesFromVars(vars: Record<string, string>): {
+  profiles: WizardProfile[];
+  defaultProfile?: string;
+} {
+  const fromKeys = (prefix: string, name: string): WizardProfile => {
+    const g = (suffix: string): string | undefined => vars[`CCU_${prefix}${suffix}`];
+    const https = boolVar(g("HTTPS"));
+    return {
+      name,
+      host: g("HOST")?.trim() ?? "",
+      port: /^\d+$/.test(g("PORT")?.trim() ?? "") ? Number(g("PORT")!.trim()) : https ? 443 : 80,
+      https,
+      tlsFingerprint: g("TLS_FINGERPRINT")?.trim() || undefined,
+      user: g("USER")?.trim() || "Admin",
+      password: g("PASSWORD") ?? "",
+      protected: boolVar(g("PROTECTED")),
+      readonly: boolVar(g("READONLY")),
+    };
+  };
+  const names = vars.CCU_PROFILES?.split(",").map((s) => s.trim()).filter(Boolean);
+  if (names && names.length > 0) {
+    return {
+      profiles: names.map((n) => fromKeys(`${envPrefix(n)}_`, n)),
+      defaultProfile: vars.CCU_DEFAULT_PROFILE?.trim() || undefined,
+    };
+  }
+  if (vars.CCU_HOST) return { profiles: [fromKeys("", "default")] };
+  return { profiles: [] };
+}
+
+/**
+ * Evaluate the env FILE with the real loadConfig(), which reads process.env.
+ * Snapshot the environment, make the file the sole source of truth for every
+ * variable the config owns, load, restore. Synchronous throughout (no await
+ * between swap and restore), so nothing else can observe the altered env.
+ */
+export function configFromEnvFile(path: string): AppConfig {
+  const vars = loadEnvFile(path);
+  const saved: Record<string, string | undefined> = {};
+  const owned = /^(CCU_|MCP_|CACHE_|RESOURCE_POLL_INTERVAL$|LOG_LEVEL$)/;
+  for (const key of Object.keys(process.env)) {
+    if (owned.test(key)) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(vars)) {
+    saved[key] = saved[key] ?? process.env[key];
+    process.env[key] = value;
+  }
+  try {
+    return loadConfig();
+  } finally {
+    for (const key of Object.keys(vars)) delete process.env[key];
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+const certShape = {
+  fingerprint256: z.string(),
+  subjectCN: z.string().optional(),
+  issuerCN: z.string().optional(),
+  validFrom: z.string().optional(),
+  validTo: z.string().optional(),
+};
+
+function certResult(cert: CertInfo): Record<string, unknown> {
+  return {
+    fingerprint256: displayFingerprint(cert.fingerprint256),
+    subjectCN: cert.subjectCN,
+    issuerCN: cert.issuerCN,
+    validFrom: cert.validFrom,
+    validTo: cert.validTo,
+  };
+}
+
+function secretCommand(deps: SetupDeps, profileName: string): string {
+  const profileArg = profileName === "default" ? "" : ` ${profileName}`;
+  return `npx ccu-mcp secret${profileArg} --env ${deps.envPath}`;
+}
+
+function registerStatus(server: McpServer, deps: SetupDeps): void {
+  server.registerTool(
+    "setup_status",
+    {
+      title: "Setup: current state",
+      description:
+        "Report why the server is in setup mode, which env file it will write, and what that " +
+        "file already contains: each configured CCU target with host/port/HTTPS/user, whether a " +
+        "TLS fingerprint is pinned, and whether a password has been stored (as a boolean — the " +
+        "password itself is never readable through any setup tool).",
+      inputSchema: {},
+      outputSchema: {
+        envPath: z.string(),
+        fileExists: z.boolean(),
+        configError: z.string(),
+        defaultProfile: z.string().optional(),
+        profiles: z.array(
+          z.object({
+            name: z.string(),
+            host: z.string(),
+            port: z.number(),
+            https: z.boolean(),
+            user: z.string(),
+            tlsFingerprintPinned: z.boolean(),
+            passwordStored: z.boolean(),
+            protected: z.boolean(),
+            readonly: z.boolean(),
+          }),
+        ),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async () =>
+      runTool("setup_status", deps.logger, async () => {
+        const content = readEnvFile(deps.envPath);
+        const vars = content === undefined ? {} : loadEnvFile(deps.envPath);
+        const { profiles, defaultProfile } = profilesFromVars(vars);
+        return structuredResult({
+          envPath: deps.envPath,
+          fileExists: content !== undefined,
+          configError: deps.configError,
+          defaultProfile,
+          profiles: profiles.map((p) => ({
+            name: p.name,
+            host: p.host,
+            port: p.port,
+            https: p.https,
+            user: p.user,
+            tlsFingerprintPinned: p.tlsFingerprint !== undefined,
+            // Key present in the file — an empty password is legal for named
+            // profiles (OpenCCU dev boxes), so presence is what matters here;
+            // setup_test gives the real verdict.
+            passwordStored: `CCU_${p.name === "default" && !vars.CCU_PROFILES ? "" : `${envPrefix(p.name)}_`}PASSWORD` in vars,
+            protected: p.protected,
+            readonly: p.readonly,
+          })),
+        });
+      }),
+  );
+}
+
+function registerProbe(server: McpServer, deps: SetupDeps): void {
+  server.registerTool(
+    "setup_probe",
+    {
+      title: "Setup: probe a CCU",
+      description:
+        "Check whether a CCU JSON-RPC API answers at a host. Without port/https the two stock " +
+        "endpoints are tried (443 HTTPS, then 80 HTTP). Over HTTPS the presented TLS certificate " +
+        "is fetched (unverified, for display) so the user can decide to pin its fingerprint in " +
+        "setup_write_profile — recommend pinning.",
+      inputSchema: {
+        host: z.string().describe("CCU hostname or IP"),
+        port: z.number().int().min(1).max(65535).optional()
+          .describe("Probe exactly this port (default: auto-detect 443/80)"),
+        https: z.boolean().optional().describe("Probe with HTTPS (required when port is given)"),
+      },
+      outputSchema: {
+        reachable: z.boolean(),
+        detail: z.string(),
+        port: z.number().optional(),
+        https: z.boolean().optional(),
+        cert: z.object(certShape).optional(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runTool("setup_probe", deps.logger, async (log) => {
+        log({ host: args.host });
+        const candidates =
+          args.port !== undefined
+            ? [{ port: args.port, https: args.https ?? args.port === 443 }]
+            : [
+                { port: 443, https: true },
+                { port: 80, https: false },
+              ];
+        let lastDetail = "";
+        for (const c of candidates) {
+          const outcome = await probeApi(probeConfig(args.host, c.port, c.https, PROBE_TIMEOUT));
+          lastDetail = `${c.https ? "https" : "http"}://${args.host}:${c.port} — ${outcome.detail}`;
+          if (outcome.kind !== "ccu") continue;
+          let cert: CertInfo | undefined;
+          if (c.https) {
+            try {
+              cert = await fetchCert(args.host, c.port);
+            } catch {
+              // Reachability is established; an unreadable cert only means no
+              // pin can be offered.
+            }
+          }
+          return structuredResult({
+            reachable: true,
+            detail: `CCU API found on port ${c.port} (${c.https ? "HTTPS" : "HTTP"})`,
+            port: c.port,
+            https: c.https,
+            ...(cert ? { cert: certResult(cert) } : {}),
+          });
+        }
+        return structuredResult({ reachable: false, detail: `No CCU API found: ${lastDetail}` });
+      }),
+  );
+}
+
+function registerWriteProfile(server: McpServer, deps: SetupDeps): void {
+  server.registerTool(
+    "setup_write_profile",
+    {
+      title: "Setup: write a CCU target",
+      description:
+        "Add or update one CCU target in the env file (connection settings only). There is " +
+        "deliberately NO password parameter: the password must never travel through the model " +
+        "or the chat — after writing, have the user run the printed `ccu-mcp secret` command in " +
+        "a terminal (hidden prompt), then call setup_test. Other targets and unmanaged variables " +
+        "in the file are preserved.",
+      inputSchema: {
+        name: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/).default("default")
+          .describe('Target name (e.g. "prod", "dev"); "default" writes the flat single-CCU form'),
+        host: z.string().describe("CCU hostname or IP"),
+        port: z.number().int().min(1).max(65535),
+        https: z.boolean(),
+        tlsFingerprint: z.string().optional()
+          .describe("SHA-256 fingerprint from setup_probe to pin (HTTPS only, recommended)"),
+        user: z.string().default("Admin").describe("CCU username"),
+        protected: z.boolean().optional()
+          .describe("Write tools on this target then require confirm:true"),
+        readonly: z.boolean().optional().describe("Refuse write tools on this target entirely"),
+        makeDefault: z.boolean().optional().describe("Make this the startup-default target"),
+      },
+      outputSchema: {
+        written: z.boolean(),
+        envPath: z.string(),
+        profiles: z.array(z.string()),
+        defaultProfile: z.string(),
+        nextStep: z.string(),
+      },
+    },
+    async (args) =>
+      runTool("setup_write_profile", deps.logger, async (log) => {
+        // The SDK applies the zod defaults on the wire; direct handler calls
+        // (unit tests) may omit them.
+        const name = args.name ?? "default";
+        const user = args.user ?? "Admin";
+        log({ profile: name, host: args.host });
+        if (!args.https && args.tlsFingerprint) {
+          throw new Error("tlsFingerprint only applies over HTTPS — drop it or set https: true");
+        }
+        const existing = readEnvFile(deps.envPath);
+        const vars = existing === undefined ? {} : loadEnvFile(deps.envPath);
+        const parsed = profilesFromVars(vars);
+        const profiles = parsed.profiles;
+        const idx = profiles.findIndex((p) => envPrefix(p.name) === envPrefix(name));
+        const previous = idx >= 0 ? profiles[idx] : undefined;
+        const updated: WizardProfile = {
+          name,
+          host: args.host,
+          port: args.port,
+          https: args.https,
+          tlsFingerprint: args.tlsFingerprint,
+          user,
+          // Same endpoint: a stored password stays valid, keep it. New or
+          // moved target: never carry a secret over to a different box.
+          password:
+            previous && previous.host === args.host && previous.port === args.port
+              ? previous.password
+              : "",
+          protected: args.protected ?? previous?.protected ?? false,
+          readonly: args.readonly ?? previous?.readonly ?? false,
+        };
+        if (idx >= 0) profiles[idx] = updated;
+        else profiles.push(updated);
+
+        let defaultProfile = parsed.defaultProfile ?? profiles[0].name;
+        if (args.makeDefault) defaultProfile = updated.name;
+        if (!profiles.some((p) => p.name === defaultProfile)) defaultProfile = profiles[0].name;
+
+        // A single target genuinely named "default" is the flat form (same as
+        // init); any real name keeps the CCU_PROFILES form so it survives.
+        const forceProfileForm = !(profiles.length === 1 && profiles[0].name === "default");
+        const managed = buildEnvContent(profiles, defaultProfile, forceProfileForm);
+        const content = existing === undefined ? managed : mergeEnvContent(existing, managed).content;
+        writeEnvFile(deps.envPath, content);
+
+        const nextStep = updated.password === ""
+          ? `Ask the user to run this in a terminal (the password is typed there, hidden — never in this chat):\n  ${secretCommand(deps, updated.name)}\nThen call setup_test.`
+          : "The stored password was kept. Call setup_test to verify the target.";
+        return structuredResult({
+          written: true,
+          envPath: deps.envPath,
+          profiles: profiles.map((p) => p.name),
+          defaultProfile,
+          nextStep,
+        });
+      }),
+  );
+}
+
+function registerTest(server: McpServer, deps: SetupDeps): void {
+  server.registerTool(
+    "setup_test",
+    {
+      title: "Setup: verify the configuration",
+      description:
+        "Validate the env file end-to-end, like `ccu-mcp doctor`: configuration loads, each " +
+        "target's CCU API is reachable, a pinned TLS fingerprint matches the presented " +
+        "certificate, and the login works (reporting the ADMIN/USER privilege level). When " +
+        "everything passes, tell the user to reconnect this MCP server — it will restart fully " +
+        "configured with the normal tool set.",
+      inputSchema: {},
+      outputSchema: {
+        ok: z.boolean(),
+        findings: z.array(
+          z.object({
+            profile: z.string(),
+            check: z.string(),
+            ok: z.boolean(),
+            detail: z.string(),
+          }),
+        ),
+        nextStep: z.string(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async () =>
+      runTool("setup_test", deps.logger, async () => {
+        const findings: { profile: string; check: string; ok: boolean; detail: string }[] = [];
+        let config: AppConfig;
+        try {
+          config = configFromEnvFile(deps.envPath);
+        } catch (err) {
+          findings.push({
+            profile: "-",
+            check: "config",
+            ok: false,
+            detail: `configuration invalid: ${(err as Error).message}`,
+          });
+          return structuredResult({
+            ok: false,
+            findings,
+            nextStep:
+              "Fix the reported problem (setup_write_profile for connection settings; " +
+              "`ccu-mcp secret` for the password), then call setup_test again.",
+          });
+        }
+        findings.push({
+          profile: "-",
+          check: "config",
+          ok: true,
+          detail: `configuration loads: ${config.profiles.length} target(s), default "${config.defaultProfile}"`,
+        });
+
+        for (const p of config.profiles) {
+          const outcome = await probeApi(p.ccu);
+          if (outcome.kind !== "ccu") {
+            findings.push({
+              profile: p.name,
+              check: "reachability",
+              ok: false,
+              detail: `CCU API not reachable: ${outcome.detail}`,
+            });
+            continue;
+          }
+          findings.push({ profile: p.name, check: "reachability", ok: true, detail: "CCU API reachable" });
+
+          if (p.ccu.https && p.ccu.tlsFingerprint) {
+            let presented: string;
+            try {
+              presented = (await fetchCert(p.ccu.host, p.ccu.port)).fingerprint256;
+            } catch (err) {
+              findings.push({
+                profile: p.name,
+                check: "tls-pin",
+                ok: false,
+                detail: `could not read the TLS certificate: ${(err as Error).message}`,
+              });
+              continue;
+            }
+            if (!fingerprintMatches(p.ccu.tlsFingerprint, presented)) {
+              findings.push({
+                profile: p.name,
+                check: "tls-pin",
+                ok: false,
+                detail:
+                  `pinned fingerprint does NOT match the presented certificate ` +
+                  `(pinned ${displayFingerprint(p.ccu.tlsFingerprint)}, presented ${displayFingerprint(presented)}). ` +
+                  "If the certificate was legitimately renewed, re-pin via setup_write_profile; " +
+                  "if not, this could be an interception attempt — investigate before continuing.",
+              });
+              continue;
+            }
+            findings.push({
+              profile: p.name,
+              check: "tls-pin",
+              ok: true,
+              detail: "pinned TLS fingerprint matches the presented certificate",
+            });
+          }
+
+          const login = await testLogin(p.ccu);
+          if (!login.ok) {
+            findings.push({
+              profile: p.name,
+              check: "login",
+              ok: false,
+              detail: `login failed: ${login.error.message}${login.error.hint ? ` — ${login.error.hint}` : ""}`,
+            });
+            continue;
+          }
+          const version = login.version ? ` (CCU ${login.version})` : "";
+          const roleNote =
+            login.role === "USER"
+              ? " — note: script-based tools (run_script, create_system_variable, acknowledge_service_messages) need an ADMIN-level CCU user"
+              : "";
+          findings.push({
+            profile: p.name,
+            check: "login",
+            ok: true,
+            detail: `login OK as "${p.ccu.user}"${version} — privilege level ${login.role}${roleNote}`,
+          });
+        }
+
+        const ok = findings.every((f) => f.ok);
+        return structuredResult({
+          ok,
+          findings,
+          nextStep: ok
+            ? "All checks passed. Tell the user to reconnect this MCP server (restart the client " +
+              "or its MCP connection) — it will start fully configured with the normal tool set."
+            : "Fix the failing check (setup_write_profile for connection settings; `ccu-mcp secret` " +
+              "for the password), then call setup_test again.",
+        });
+      }),
+  );
+}
+
+export function registerSetupTools(server: McpServer, deps: SetupDeps): void {
+  registerStatus(server, deps);
+  registerProbe(server, deps);
+  registerWriteProfile(server, deps);
+  registerTest(server, deps);
+}

--- a/test/e2e/cli-flags.test.ts
+++ b/test/e2e/cli-flags.test.ts
@@ -78,4 +78,25 @@ describe.skipIf(distMissing)("CLI info flags (no environment)", () => {
     expect(res.status).not.toBe(0);
     expect(res.stderr).toContain("CCU_HOST");
   });
+
+  it("rejects an unknown subcommand by name and version, without starting a server", () => {
+    // A build that predates a subcommand used to fall through to server
+    // startup and answer `ccu-mcp secret …` with "CCU_HOST environment
+    // variable is required" — a configuration complaint for what is really a
+    // wrong/old binary. The version in the message is the point: it tells you
+    // which install a printed command actually reached.
+    const res = runBare("frobnicate");
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('unknown command "frobnicate"');
+    expect(res.stderr).toContain(PKG_VERSION.version);
+    expect(res.stderr).not.toContain("environment variable is required");
+  });
+
+  it("still treats the real subcommands as subcommands", () => {
+    // The guard keys off "does not start with -", so a typo'd flag must not be
+    // swallowed as a command, and a real command must still reach its handler.
+    const res = runBare("doctor", "--env", "/nonexistent/ccu.env");
+    expect(res.stderr).not.toContain("unknown command");
+    expect(`${res.stdout}${res.stderr}`).toContain("doctor");
+  });
 });

--- a/test/e2e/cli-init.test.ts
+++ b/test/e2e/cli-init.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, spawnSync } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, rmSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { AddressInfo } from "node:net";
+import { DIST, distMissing } from "./_dist.js";
+
+// The wizard subcommands run against the BUILT dist like every e2e suite:
+// piped answers drive `ccu-mcp init` against a mock CCU, and `ccu-mcp doctor`
+// then validates the file init wrote. This proves the whole chain — argv
+// dispatch, prompting over a pipe, probing, login, env writing — not just the
+// units.
+
+function startMockCcu(): Promise<{ server: Server; port: number }> {
+  const results: Record<string, unknown> = {
+    "Session.login": "mock-session-id",
+    "Session.logout": true,
+    "Session.renew": true,
+    "CCU.getVersion": "3.85.7-mock",
+  };
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      let method = "";
+      try {
+        method = (JSON.parse(body) as { method: string }).method;
+      } catch {
+        // fall through
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      if (Object.hasOwn(results, method)) {
+        res.end(JSON.stringify({ version: "2.0", result: results[method], error: null }));
+      } else {
+        res.end(
+          JSON.stringify({
+            version: "2.0",
+            result: null,
+            error: { name: "JSONRPCError", code: 501, message: `unknown method ${method}` },
+          }),
+        );
+      }
+    });
+  });
+  return new Promise((resolve) =>
+    server.listen(0, "127.0.0.1", () =>
+      resolve({ server, port: (server.address() as AddressInfo).port }),
+    ),
+  );
+}
+
+/** Run the built CLI with a scrubbed env and the given stdin (no mock needed). */
+function runCli(args: string[], input = "") {
+  return spawnSync(process.execPath, [DIST, ...args], {
+    env: { PATH: process.env.PATH ?? "" },
+    input,
+    encoding: "utf-8",
+    timeout: 60_000,
+  });
+}
+
+/**
+ * Async variant for tests whose child talks to the mock CCU hosted in THIS
+ * process: spawnSync would block the event loop, the mock could never answer,
+ * and every probe would time out.
+ */
+function runCliAsync(
+  args: string[],
+  input = "",
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [DIST, ...args], {
+      env: { PATH: process.env.PATH ?? "" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf-8").on("data", (chunk: string) => (stdout += chunk));
+    child.stderr.setEncoding("utf-8").on("data", (chunk: string) => (stderr += chunk));
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`CLI run timed out\nstdout so far:\n${stdout}`));
+    }, 60_000);
+    child.on("close", (status) => {
+      clearTimeout(timer);
+      resolve({ status, stdout, stderr });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.stdin.end(input);
+  });
+}
+
+describe.skipIf(distMissing)("CLI wizard (built dist)", () => {
+  let dir: string;
+  let envPath: string;
+  let mock: { server: Server; port: number };
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), "e2e-cli-init-"));
+    envPath = join(dir, ".env");
+    mock = await startMockCcu();
+  });
+
+  afterAll(() => {
+    mock.server.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("--help documents the subcommands and the --env flag", () => {
+    const res = runCli(["--help"]);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("init");
+    expect(res.stdout).toContain("doctor");
+    expect(res.stdout).toContain("--env");
+  });
+
+  it("init writes a working .env from piped answers", async () => {
+    const answers = ["n", "127.0.0.1", "n", String(mock.port), "", "e2e-secret", ""].join("\n");
+    const res = await runCliAsync(["init", "--env", envPath], answers);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("privilege level ADMIN");
+    expect(res.stdout).not.toContain("e2e-secret");
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("CCU_HOST=127.0.0.1");
+    expect(content).toContain("CCU_PASSWORD=e2e-secret");
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("doctor passes on the file init wrote", async () => {
+    const res = await runCliAsync(["doctor", "--env", envPath]);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("All checks passed");
+  });
+
+  it("doctor fails on a broken configuration", () => {
+    const brokenPath = join(dir, "broken.env");
+    writeFileSync(brokenPath, "CCU_HOST=127.0.0.1\n"); // password missing
+    const res = runCli(["doctor", "--env", brokenPath]);
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain("configuration invalid");
+  });
+
+  it("the server itself accepts --env (file is loaded before config validation)", () => {
+    // CCU_HOST comes from the file, CCU_PASSWORD is still missing — the error
+    // proves the env file WAS applied (otherwise it would complain about
+    // CCU_HOST first) without having to boot a whole server.
+    const hostOnly = join(dir, "host-only.env");
+    writeFileSync(hostOnly, "CCU_HOST=127.0.0.1\n");
+    const res = runCli(["--http", "--env", hostOnly]);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("CCU_PASSWORD");
+    expect(res.stderr).not.toContain("CCU_HOST environment variable");
+  });
+
+  it("init without answers exits 130 and writes nothing", () => {
+    const emptyPath = join(dir, "never.env");
+    const res = runCli(["init", "--env", emptyPath]);
+    expect(res.status).toBe(130);
+    expect(() => statSync(emptyPath)).toThrow();
+  });
+});

--- a/test/e2e/setup-mode.test.ts
+++ b/test/e2e/setup-mode.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { DIST, distMissing } from "./_dist.js";
+import { startMockCcu, adminResults, type MockCcu } from "../unit/_mock-ccu.js";
+
+// End-to-end test of SETUP MODE (issue #196): the BUILT server, started with
+// --stdio --env <missing file>, must come up as a minimal MCP server exposing
+// only the setup_* tools, let the flow write a real env file (password via the
+// `ccu-mcp secret` CLI, never through the MCP transport), verify it with
+// setup_test, and then — restarted with the identical command line — come up
+// fully configured. That restart is the product promise: the MCP client entry
+// never changes between "not configured yet" and "configured".
+
+/** process.env with every server config var scrubbed. */
+function cleanEnv(): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (/^(CCU_|MCP_|CACHE_|RESOURCE_POLL_INTERVAL$|LOG_LEVEL$)/.test(key)) delete env[key];
+  }
+  return env;
+}
+
+/** Same newline-delimited JSON-RPC framing as stdio-transport.test.ts. */
+class StdioClient {
+  private buffer = "";
+  private pending = new Map<number, (msg: any) => void>();
+  private nextId = 1;
+
+  constructor(private child: ChildProcess) {
+    child.stdout!.setEncoding("utf-8");
+    child.stdout!.on("data", (chunk: string) => {
+      this.buffer += chunk;
+      let nl: number;
+      while ((nl = this.buffer.indexOf("\n")) !== -1) {
+        const line = this.buffer.slice(0, nl).trim();
+        this.buffer = this.buffer.slice(nl + 1);
+        if (!line) continue;
+        let msg: any;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (typeof msg.id === "number" && this.pending.has(msg.id)) {
+          this.pending.get(msg.id)!(msg);
+          this.pending.delete(msg.id);
+        }
+      }
+    });
+  }
+
+  request(method: string, params: unknown = {}, timeoutMs = 10_000): Promise<any> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`stdio request "${method}" timed out`));
+      }, timeoutMs);
+      this.pending.set(id, (msg) => { clearTimeout(timer); resolve(msg); });
+      this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  }
+
+  notify(method: string, params: unknown = {}): void {
+    this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+  }
+}
+
+function spawnServer(envPath: string): { child: ChildProcess; client: StdioClient } {
+  const child = spawn("node", [DIST, "--stdio", "--env", envPath], {
+    env: { ...cleanEnv(), LOG_LEVEL: "error", CACHE_DIR: mkdtempSync(join(tmpdir(), "setup-e2e-cache-")) },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return { child, client: new StdioClient(child) };
+}
+
+async function initialize(client: StdioClient): Promise<any> {
+  const init = await client.request("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "e2e-setup", version: "1" },
+  }, 20_000);
+  client.notify("notifications/initialized");
+  return init;
+}
+
+function endChild(child: ChildProcess | undefined): Promise<number | null> {
+  if (!child || child.exitCode !== null) return Promise.resolve(child?.exitCode ?? null);
+  const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
+  child.stdin!.end();
+  const killTimer = setTimeout(() => child.kill("SIGKILL"), 10_000);
+  return exited.finally(() => clearTimeout(killTimer));
+}
+
+describe.skipIf(distMissing)("setup mode e2e (built server)", () => {
+  let dir: string;
+  let envPath: string;
+  let ccu: MockCcu;
+  let child: ChildProcess | undefined;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), "setup-e2e-"));
+    envPath = join(dir, ".env");
+    ccu = await startMockCcu(adminResults());
+  });
+
+  afterAll(async () => {
+    await endChild(child);
+    await ccu.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("walks the whole flow: setup server → write → secret CLI → verify → configured restart", async () => {
+    // 1. The env file does not exist: the identical client command line must
+    //    yield the setup server, announced via its instructions.
+    const first = spawnServer(envPath);
+    child = first.child;
+    const init = await initialize(first.client);
+    expect(init.result?.serverInfo?.name).toBe("ccu-mcp");
+    expect(init.result?.instructions).toContain("setup mode");
+    expect(init.result?.instructions).toContain("NEVER travel through this conversation");
+
+    const tools = await first.client.request("tools/list");
+    const names = (tools.result?.tools ?? []).map((t: { name: string }) => t.name).sort();
+    expect(names).toEqual(["setup_probe", "setup_status", "setup_test", "setup_write_profile"]);
+
+    // 2. Status → probe → write, all over MCP.
+    const status = await first.client.request("tools/call", { name: "setup_status", arguments: {} });
+    expect(status.result?.structuredContent?.fileExists).toBe(false);
+
+    const probe = await first.client.request("tools/call", {
+      name: "setup_probe",
+      arguments: { host: "127.0.0.1", port: ccu.port, https: false },
+    });
+    expect(probe.result?.structuredContent?.reachable).toBe(true);
+
+    const write = await first.client.request("tools/call", {
+      name: "setup_write_profile",
+      arguments: { name: "dev", host: "127.0.0.1", port: ccu.port, https: false },
+    });
+    expect(write.result?.structuredContent?.written).toBe(true);
+    expect(write.result?.structuredContent?.nextStep).toContain("ccu-mcp secret dev");
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+    // The password is NOT in the file yet — and there is no way to put it
+    // there over MCP.
+    expect(readFileSync(envPath, "utf-8")).toContain('CCU_DEV_PASSWORD=""');
+
+    // 3. The password arrives out-of-band through the local CLI.
+    const secret = spawn("node", [DIST, "secret", "dev", "--env", envPath], {
+      env: { ...cleanEnv() },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    secret.stdin.end("mock-password\n");
+    const secretExit = await new Promise<number | null>((resolve) => secret.once("exit", resolve));
+    expect(secretExit).toBe(0);
+    expect(readFileSync(envPath, "utf-8")).toContain("CCU_DEV_PASSWORD=mock-password");
+
+    // 4. Verification over MCP goes green and points at reconnecting.
+    const test = await first.client.request("tools/call", { name: "setup_test", arguments: {} }, 20_000);
+    expect(test.result?.structuredContent?.ok).toBe(true);
+    expect(test.result?.structuredContent?.nextStep).toContain("reconnect");
+
+    // 5. "Reconnect": stdin EOF ends the setup server cleanly…
+    expect(await endChild(child)).toBe(0);
+
+    // 6. …and the SAME command line now starts the configured server.
+    const second = spawnServer(envPath);
+    child = second.child;
+    const reinit = await initialize(second.client);
+    expect(reinit.result?.instructions ?? "").not.toContain("setup mode");
+    const fullTools = await second.client.request("tools/list");
+    expect((fullTools.result?.tools ?? []).length).toBeGreaterThan(20);
+    expect(await endChild(child)).toBe(0);
+    child = undefined;
+  }, 90_000);
+
+  it("never enters setup mode without --stdio: HTTP with a broken config still dies", () => {
+    const res = spawnSync("node", [DIST, "--http", "--env", join(dir, "does-not-exist.env")], {
+      env: { ...cleanEnv() },
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("does-not-exist.env");
+  });
+
+  it("never enters setup mode without --env: a bare stdio start still fails loudly", () => {
+    const res = spawnSync("node", [DIST, "--stdio"], {
+      env: { ...cleanEnv() },
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("CCU_HOST");
+  });
+});

--- a/test/e2e/setup-mode.test.ts
+++ b/test/e2e/setup-mode.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { mkdtempSync, rmSync, readFileSync, statSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { DIST, distMissing } from "./_dist.js";
@@ -181,6 +181,44 @@ describe.skipIf(distMissing)("setup mode e2e (built server)", () => {
     expect(await endChild(child)).toBe(0);
     child = undefined;
   }, 90_000);
+
+  // QA F-008: a named target loads with an empty password when its key was
+  // never written (the #69 contract), so writing just the host used to be
+  // enough to leave setup mode — full tool set, every call AUTH 501, and no
+  // setup_* tools left to explain it or finish the job.
+  it("stays in setup mode when a named target has no password key yet", async () => {
+    const pendingEnv = join(dir, "pending.env");
+    writeFileSync(pendingEnv, `CCU_PROFILES=prod\nCCU_PROD_HOST=127.0.0.1\nCCU_PROD_PORT=${ccu.port}\n`);
+
+    const s = spawnServer(pendingEnv);
+    child = s.child;
+    const init = await initialize(s.client);
+    expect(init.result?.instructions).toContain("setup mode");
+    // The message must name the target and the exact command that finishes it.
+    expect(init.result?.instructions).toContain("no password stored yet for target prod");
+    expect(init.result?.instructions).toContain("secret prod");
+    const tools = await s.client.request("tools/list");
+    const names = (tools.result?.tools ?? []).map((t: { name: string }) => t.name).sort();
+    expect(names).toEqual(["setup_probe", "setup_status", "setup_test", "setup_write_profile"]);
+    expect(await endChild(child)).toBe(0);
+    child = undefined;
+  }, 60_000);
+
+  // The other half of the rule: an empty password the user MEANT (key present,
+  // no value) is a finished configuration — the #69 OpenCCU dev-box case.
+  it("starts configured when the password key is present but empty", async () => {
+    const emptyPwEnv = join(dir, "emptypw.env");
+    writeFileSync(emptyPwEnv, `CCU_PROFILES=prod\nCCU_PROD_HOST=127.0.0.1\nCCU_PROD_PORT=${ccu.port}\nCCU_PROD_PASSWORD=\n`);
+
+    const s = spawnServer(emptyPwEnv);
+    child = s.child;
+    const init = await initialize(s.client);
+    expect(init.result?.instructions ?? "").not.toContain("setup mode");
+    const tools = await s.client.request("tools/list");
+    expect((tools.result?.tools ?? []).length).toBeGreaterThan(20);
+    expect(await endChild(child)).toBe(0);
+    child = undefined;
+  }, 60_000);
 
   it("never enters setup mode without --stdio: HTTP with a broken config still dies", () => {
     const res = spawnSync("node", [DIST, "--http", "--env", join(dir, "does-not-exist.env")], {

--- a/test/e2e/setup-mode.test.ts
+++ b/test/e2e/setup-mode.test.ts
@@ -139,10 +139,14 @@ describe.skipIf(distMissing)("setup mode e2e (built server)", () => {
     });
     expect(write.result?.structuredContent?.written).toBe(true);
     expect(write.result?.structuredContent?.nextStep).toContain("ccu-mcp secret dev");
+    // Read before stat: the reverse order is a check-then-use pattern CodeQL
+    // flags as a file-system race (js/file-system-race).
+    const written = readFileSync(envPath, "utf-8");
     expect(statSync(envPath).mode & 0o777).toBe(0o600);
-    // The password is NOT in the file yet — and there is no way to put it
-    // there over MCP.
-    expect(readFileSync(envPath, "utf-8")).toContain('CCU_DEV_PASSWORD=""');
+    // The password is NOT in the file yet — the key is absent rather than
+    // empty, so it cannot be mistaken for a deliberately empty password — and
+    // there is no way to put it there over MCP.
+    expect(written).not.toContain("CCU_DEV_PASSWORD");
 
     // 3. The password arrives out-of-band through the local CLI.
     const secret = spawn("node", [DIST, "secret", "dev", "--env", envPath], {

--- a/test/e2e/setup-mode.test.ts
+++ b/test/e2e/setup-mode.test.ts
@@ -138,7 +138,12 @@ describe.skipIf(distMissing)("setup mode e2e (built server)", () => {
       arguments: { name: "dev", host: "127.0.0.1", port: ccu.port, https: false },
     });
     expect(write.result?.structuredContent?.written).toBe(true);
-    expect(write.result?.structuredContent?.nextStep).toContain("ccu-mcp secret dev");
+    // The printed command must invoke THIS server's own entry point — the
+    // subprocess was spawned as `node DIST --stdio …`, so argv[1] is DIST.
+    // A bare `npx ccu-mcp` here reaches whichever install npx finds, which for
+    // an older global has no `secret` subcommand and fails with a misleading
+    // "CCU_HOST environment variable is required".
+    expect(write.result?.structuredContent?.nextStep).toContain(`node ${DIST} secret dev`);
     // Read before stat: the reverse order is a check-then-use pattern CodeQL
     // flags as a file-system race (js/file-system-race).
     const written = readFileSync(envPath, "utf-8");

--- a/test/integration/setup-live.test.ts
+++ b/test/integration/setup-live.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PassThrough } from "node:stream";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createSetupServer } from "../../src/setup-server.js";
+import { probeApi, probeConfig, testLogin } from "../../src/cli/probe.js";
+import { run as runSecret } from "../../src/cli/secret.js";
+import { run as runDoctor } from "../../src/cli/doctor.js";
+import { Logger } from "../../src/logger.js";
+import { callTool, parseToolResult } from "../unit/_helpers.js";
+
+// Live integration for the setup flow against the OpenCCU dev VM — a real
+// ReGa, no radio hardware, Admin with (usually) an empty password. Gated on
+// CCU_DEV_HOST, so `npm test` stays hermetic; run it with the VM up:
+//
+//   CCU_DEV_HOST=127.0.0.1 CCU_DEV_PORT=18080 npm test
+//
+// (CCU_DEV_USER / CCU_DEV_PASSWORD override the Admin/empty default.) These
+// are the dev-profile variable names from .env, read directly by this suite —
+// deliberately NOT via loadConfig, so the flat CCU_* vars can simultaneously
+// point the tools-live suite at another box (or the same one).
+
+const DEV_HOST = process.env.CCU_DEV_HOST;
+const describeIf = DEV_HOST ? describe : describe.skip;
+
+const DEV = {
+  host: DEV_HOST ?? "",
+  port: parseInt(process.env.CCU_DEV_PORT || "80", 10),
+  https: process.env.CCU_DEV_HTTPS === "true",
+  user: process.env.CCU_DEV_USER || "Admin",
+  password: process.env.CCU_DEV_PASSWORD ?? "",
+};
+
+describeIf("setup flow against the live dev CCU", () => {
+  let dir: string;
+  let envPath: string;
+  let server: McpServer;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "setup-live-"));
+    envPath = join(dir, ".env");
+    server = createSetupServer(envPath, "CCU_HOST environment variable is required", new Logger("error"));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("probeApi classifies the real JSON-RPC endpoint as a CCU", async () => {
+    const outcome = await probeApi(probeConfig(DEV.host, DEV.port, DEV.https));
+    expect(outcome.kind).toBe("ccu");
+  });
+
+  it("testLogin detects the ADMIN role against the real ReGa", async () => {
+    const result = await testLogin({
+      host: DEV.host,
+      port: DEV.port,
+      https: DEV.https,
+      tlsVerify: false,
+      user: DEV.user,
+      password: DEV.password,
+      timeout: 10_000,
+      scriptTimeout: 30_000,
+    });
+    expect(result).toMatchObject({ ok: true, role: "ADMIN" });
+    if (result.ok) expect(result.version).toMatch(/^\d+\./);
+  });
+
+  it("walks probe → write → secret → setup_test green, then doctor agrees", async () => {
+    const probe = parseToolResult(
+      await callTool(server, "setup_probe", { host: DEV.host, port: DEV.port, https: DEV.https }),
+    ) as any;
+    expect(probe.reachable).toBe(true);
+
+    const write = parseToolResult(
+      await callTool(server, "setup_write_profile", {
+        name: "dev",
+        host: DEV.host,
+        port: DEV.port,
+        https: DEV.https,
+        user: DEV.user,
+      }),
+    ) as any;
+    expect(write.written).toBe(true);
+
+    // The password hand-off, exactly as a user would run it (piped answer
+    // standing in for the hidden prompt).
+    const input = new PassThrough();
+    const output = new PassThrough();
+    output.on("data", () => {});
+    input.end(DEV.password + "\n");
+    expect(await runSecret(["dev", "--env", envPath], { input, output })).toBe(0);
+
+    const test = parseToolResult(await callTool(server, "setup_test")) as any;
+    expect(test.ok).toBe(true);
+    expect(test.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ profile: "dev", check: "login", ok: true }),
+      ]),
+    );
+
+    // Independent second opinion: the doctor CLI on the same file. It loads
+    // the env file into process.env, so scrub what it may set afterwards.
+    const before = { ...process.env };
+    try {
+      const docOut = new PassThrough();
+      let doc = "";
+      docOut.on("data", (chunk) => (doc += String(chunk)));
+      const docIn = new PassThrough();
+      docIn.end();
+      expect(await runDoctor(["--env", envPath], { input: docIn, output: docOut })).toBe(0);
+      expect(doc).toContain("All checks passed");
+      expect(doc).toContain("privilege level ADMIN");
+    } finally {
+      for (const key of Object.keys(process.env)) {
+        if (!(key in before)) delete process.env[key];
+      }
+      Object.assign(process.env, before);
+    }
+
+    // The file holds what the flow established — and nothing else leaked out.
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("CCU_PROFILES=dev");
+    expect(content).toContain(`CCU_DEV_HOST=${DEV.host}`);
+  });
+});

--- a/test/integration/tools-live.test.ts
+++ b/test/integration/tools-live.test.ts
@@ -82,8 +82,11 @@ describeIf("MCP tools against live CCU", () => {
     }
   }, 60_000);
 
-  it("get_values by channel list returns exactly the requested channels", async () => {
+  it("get_values by channel list returns exactly the requested channels", async (ctx) => {
     const devices = parseToolResult(await callTool(server, "list_devices")) as Array<{ channels: Array<{ address: string }> }>;
+    // A device-less CCU (the OpenCCU dev VM has no RF hardware) has nothing to
+    // read — skip rather than fail on the environment.
+    if (devices.length === 0) ctx.skip();
     const channel = devices[0]!.channels[0]!.address;
 
     const result = parseToolResult(await callTool(server, "get_values", { channels: [channel] })) as any[];
@@ -255,7 +258,7 @@ describeIf("MCP tools against live CCU", () => {
 
   // Assign a channel to a room, verify via list_rooms, then revert — leaving the
   // CCU as found. Skips gracefully if the CCU has no rooms/channels to work with.
-  it("assign_channel → verify via list_rooms → unassign (live)", async () => {
+  it("assign_channel → verify via list_rooms → unassign (live)", async (ctx) => {
     const rooms = parseToolResult(await callTool(server, "list_rooms")) as Array<{ id: string; name: string; channelIds: string[] }>;
     expect(rooms.length).toBeGreaterThan(0);
     // Filtered list_devices returns FULL channel objects (with `id`); the
@@ -263,6 +266,9 @@ describeIf("MCP tools against live CCU", () => {
     const populated = rooms.find((r) => r.channelIds.length > 0) ?? rooms[0]!;
     const devices = parseToolResult(await callTool(server, "list_devices", { room: populated.name })) as Array<{ channels: Array<{ id: string; address: string }> }>;
     const channel = devices.flatMap((d) => d.channels).find((c) => c.id && c.address);
+    // A device-less CCU (the OpenCCU dev VM) has no channel to move — skip
+    // rather than fail on the environment.
+    if (!channel) ctx.skip();
     expect(channel).toBeDefined();
 
     // Pick a room the channel is NOT already in, so the revert is a true revert.

--- a/test/unit/_helpers.ts
+++ b/test/unit/_helpers.ts
@@ -15,14 +15,16 @@ interface TargetSpec {
   readonly?: boolean;
   password?: string;
   sessionCall?: SessionCall;
+  /** Session state reported by isLoggedIn() — false stands in for a login that never succeeded. */
+  loggedIn?: boolean;
 }
 
-function makeSession(sessionCall?: SessionCall) {
+function makeSession(sessionCall?: SessionCall, loggedIn = true) {
   return {
     call: sessionCall ?? vi.fn(async () => []),
     login: vi.fn(async () => {}),
     logout: vi.fn(async () => {}),
-    isLoggedIn: vi.fn(() => true),
+    isLoggedIn: vi.fn(() => loggedIn),
     getSessionId: vi.fn(() => "test-session"),
     callNoSession: vi.fn(async () => null),
     destroy: vi.fn(),
@@ -38,7 +40,7 @@ function makeTarget(spec: TargetSpec): Target {
       readonly: spec.readonly ?? false,
       ccu: { host: "test", port: 80, https: false, tlsVerify: false, user: "Admin", password: spec.password ?? "pw", timeout: 5000, scriptTimeout: 10000 },
     },
-    session: makeSession(spec.sessionCall),
+    session: makeSession(spec.sessionCall, spec.loggedIn ?? true),
     resolver: new Resolver(),
     deviceTypeCache: new DeviceTypeCache("/tmp/nonexistent-test", 86400, new Logger("error"), `device-type-cache.${name}.json`),
     sysVarTypeCache: { entry: null, gen: 0 },
@@ -73,6 +75,8 @@ export function createMockDeps(overrides?: {
   readonly?: boolean;
   /** Build a multi-target registry instead of the single default target. */
   targets?: TargetSpec[];
+  /** Session state of the single default target; false = login never succeeded. */
+  loggedIn?: boolean;
 }): ServerDeps {
   const rateLimiter = new RateLimiter(1000, 1000); // effectively unlimited for tests
   const specs: TargetSpec[] = overrides?.targets ?? [{
@@ -80,6 +84,7 @@ export function createMockDeps(overrides?: {
     protected: overrides?.protected,
     readonly: overrides?.readonly,
     sessionCall: overrides?.sessionCall,
+    loggedIn: overrides?.loggedIn,
   }];
   const registry = new FakeRegistry(specs.map(makeTarget));
   const selection = new TargetSelection(registry as unknown as TargetRegistry);

--- a/test/unit/_mock-ccu.ts
+++ b/test/unit/_mock-ccu.ts
@@ -1,0 +1,88 @@
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
+import type { AddressInfo } from "node:net";
+
+/**
+ * Minimal mock CCU JSON-RPC endpoint for the CLI wizard tests: answers every
+ * POST with the configured result for the request's method, or a JSON-RPC
+ * error envelope. Values in `results` may be an error spec to simulate CCU
+ * error codes (e.g. 400 access denied for privilege probes).
+ */
+export type MockResult = unknown | { __error: { code: number; message: string } };
+
+export interface MockCcu {
+  port: number;
+  calls: string[];
+  close: () => Promise<void>;
+}
+
+function handler(results: Record<string, MockResult>, calls: string[]) {
+  return (req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse): void => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      let method = "";
+      try {
+        method = (JSON.parse(body) as { method: string }).method;
+      } catch {
+        // fall through to the unknown-method error envelope
+      }
+      calls.push(method);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      if (Object.hasOwn(results, method)) {
+        const value = results[method] as MockResult;
+        if (value !== null && typeof value === "object" && "__error" in (value as object)) {
+          const e = (value as { __error: { code: number; message: string } }).__error;
+          res.end(JSON.stringify({ version: "2.0", result: null, error: { name: "Error", ...e } }));
+          return;
+        }
+        res.end(JSON.stringify({ version: "2.0", result: value, error: null }));
+        return;
+      }
+      res.end(
+        JSON.stringify({
+          version: "2.0",
+          result: null,
+          error: { name: "JSONRPCError", code: 501, message: `unknown method ${method}` },
+        }),
+      );
+    });
+  };
+}
+
+export function startMockCcu(results: Record<string, MockResult> = {}): Promise<MockCcu> {
+  const calls: string[] = [];
+  const server: HttpServer = createHttpServer(handler(results, calls));
+  return listen(server, calls);
+}
+
+export function startMockCcuTls(
+  tls: { cert: string; key: string },
+  results: Record<string, MockResult> = {},
+): Promise<MockCcu> {
+  const calls: string[] = [];
+  const server: HttpsServer = createHttpsServer(tls, handler(results, calls));
+  return listen(server, calls);
+}
+
+function listen(server: HttpServer | HttpsServer, calls: string[]): Promise<MockCcu> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        port: (server.address() as AddressInfo).port,
+        calls,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+/** The standard happy-path result set: login works, the user is ADMIN. */
+export function adminResults(): Record<string, MockResult> {
+  return {
+    "Session.login": "mock-session-id",
+    "Session.logout": true,
+    "Session.renew": true,
+    "CCU.getVersion": "3.85.7-mock",
+  };
+}

--- a/test/unit/cli-doctor.test.ts
+++ b/test/unit/cli-doctor.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PassThrough } from "node:stream";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { X509Certificate } from "node:crypto";
+import { run } from "../../src/cli/doctor.js";
+import type { PromptIo } from "../../src/cli/prompt.js";
+import { startMockCcu, startMockCcuTls, adminResults, type MockCcu } from "./_mock-ccu.js";
+
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+
+// doctor loads the env file into process.env (same precedence as the server's
+// --env flag), so every test must start from a scrubbed environment and leave
+// no residue for the next one.
+const savedEnv = { ...process.env };
+function scrubEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (/^(CCU_|MCP_|CACHE_)/.test(key)) delete process.env[key];
+  }
+}
+function restoreEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, savedEnv);
+}
+
+function makeIo(answers: string[], tty = false): { io: PromptIo; output: () => string } {
+  const input = new PassThrough() as PassThrough & { isTTY?: boolean };
+  if (tty) input.isTTY = true;
+  const output = new PassThrough();
+  let out = "";
+  output.on("data", (chunk) => (out += String(chunk)));
+  input.end(answers.join("\n") + "\n");
+  return { io: { input, output }, output: () => out };
+}
+
+describe("ccu-mcp doctor", () => {
+  let dir: string;
+  let envPath: string;
+  let mock: MockCcu | undefined;
+
+  beforeEach(() => {
+    scrubEnv();
+    dir = mkdtempSync(join(tmpdir(), "cli-doctor-"));
+    envPath = join(dir, ".env");
+  });
+
+  afterEach(async () => {
+    restoreEnv();
+    rmSync(dir, { recursive: true, force: true });
+    await mock?.close();
+    mock = undefined;
+  });
+
+  it("passes on a valid flat configuration", async () => {
+    mock = await startMockCcu(adminResults());
+    writeFileSync(envPath, `CCU_HOST=127.0.0.1\nCCU_PORT=${mock.port}\nCCU_PASSWORD=pw\n`);
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain("All checks passed");
+    expect(output()).toContain("privilege level ADMIN");
+  });
+
+  it("fails when the env file does not exist", async () => {
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", join(dir, "missing.env")], io)).toBe(1);
+    expect(output()).toContain("✗");
+  });
+
+  it("reports configuration errors as findings", async () => {
+    writeFileSync(envPath, "CCU_HOST=127.0.0.1\n"); // no password
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(output()).toContain("configuration invalid");
+    expect(output()).toContain("CCU_PASSWORD");
+  });
+
+  it("fails on an unreachable CCU", async () => {
+    // Reserve a port and free it again so nothing answers there.
+    mock = await startMockCcu();
+    const port = mock.port;
+    await mock.close();
+    mock = undefined;
+    writeFileSync(envPath, `CCU_HOST=127.0.0.1\nCCU_PORT=${port}\nCCU_PASSWORD=pw\n`);
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(output()).toContain("not reachable");
+  });
+
+  it("checks every profile of a multi-target file", async () => {
+    mock = await startMockCcu(adminResults());
+    writeFileSync(
+      envPath,
+      [
+        "CCU_PROFILES=prod,dev",
+        "CCU_DEFAULT_PROFILE=prod",
+        `CCU_PROD_HOST=127.0.0.1`,
+        `CCU_PROD_PORT=${mock.port}`,
+        "CCU_PROD_PASSWORD=pw",
+        `CCU_DEV_HOST=127.0.0.1`,
+        `CCU_DEV_PORT=${mock.port}`,
+        "CCU_DEV_PASSWORD=pw",
+        "",
+      ].join("\n"),
+    );
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain('Target "prod"');
+    expect(output()).toContain('Target "dev"');
+  });
+});
+
+describe.skipIf(!HAVE_OPENSSL)("ccu-mcp doctor TLS pin checks", () => {
+  let dir: string;
+  let tlsDir: string;
+  let envPath: string;
+  let mock: MockCcu;
+  let fingerprint: string;
+
+  beforeEach(async () => {
+    scrubEnv();
+    dir = mkdtempSync(join(tmpdir(), "cli-doctor-tls-"));
+    tlsDir = mkdtempSync(join(tmpdir(), "cli-doctor-cert-"));
+    envPath = join(dir, ".env");
+    const certPath = join(tlsDir, "cert.pem");
+    const keyPath = join(tlsDir, "key.pem");
+    spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=ccu-doctor",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    const certPem = readFileSync(certPath, "utf-8");
+    fingerprint = new X509Certificate(certPem).fingerprint256;
+    mock = await startMockCcuTls({ cert: certPem, key: readFileSync(keyPath, "utf-8") }, adminResults());
+  });
+
+  afterEach(async () => {
+    restoreEnv();
+    await mock.close();
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(tlsDir, { recursive: true, force: true });
+  });
+
+  function writeEnv(pin: string): void {
+    writeFileSync(
+      envPath,
+      `CCU_HOST=127.0.0.1\nCCU_PORT=${mock.port}\nCCU_HTTPS=true\nCCU_TLS_FINGERPRINT=${pin}\nCCU_PASSWORD=pw\n`,
+    );
+  }
+
+  it("passes when the pinned fingerprint matches", async () => {
+    writeEnv(fingerprint);
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain("fingerprint matches");
+  });
+
+  it("reports a mismatch and skips the login test (non-interactive)", async () => {
+    writeEnv("00".repeat(32));
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(output()).toContain("does NOT match");
+    expect(output()).toContain("skipping the login test");
+    // Non-interactive: the file must not have been touched.
+    expect(readFileSync(envPath, "utf-8")).toContain("00".repeat(32));
+  });
+
+  it("offers to refresh the pin when interactive, then a re-run passes", async () => {
+    writeEnv("00".repeat(32));
+    const first = makeIo(["y"], true);
+    expect(await run(["--env", envPath], first.io)).toBe(1);
+    expect(first.output()).toContain("Pin updated");
+    expect(readFileSync(envPath, "utf-8")).toContain(`CCU_TLS_FINGERPRINT=${fingerprint}`);
+
+    // Doctor's env application skips already-set keys; scrub between runs so
+    // the second run reads the refreshed file, not the first run's residue.
+    scrubEnv();
+    const second = makeIo([]);
+    expect(await run(["--env", envPath], second.io)).toBe(0);
+    expect(second.output()).toContain("All checks passed");
+  });
+
+  it("leaves the pin alone when the user declines", async () => {
+    writeEnv("00".repeat(32));
+    const { io } = makeIo(["n"], true);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(readFileSync(envPath, "utf-8")).toContain("00".repeat(32));
+  });
+});

--- a/test/unit/cli-env-writer.test.ts
+++ b/test/unit/cli-env-writer.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { parseEnv } from "node:util";
+import { mkdtempSync, rmSync, statSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  MANAGED_KEY_RE,
+  quoteEnvValue,
+  buildEnvContent,
+  mergeEnvContent,
+  replaceEnvKey,
+  writeEnvFile,
+  type WizardProfile,
+} from "../../src/cli/env-writer.js";
+
+function profile(overrides: Partial<WizardProfile> = {}): WizardProfile {
+  return {
+    name: "default",
+    host: "ccu.local",
+    port: 443,
+    https: true,
+    user: "Admin",
+    password: "pw",
+    protected: false,
+    readonly: false,
+    ...overrides,
+  };
+}
+
+describe("quoteEnvValue", () => {
+  // Round-trip through the same parser doctor and the server's --env flag
+  // use: whatever the writer quotes, parseEnv must read back verbatim.
+  it("round-trips awkward values through util.parseEnv", () => {
+    const values = ["plain", "with space", "pa#ss", 'quo"te', "s'ngle", "back`tick", 'mi"x\'ed', "", "tra1l1ng!"];
+    for (const value of values) {
+      const parsed = parseEnv(`KEY=${quoteEnvValue(value)}`) as Record<string, string>;
+      expect(parsed.KEY, JSON.stringify(value)).toBe(value);
+    }
+  });
+
+  it("rejects a value containing all three quote characters", () => {
+    expect(() => quoteEnvValue("a\"b'c`d")).toThrow(/quote characters/);
+  });
+});
+
+describe("buildEnvContent", () => {
+  it("writes flat vars for a single target", () => {
+    const content = buildEnvContent([profile({ tlsFingerprint: "AB:CD" })], "default");
+    expect(content).toContain("CCU_HOST=ccu.local");
+    expect(content).toContain("CCU_PORT=443");
+    expect(content).toContain("CCU_HTTPS=true");
+    expect(content).toContain("CCU_USER=Admin");
+    expect(content).toContain("CCU_PASSWORD=pw");
+    expect(content).toContain("CCU_TLS_FINGERPRINT=AB:CD");
+    expect(content).not.toContain("CCU_PROFILES");
+    expect(content).not.toContain("PROTECTED");
+  });
+
+  it("writes CCU_PROFILES form for multiple targets", () => {
+    const content = buildEnvContent(
+      [
+        profile({ name: "prod", protected: true }),
+        profile({ name: "dev", host: "dev.local", https: false, port: 80, readonly: true }),
+      ],
+      "prod",
+    );
+    expect(content).toContain("CCU_PROFILES=prod,dev");
+    expect(content).toContain("CCU_DEFAULT_PROFILE=prod");
+    expect(content).toContain("CCU_PROD_HOST=ccu.local");
+    expect(content).toContain("CCU_PROD_PROTECTED=true");
+    expect(content).toContain("CCU_DEV_HOST=dev.local");
+    expect(content).toContain("CCU_DEV_READONLY=true");
+    expect(content).not.toContain("CCU_DEV_PROTECTED");
+    expect(content).not.toContain("\nCCU_HOST=");
+  });
+});
+
+describe("mergeEnvContent", () => {
+  const existing = [
+    "# operator notes",
+    "MCP_AUTH_TOKEN=tok123",
+    "CCU_HOST=old.local",
+    "CCU_PASSWORD=oldpw",
+    "CCU_OLDPROF_HOST=stale.local",
+    "CCU_RATE_LIMIT_BURST=50",
+    "CCU_TIMEOUT=20000",
+    "LOG_LEVEL=debug",
+  ].join("\n");
+
+  it("replaces managed keys (any profile prefix) and preserves the rest", () => {
+    const managed = buildEnvContent([profile()], "default");
+    const { content, replaced } = mergeEnvContent(existing, managed);
+    expect(replaced).toEqual(["CCU_HOST", "CCU_PASSWORD", "CCU_OLDPROF_HOST"]);
+    expect(content).toContain("CCU_HOST=ccu.local");
+    expect(content).not.toContain("old.local");
+    expect(content).not.toContain("stale.local");
+    // Operator-owned lines survive: token, comments, tuning knobs.
+    expect(content).toContain("MCP_AUTH_TOKEN=tok123");
+    expect(content).toContain("# operator notes");
+    expect(content).toContain("CCU_RATE_LIMIT_BURST=50");
+    expect(content).toContain("CCU_TIMEOUT=20000");
+    expect(content).toContain("LOG_LEVEL=debug");
+  });
+
+  it("managed-key regex owns the roster keys but not tuning knobs", () => {
+    for (const line of ["CCU_PROFILES=a,b", "CCU_DEFAULT_PROFILE=a", "CCU_PROD_TLS_FINGERPRINT=x"]) {
+      expect(MANAGED_KEY_RE.test(line), line).toBe(true);
+    }
+    for (const line of ["CCU_RATE_LIMIT_BURST=1", "CCU_RATE_LIMIT_RATE=1", "CCU_TIMEOUT=1", "CCU_PROD_SCRIPT_TIMEOUT=1", "MCP_PORT=3000"]) {
+      expect(MANAGED_KEY_RE.test(line), line).toBe(false);
+    }
+  });
+});
+
+describe("replaceEnvKey", () => {
+  it("replaces an existing key in place", () => {
+    const content = "CCU_HOST=x\nCCU_TLS_FINGERPRINT=old\nLOG_LEVEL=info\n";
+    const out = replaceEnvKey(content, "CCU_TLS_FINGERPRINT", "new");
+    expect(out).toContain("CCU_TLS_FINGERPRINT=new");
+    expect(out).not.toContain("old");
+    expect(out).toContain("LOG_LEVEL=info");
+  });
+
+  it("appends when the key is missing", () => {
+    const out = replaceEnvKey("CCU_HOST=x\n", "CCU_TLS_FINGERPRINT", "new");
+    expect(out).toContain("CCU_HOST=x");
+    expect(out.trimEnd().endsWith("CCU_TLS_FINGERPRINT=new")).toBe(true);
+  });
+});
+
+describe("writeEnvFile", () => {
+  it("writes mode 0600", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cli-env-"));
+    try {
+      const path = join(dir, ".env");
+      writeEnvFile(path, "CCU_HOST=x\n");
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+      expect(readFileSync(path, "utf-8")).toBe("CCU_HOST=x\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/cli-init.test.ts
+++ b/test/unit/cli-init.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PassThrough } from "node:stream";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { X509Certificate } from "node:crypto";
+import { run } from "../../src/cli/init.js";
+import type { PromptIo } from "../../src/cli/prompt.js";
+import { startMockCcu, startMockCcuTls, adminResults, type MockCcu } from "./_mock-ccu.js";
+
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+
+function makeIo(answers: string[]): { io: PromptIo; output: () => string } {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  let out = "";
+  output.on("data", (chunk) => (out += String(chunk)));
+  input.end(answers.join("\n") + "\n");
+  return { io: { input, output }, output: () => out };
+}
+
+describe("ccu-mcp init", () => {
+  let dir: string;
+  let envPath: string;
+  let mock: MockCcu | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "cli-init-"));
+    envPath = join(dir, ".env");
+  });
+
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true });
+    await mock?.close();
+    mock = undefined;
+  });
+
+  it("writes a flat .env for a single target (happy path)", async () => {
+    mock = await startMockCcu(adminResults());
+    const { io, output } = makeIo([
+      "n", // multiple targets?
+      "127.0.0.1", // host
+      "n", // HTTPS?
+      String(mock.port), // port
+      "", // user -> Admin
+      "s3cret", // password
+    ]);
+    const code = await run(["--env", envPath], io);
+    expect(code).toBe(0);
+    expect(output()).toContain("privilege level ADMIN");
+    expect(output()).toContain("--env");
+    expect(output()).not.toContain("s3cret"); // never echo the password
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("CCU_HOST=127.0.0.1");
+    expect(content).toContain(`CCU_PORT=${mock.port}`);
+    expect(content).toContain("CCU_HTTPS=false");
+    expect(content).toContain("CCU_USER=Admin");
+    expect(content).toContain("CCU_PASSWORD=s3cret");
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("writes CCU_PROFILES for a multi-target setup", async () => {
+    mock = await startMockCcu(adminResults());
+    const p = String(mock.port);
+    const { io } = makeIo([
+      "y", // multiple targets
+      "", // name -> prod
+      "127.0.0.1", "n", p, "", "pw1", // endpoint + creds
+      "y", // protected
+      "", // readonly -> n
+      "y", // add another
+      "dev", // name
+      "127.0.0.1", "n", p, "", "pw2",
+      "", "", // protected/readonly -> n
+      "", // add another -> n
+      "dev", // default target
+    ]);
+    const code = await run(["--env", envPath], io);
+    expect(code).toBe(0);
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("CCU_PROFILES=prod,dev");
+    expect(content).toContain("CCU_DEFAULT_PROFILE=dev");
+    expect(content).toContain("CCU_PROD_PROTECTED=true");
+    expect(content).toContain("CCU_DEV_HOST=127.0.0.1");
+    expect(content).not.toContain("CCU_DEV_PROTECTED");
+  });
+
+  it("warns about USER-level accounts", async () => {
+    mock = await startMockCcu({
+      ...adminResults(),
+      "CCU.getVersion": { __error: { code: 400, message: "access denied" } },
+    });
+    const { io, output } = makeIo(["n", "127.0.0.1", "n", String(mock.port), "claude", "pw"]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain("privilege level USER");
+    expect(output()).toContain("need an ADMIN-level CCU user");
+  });
+
+  it("aborts without writing when credentials fail and the user gives up", async () => {
+    mock = await startMockCcu({
+      ...adminResults(),
+      "Session.login": { __error: { code: 400, message: "access denied" } },
+    });
+    const { io, output } = makeIo([
+      "n", "127.0.0.1", "n", String(mock.port), "", "wrongpw",
+      "n", // re-enter?
+      "n", // save anyway?
+    ]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(output()).toContain("Login failed");
+    expect(existsSync(envPath)).toBe(false);
+  });
+
+  it("can save untested credentials on explicit request", async () => {
+    mock = await startMockCcu({
+      ...adminResults(),
+      "Session.login": { __error: { code: 400, message: "access denied" } },
+    });
+    const { io } = makeIo([
+      "n", "127.0.0.1", "n", String(mock.port), "", "maybe-right",
+      "n", // re-enter?
+      "y", // save anyway
+    ]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(readFileSync(envPath, "utf-8")).toContain("CCU_PASSWORD=maybe-right");
+  });
+
+  it("preserves foreign lines and asks before replacing managed keys", async () => {
+    mock = await startMockCcu(adminResults());
+    writeFileSync(envPath, "MCP_AUTH_TOKEN=tok\nCCU_HOST=old.local\n");
+    const { io, output } = makeIo([
+      "n", "127.0.0.1", "n", String(mock.port), "", "pw",
+      "y", // replace existing CCU settings
+    ]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain("already configures a CCU");
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("MCP_AUTH_TOKEN=tok");
+    expect(content).toContain("CCU_HOST=127.0.0.1");
+    expect(content).not.toContain("old.local");
+  });
+
+  it("leaves an existing file untouched when the user declines", async () => {
+    mock = await startMockCcu(adminResults());
+    const before = "CCU_HOST=old.local\nCCU_PASSWORD=oldpw\n";
+    writeFileSync(envPath, before);
+    const { io } = makeIo([
+      "n", "127.0.0.1", "n", String(mock.port), "", "pw",
+      "n", // do NOT replace
+    ]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(readFileSync(envPath, "utf-8")).toBe(before);
+  });
+
+  it("returns 130 when the input closes mid-wizard", async () => {
+    const { io } = makeIo(["n"]); // only the first answer, then EOF
+    expect(await run(["--env", envPath], io)).toBe(130);
+    expect(existsSync(envPath)).toBe(false);
+  });
+});
+
+describe.skipIf(!HAVE_OPENSSL)("ccu-mcp init over HTTPS", () => {
+  let dir: string;
+  let tlsDir: string;
+  let mock: MockCcu;
+  let fingerprint: string;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "cli-init-tls-"));
+    tlsDir = mkdtempSync(join(tmpdir(), "cli-init-cert-"));
+    const certPath = join(tlsDir, "cert.pem");
+    const keyPath = join(tlsDir, "key.pem");
+    spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=ccu-init",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    const certPem = readFileSync(certPath, "utf-8");
+    fingerprint = new X509Certificate(certPem).fingerprint256;
+    mock = await startMockCcuTls({ cert: certPem, key: readFileSync(keyPath, "utf-8") }, adminResults());
+  });
+
+  afterEach(async () => {
+    await mock.close();
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(tlsDir, { recursive: true, force: true });
+  });
+
+  it("shows the certificate and pins its fingerprint", async () => {
+    const envPath = join(dir, ".env");
+    const { io, output } = makeIo([
+      "n", "127.0.0.1",
+      "y", // HTTPS
+      String(mock.port),
+      "y", // pin fingerprint
+      "", "pw",
+    ]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(output()).toContain("ccu-init"); // subject CN shown
+    expect(readFileSync(envPath, "utf-8")).toContain(`CCU_TLS_FINGERPRINT=${fingerprint}`);
+  });
+});

--- a/test/unit/cli-probe.test.ts
+++ b/test/unit/cli-probe.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { X509Certificate } from "node:crypto";
+import type { AddressInfo } from "node:net";
+import {
+  probeApi,
+  probeConfig,
+  fetchCert,
+  fingerprintMatches,
+  testLogin,
+} from "../../src/cli/probe.js";
+import { startMockCcu, startMockCcuTls, adminResults, type MockCcu } from "./_mock-ccu.js";
+
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+
+describe("probeApi", () => {
+  it("classifies a JSON-RPC error envelope as a CCU", async () => {
+    const mock = await startMockCcu(); // every method -> error envelope
+    try {
+      const outcome = await probeApi(probeConfig("127.0.0.1", mock.port, false));
+      expect(outcome.kind).toBe("ccu");
+    } finally {
+      await mock.close();
+    }
+  });
+
+  it("classifies a non-JSON-RPC HTTP server as not-ccu", async () => {
+    const server: Server = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<html>hello</html>");
+    });
+    const port = await new Promise<number>((resolve) =>
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port)),
+    );
+    try {
+      const outcome = await probeApi(probeConfig("127.0.0.1", port, false));
+      expect(outcome.kind).toBe("not-ccu");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("classifies a closed port as unreachable", async () => {
+    // Grab an ephemeral port and free it again — nothing listens there now.
+    const server: Server = createServer(() => {});
+    const port = await new Promise<number>((resolve) =>
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port)),
+    );
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    const outcome = await probeApi(probeConfig("127.0.0.1", port, false));
+    expect(outcome.kind).toBe("unreachable");
+  });
+});
+
+describe("testLogin", () => {
+  let mock: MockCcu;
+
+  afterAll(async () => {
+    await mock?.close();
+  });
+
+  it("reports ADMIN when the capability probe answers", async () => {
+    mock = await startMockCcu(adminResults());
+    const result = await testLogin({ ...probeConfig("127.0.0.1", mock.port, false), user: "Admin", password: "pw" });
+    expect(result).toMatchObject({ ok: true, role: "ADMIN", version: "3.85.7-mock" });
+    // The probe must clean up after itself: the session it minted is logged out.
+    expect(mock.calls).toContain("Session.logout");
+    await mock.close();
+  });
+
+  it("reports USER when the ADMIN-only probe is denied", async () => {
+    // Code 400 is the CCU's "access denied"; with the session still valid the
+    // session manager surfaces it as a privilege denial, which means USER.
+    mock = await startMockCcu({
+      ...adminResults(),
+      "CCU.getVersion": { __error: { code: 400, message: "access denied" } },
+    });
+    const result = await testLogin({ ...probeConfig("127.0.0.1", mock.port, false), user: "claude", password: "pw" });
+    expect(result).toMatchObject({ ok: true, role: "USER" });
+    await mock.close();
+  });
+
+  it("reports UNKNOWN when the probe fails for a non-privilege reason", async () => {
+    mock = await startMockCcu({
+      ...adminResults(),
+      "CCU.getVersion": { __error: { code: 501, message: "internal error" } },
+    });
+    const result = await testLogin({ ...probeConfig("127.0.0.1", mock.port, false), user: "Admin", password: "pw" });
+    expect(result).toMatchObject({ ok: true, role: "UNKNOWN" });
+    await mock.close();
+  });
+
+  it("returns the structured error when login fails", async () => {
+    mock = await startMockCcu({
+      ...adminResults(),
+      "Session.login": { __error: { code: 400, message: "access denied" } },
+    });
+    const result = await testLogin({ ...probeConfig("127.0.0.1", mock.port, false), user: "Admin", password: "wrong" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.error).toBe("AUTH");
+    await mock.close();
+  });
+});
+
+describe.skipIf(!HAVE_OPENSSL)("fetchCert (real HTTPS server)", () => {
+  let mock: MockCcu;
+  let fingerprint: string;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "cli-probe-tls-"));
+    const certPath = join(tmpDir, "cert.pem");
+    const keyPath = join(tmpDir, "key.pem");
+    const gen = spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=ccu-test",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    if (gen.status !== 0) throw new Error("openssl failed to generate test cert");
+    const certPem = readFileSync(certPath, "utf-8");
+    fingerprint = new X509Certificate(certPem).fingerprint256;
+    mock = await startMockCcuTls({ cert: certPem, key: readFileSync(keyPath, "utf-8") }, adminResults());
+  });
+
+  afterAll(async () => {
+    await mock?.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the certificate's SHA-256 fingerprint and subject", async () => {
+    const cert = await fetchCert("127.0.0.1", mock.port);
+    expect(fingerprintMatches(cert.fingerprint256, fingerprint)).toBe(true);
+    expect(cert.subjectCN).toBe("ccu-test");
+  });
+
+  it("fingerprintMatches is colon- and case-insensitive", () => {
+    expect(fingerprintMatches(fingerprint.replace(/:/g, "").toLowerCase(), fingerprint)).toBe(true);
+    expect(fingerprintMatches("00".repeat(32), fingerprint)).toBe(false);
+  });
+
+  it("probes and logs in over HTTPS with a pinned fingerprint", async () => {
+    const config = {
+      ...probeConfig("127.0.0.1", mock.port, true),
+      tlsFingerprint: fingerprint,
+      user: "Admin",
+      password: "pw",
+    };
+    expect((await probeApi(config)).kind).toBe("ccu");
+    const result = await testLogin(config);
+    expect(result).toMatchObject({ ok: true, role: "ADMIN" });
+  });
+
+  it("rejects on a connection that is not TLS", async () => {
+    const plain = await startMockCcu();
+    try {
+      await expect(fetchCert("127.0.0.1", plain.port, 2000)).rejects.toThrow();
+    } finally {
+      await plain.close();
+    }
+  });
+});

--- a/test/unit/cli-prompt.test.ts
+++ b/test/unit/cli-prompt.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { PassThrough } from "node:stream";
+import { Prompter, type PromptIo } from "../../src/cli/prompt.js";
+
+function makeIo(text?: string): { io: PromptIo; input: PassThrough; output: () => string } {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  let out = "";
+  output.on("data", (chunk) => (out += String(chunk)));
+  if (text !== undefined) input.end(text);
+  return { io: { input, output }, input, output: () => out };
+}
+
+describe("Prompter", () => {
+  it("returns the trimmed answer", async () => {
+    const { io } = makeIo("  debmatic  \n");
+    const ui = new Prompter(io);
+    expect(await ui.ask("Host")).toBe("debmatic");
+    ui.close();
+  });
+
+  it("falls back to the default on empty input and shows it in the prompt", async () => {
+    const { io, output } = makeIo("\n");
+    const ui = new Prompter(io);
+    expect(await ui.ask("CCU user", { def: "Admin" })).toBe("Admin");
+    expect(output()).toContain("[Admin]");
+    ui.close();
+  });
+
+  it("re-asks while validate rejects", async () => {
+    const { io, output } = makeIo("nope\n42\n");
+    const ui = new Prompter(io);
+    const answer = await ui.ask("Port", {
+      validate: (v) => (/^\d+$/.test(v) ? null : "Digits only."),
+    });
+    expect(answer).toBe("42");
+    expect(output()).toContain("Digits only.");
+    ui.close();
+  });
+
+  // The regression this design exists for: piped input delivers every answer
+  // in ONE chunk before the second question is even asked. rl.question()
+  // would emit the excess lines with no listener attached and drop them.
+  it("answers multiple questions from a single buffered chunk", async () => {
+    const { io } = makeIo("one\ntwo\nthree\n");
+    const ui = new Prompter(io);
+    expect(await ui.ask("A")).toBe("one");
+    await new Promise((r) => setTimeout(r, 10)); // let any stray events fire
+    expect(await ui.ask("B")).toBe("two");
+    expect(await ui.ask("C")).toBe("three");
+    ui.close();
+  });
+
+  it("parses yes/no with a default", async () => {
+    const { io, output } = makeIo("\ny\nno\nmaybe\nn\n");
+    const ui = new Prompter(io);
+    expect(await ui.askYesNo("Q1", true)).toBe(true); // empty -> default
+    expect(await ui.askYesNo("Q2", false)).toBe(true);
+    expect(await ui.askYesNo("Q3", true)).toBe(false);
+    expect(await ui.askYesNo("Q4", true)).toBe(false); // "maybe" re-asks, then "n"
+    expect(output()).toContain("Please answer y or n.");
+    ui.close();
+  });
+
+  it("askChoice accepts only listed values", async () => {
+    const { io, output } = makeIo("staging\ndev\n");
+    const ui = new Prompter(io);
+    expect(await ui.askChoice("Default target", ["prod", "dev"], "prod")).toBe("dev");
+    expect(output()).toContain("Must be one of: prod, dev");
+    ui.close();
+  });
+
+  it("askHidden returns the answer without echoing it", async () => {
+    const { io, output } = makeIo("s3cret\n");
+    const ui = new Prompter(io);
+    expect(await ui.askHidden("Password")).toBe("s3cret");
+    expect(output()).toContain("Password: ");
+    expect(output()).not.toContain("s3cret");
+    ui.close();
+  });
+
+  it("rejects a pending question when the input closes", async () => {
+    const { io, input } = makeIo();
+    const ui = new Prompter(io);
+    const pending = ui.ask("Host");
+    input.end();
+    await expect(pending).rejects.toThrow("input closed");
+  });
+
+  it("rejects new questions after close", async () => {
+    const { io } = makeIo("only-line\n");
+    const ui = new Prompter(io);
+    expect(await ui.ask("A")).toBe("only-line");
+    ui.close();
+    await expect(ui.ask("B")).rejects.toThrow("input closed");
+  });
+});

--- a/test/unit/cli-secret.test.ts
+++ b/test/unit/cli-secret.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PassThrough } from "node:stream";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseEnv } from "node:util";
+import { run } from "../../src/cli/secret.js";
+import type { PromptIo } from "../../src/cli/prompt.js";
+
+function makeIo(answers: string[]): { io: PromptIo; output: () => string } {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  let out = "";
+  output.on("data", (chunk) => (out += String(chunk)));
+  if (answers.length > 0) input.end(answers.join("\n") + "\n");
+  else input.end();
+  return { io: { input, output }, output: () => out };
+}
+
+describe("ccu-mcp secret", () => {
+  let dir: string;
+  let envPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "cli-secret-"));
+    envPath = join(dir, ".env");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes CCU_PASSWORD into a flat file, 0600, everything else untouched", async () => {
+    writeFileSync(envPath, "# note\nCCU_HOST=ccu.local\nCCU_USER=Admin\nCCU_PASSWORD=\"\"\nLOG_LEVEL=debug\n");
+    const { io, output } = makeIo(["hunter2"]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    const content = readFileSync(envPath, "utf-8");
+    expect(parseEnv(content).CCU_PASSWORD).toBe("hunter2");
+    expect(content).toContain("# note");
+    expect(content).toContain("LOG_LEVEL=debug");
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+    expect(output()).toContain("Wrote CCU_PASSWORD");
+    // The hidden prompt must not echo the password back.
+    expect(output()).not.toContain("hunter2");
+  });
+
+  it("targets the named profile's key in a CCU_PROFILES file", async () => {
+    writeFileSync(
+      envPath,
+      "CCU_PROFILES=prod,dev\nCCU_PROD_HOST=a\nCCU_PROD_PASSWORD=keepme\nCCU_DEV_HOST=b\nCCU_DEV_PASSWORD=\"\"\n",
+    );
+    const { io } = makeIo(["devpw"]);
+    expect(await run(["dev", "--env", envPath], io)).toBe(0);
+    const vars = parseEnv(readFileSync(envPath, "utf-8"));
+    expect(vars.CCU_DEV_PASSWORD).toBe("devpw");
+    expect(vars.CCU_PROD_PASSWORD).toBe("keepme");
+  });
+
+  it("quotes awkward passwords so they round-trip through parseEnv", async () => {
+    writeFileSync(envPath, "CCU_HOST=ccu.local\n");
+    const password = 'sp ace#ha"sh';
+    const { io } = makeIo([password]);
+    expect(await run(["--env", envPath], io)).toBe(0);
+    expect(parseEnv(readFileSync(envPath, "utf-8")).CCU_PASSWORD).toBe(password);
+  });
+
+  it("accepts an empty password with a note", async () => {
+    writeFileSync(envPath, "CCU_PROFILES=dev\nCCU_DEV_HOST=127.0.0.1\n");
+    const { io, output } = makeIo([""]);
+    expect(await run(["dev", "--env", envPath], io)).toBe(0);
+    expect(output()).toContain("EMPTY password");
+    expect(parseEnv(readFileSync(envPath, "utf-8")).CCU_DEV_PASSWORD).toBe("");
+  });
+
+  it("requires a profile name when the file defines profiles", async () => {
+    writeFileSync(envPath, "CCU_PROFILES=prod,dev\nCCU_PROD_HOST=a\nCCU_DEV_HOST=b\n");
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", envPath], io)).toBe(1);
+    expect(output()).toContain("prod, dev");
+  });
+
+  it("rejects an unknown profile name", async () => {
+    writeFileSync(envPath, "CCU_PROFILES=prod\nCCU_PROD_HOST=a\n");
+    const { io, output } = makeIo(["x"]);
+    expect(await run(["staging", "--env", envPath], io)).toBe(1);
+    expect(output()).toContain('"staging" is not one of');
+  });
+
+  it("rejects a profile name against a flat file", async () => {
+    writeFileSync(envPath, "CCU_HOST=a\n");
+    const { io, output } = makeIo(["x"]);
+    expect(await run(["prod", "--env", envPath], io)).toBe(1);
+    expect(output()).toContain("single-CCU form");
+  });
+
+  it("fails cleanly when the env file does not exist", async () => {
+    const { io, output } = makeIo([]);
+    expect(await run(["--env", join(dir, "missing.env")], io)).toBe(1);
+    expect(output()).toContain("does not exist");
+  });
+
+  it("exits 130 when input closes before an answer", async () => {
+    writeFileSync(envPath, "CCU_HOST=a\n");
+    const input = new PassThrough();
+    const output = new PassThrough();
+    output.on("data", () => {});
+    input.end(); // EOF with no line at all
+    expect(await run(["--env", envPath], { input, output })).toBe(130);
+    // Nothing written.
+    expect(readFileSync(envPath, "utf-8")).toBe("CCU_HOST=a\n");
+  });
+});

--- a/test/unit/cli-secret.test.ts
+++ b/test/unit/cli-secret.test.ts
@@ -77,6 +77,10 @@ describe("ccu-mcp secret", () => {
     const { io, output } = makeIo([]);
     expect(await run(["--env", envPath], io)).toBe(1);
     expect(output()).toContain("prod, dev");
+    // A runnable line per target, not a shell-quoted `'<profile>'` placeholder.
+    expect(output()).toMatch(/secret prod --env/);
+    expect(output()).toMatch(/secret dev --env/);
+    expect(output()).not.toContain("<profile>");
   });
 
   it("rejects an unknown profile name", async () => {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { loadConfig } from "../../src/config.js";
+import { loadConfig, targetsAwaitingPassword } from "../../src/config.js";
 
 describe("loadConfig", () => {
   const originalEnv = { ...process.env };
@@ -484,5 +484,47 @@ describe("loadConfig", () => {
       process.env.CCU_PROD_READONLY = "true";
       expect(loadConfig().profiles[0]!.readonly).toBe(true);
     });
+  });
+});
+
+describe("targetsAwaitingPassword", () => {
+  // The setup gate's rule (QA F-008). Deliberately separate from loadConfig,
+  // which still accepts an absent named-profile password as empty (issue #69).
+  const originalEnv = { ...process.env };
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("CCU_")) delete process.env[key];
+    }
+  });
+  afterEach(() => { process.env = { ...originalEnv }; });
+
+  it("names targets whose password key is absent", () => {
+    process.env.CCU_PROFILES = "prod,dev";
+    process.env.CCU_PROD_HOST = "debmatic";
+    process.env.CCU_PROD_PASSWORD = "pw";
+    process.env.CCU_DEV_HOST = "127.0.0.1";
+    expect(targetsAwaitingPassword(loadConfig())).toEqual(["dev"]);
+  });
+
+  it("treats a present-but-empty key as deliberately empty", () => {
+    process.env.CCU_PROFILES = "dev";
+    process.env.CCU_DEV_HOST = "127.0.0.1";
+    process.env.CCU_DEV_PASSWORD = "";
+    expect(targetsAwaitingPassword(loadConfig())).toEqual([]);
+  });
+
+  it("never reports anything for the flat form, where loadConfig already requires the key", () => {
+    process.env.CCU_HOST = "debmatic";
+    process.env.CCU_PASSWORD = "";
+    expect(targetsAwaitingPassword(loadConfig())).toEqual([]);
+  });
+
+  it("does not change what loadConfig accepts — an absent key still loads as empty", () => {
+    process.env.CCU_PROFILES = "dev";
+    process.env.CCU_DEV_HOST = "127.0.0.1";
+    const config = loadConfig();
+    expect(config.profiles[0]!.ccu.password).toBe("");
+    expect(targetsAwaitingPassword(config)).toEqual(["dev"]);
   });
 });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -410,6 +410,16 @@ describe("loadConfig", () => {
       expect(config.ccu.password).toBe("secret");
     });
 
+    it("accepts an empty flat CCU_PASSWORD, but not a missing one", () => {
+      process.env.CCU_HOST = "openccu";
+      // A fresh OpenCCU box has no Admin password; `ccu-mcp secret` stores "".
+      process.env.CCU_PASSWORD = "";
+      expect(loadConfig().ccu.password).toBe("");
+
+      delete process.env.CCU_PASSWORD;
+      expect(() => loadConfig()).toThrow(/CCU_PASSWORD environment variable is required/);
+    });
+
     it("builds one profile per CCU_PROFILES entry from CCU_<NAME>_* vars", () => {
       process.env.CCU_PROFILES = "prod,dev";
       process.env.CCU_DEFAULT_PROFILE = "prod";

--- a/test/unit/env-example-sync.test.ts
+++ b/test/unit/env-example-sync.test.ts
@@ -28,9 +28,10 @@ function envKeysReferencedInCode(): Set<string> {
       keys.add(m[1] ?? m[2]);
     }
     // parseIntEnv("FOO", …) / parseDurationEnv("FOO", …) / parseBoolEnv("FOO")
-    // — indirect reads. Keep this alternation in step with the helpers in
-    // config.ts, or a var read only through a new helper looks undocumented.
-    for (const m of text.matchAll(/parse(?:Int|Duration|Bool)Env\("([A-Z][A-Z0-9_]*)"/g)) {
+    // / requirePasswordEnv("FOO", …) — indirect reads. Keep this alternation in
+    // step with the helpers in config.ts, or a var read only through a new
+    // helper looks undocumented.
+    for (const m of text.matchAll(/(?:parse(?:Int|Duration|Bool)|requirePassword)Env\("([A-Z][A-Z0-9_]*)"/g)) {
       keys.add(m[1]);
     }
   }

--- a/test/unit/setup-tools.test.ts
+++ b/test/unit/setup-tools.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { X509Certificate } from "node:crypto";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createSetupServer } from "../../src/setup-server.js";
+import { configFromEnvFile, profilesFromVars } from "../../src/tools/setup.js";
+import { Logger } from "../../src/logger.js";
+import { callTool, parseToolResult } from "./_helpers.js";
+import { startMockCcu, startMockCcuTls, adminResults, type MockCcu } from "./_mock-ccu.js";
+
+const HAVE_OPENSSL = spawnSync("openssl", ["version"]).status === 0;
+const CONFIG_ERROR = "CCU_HOST environment variable is required";
+
+function makeServer(envPath: string): McpServer {
+  return createSetupServer(envPath, CONFIG_ERROR, new Logger("error"));
+}
+
+function registeredTools(server: McpServer): string[] {
+  return Object.keys((server as any)._registeredTools).sort();
+}
+
+describe("setup-mode server", () => {
+  let dir: string;
+  let envPath: string;
+  let server: McpServer;
+  let mock: MockCcu | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "setup-tools-"));
+    envPath = join(dir, ".env");
+    server = makeServer(envPath);
+  });
+
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true });
+    await mock?.close();
+    mock = undefined;
+  });
+
+  it("registers exactly the four setup tools — nothing CCU-backed", () => {
+    expect(registeredTools(server)).toEqual([
+      "setup_probe",
+      "setup_status",
+      "setup_test",
+      "setup_write_profile",
+    ]);
+    expect((server as any)._registeredResources ?? {}).toEqual({});
+    expect((server as any)._registeredPrompts ?? {}).toEqual({});
+  });
+
+  it("carries the flow and the password rule in its instructions", () => {
+    const instructions = (server.server as any)._instructions as string;
+    expect(instructions).toContain(envPath);
+    expect(instructions).toContain(CONFIG_ERROR);
+    expect(instructions).toContain("NEVER travel through this conversation");
+    expect(instructions).toContain("ccu-mcp secret");
+  });
+
+  it("setup_write_profile exposes no password parameter", () => {
+    const tool = (server as any)._registeredTools.setup_write_profile;
+    expect(Object.keys(tool.inputSchema.shape)).not.toContain("password");
+  });
+
+  describe("setup_status", () => {
+    it("reports a missing file with the config error", async () => {
+      const res = parseToolResult(await callTool(server, "setup_status")) as any;
+      expect(res.fileExists).toBe(false);
+      expect(res.configError).toBe(CONFIG_ERROR);
+      expect(res.profiles).toEqual([]);
+    });
+
+    it("reads a flat file back, reporting the password only as a boolean", async () => {
+      writeFileSync(envPath, "CCU_HOST=ccu.local\nCCU_PORT=8080\nCCU_PASSWORD=hunter2\n");
+      const raw = await callTool(server, "setup_status");
+      const res = parseToolResult(raw) as any;
+      expect(res.profiles).toEqual([
+        expect.objectContaining({
+          name: "default",
+          host: "ccu.local",
+          port: 8080,
+          https: false,
+          user: "Admin",
+          passwordStored: true,
+          tlsFingerprintPinned: false,
+        }),
+      ]);
+      expect(JSON.stringify(raw)).not.toContain("hunter2");
+    });
+
+    it("reads a multi-profile file back", async () => {
+      writeFileSync(
+        envPath,
+        [
+          "CCU_PROFILES=prod,dev",
+          "CCU_DEFAULT_PROFILE=prod",
+          "CCU_PROD_HOST=ccu.local",
+          "CCU_PROD_HTTPS=true",
+          "CCU_PROD_PORT=443",
+          "CCU_PROD_TLS_FINGERPRINT=AA:BB",
+          "CCU_PROD_PASSWORD=secret",
+          "CCU_PROD_PROTECTED=true",
+          "CCU_DEV_HOST=127.0.0.1",
+          "CCU_DEV_PORT=18080",
+          "",
+        ].join("\n"),
+      );
+      const res = parseToolResult(await callTool(server, "setup_status")) as any;
+      expect(res.defaultProfile).toBe("prod");
+      expect(res.profiles).toHaveLength(2);
+      expect(res.profiles[0]).toMatchObject({
+        name: "prod",
+        https: true,
+        tlsFingerprintPinned: true,
+        passwordStored: true,
+        protected: true,
+      });
+      expect(res.profiles[1]).toMatchObject({ name: "dev", port: 18080, passwordStored: false });
+    });
+  });
+
+  describe("setup_probe", () => {
+    it("finds a CCU on an explicit port", async () => {
+      mock = await startMockCcu();
+      const res = parseToolResult(
+        await callTool(server, "setup_probe", { host: "127.0.0.1", port: mock.port, https: false }),
+      ) as any;
+      expect(res.reachable).toBe(true);
+      expect(res.port).toBe(mock.port);
+      expect(res.https).toBe(false);
+      expect(res.cert).toBeUndefined();
+    });
+
+    it("reports an unreachable endpoint", async () => {
+      mock = await startMockCcu();
+      const port = mock.port;
+      await mock.close();
+      mock = undefined;
+      const res = parseToolResult(
+        await callTool(server, "setup_probe", { host: "127.0.0.1", port, https: false }),
+      ) as any;
+      expect(res.reachable).toBe(false);
+      expect(res.detail).toContain("No CCU API found");
+    });
+  });
+
+  describe("setup_write_profile", () => {
+    it("writes the flat form for a single default target, without a password", async () => {
+      const res = parseToolResult(
+        await callTool(server, "setup_write_profile", {
+          name: "default",
+          host: "ccu.local",
+          port: 80,
+          https: false,
+          user: "Admin",
+        }),
+      ) as any;
+      expect(res.written).toBe(true);
+      expect(res.nextStep).toContain("ccu-mcp secret");
+      expect(res.nextStep).toContain(envPath);
+      const content = readFileSync(envPath, "utf-8");
+      expect(content).toContain("CCU_HOST=ccu.local");
+      expect(content).not.toContain("CCU_PROFILES");
+      expect(content).toContain('CCU_PASSWORD=""');
+      expect(statSync(envPath).mode & 0o777).toBe(0o600);
+    });
+
+    it("keeps the CCU_PROFILES form for a named single target", async () => {
+      await callTool(server, "setup_write_profile", {
+        name: "dev",
+        host: "127.0.0.1",
+        port: 18080,
+        https: false,
+        user: "Admin",
+      });
+      const content = readFileSync(envPath, "utf-8");
+      expect(content).toContain("CCU_PROFILES=dev");
+      expect(content).toContain("CCU_DEV_HOST=127.0.0.1");
+    });
+
+    it("upserts a second target, preserving the first one's stored password", async () => {
+      writeFileSync(
+        envPath,
+        "CCU_PROFILES=prod\nCCU_DEFAULT_PROFILE=prod\nCCU_PROD_HOST=ccu.local\nCCU_PROD_PORT=443\nCCU_PROD_HTTPS=true\nCCU_PROD_USER=Admin\nCCU_PROD_PASSWORD=hunter2\n# operator note\nLOG_LEVEL=debug\n",
+      );
+      const raw = await callTool(server, "setup_write_profile", {
+        name: "dev",
+        host: "127.0.0.1",
+        port: 18080,
+        https: false,
+        user: "Admin",
+      });
+      const res = parseToolResult(raw) as any;
+      expect(res.profiles).toEqual(["prod", "dev"]);
+      expect(res.defaultProfile).toBe("prod");
+      expect(JSON.stringify(raw)).not.toContain("hunter2");
+      const content = readFileSync(envPath, "utf-8");
+      expect(content).toContain("CCU_PROD_PASSWORD=hunter2");
+      expect(content).toContain("CCU_DEV_HOST=127.0.0.1");
+      expect(content).toContain("LOG_LEVEL=debug");
+      expect(content).toContain("# operator note");
+    });
+
+    it("keeps a stored password when rewriting the same endpoint, drops it when the host moves", async () => {
+      writeFileSync(envPath, "CCU_HOST=ccu.local\nCCU_PORT=80\nCCU_PASSWORD=hunter2\n");
+      await callTool(server, "setup_write_profile", {
+        name: "default",
+        host: "ccu.local",
+        port: 80,
+        https: false,
+        user: "Other",
+      });
+      expect(readFileSync(envPath, "utf-8")).toContain("CCU_PASSWORD=hunter2");
+
+      await callTool(server, "setup_write_profile", {
+        name: "default",
+        host: "elsewhere.local",
+        port: 80,
+        https: false,
+        user: "Other",
+      });
+      const content = readFileSync(envPath, "utf-8");
+      expect(content).not.toContain("hunter2");
+      expect(content).toContain('CCU_PASSWORD=""');
+    });
+
+    it("honors makeDefault", async () => {
+      await callTool(server, "setup_write_profile", {
+        name: "prod", host: "ccu.local", port: 80, https: false, user: "Admin",
+      });
+      const res = parseToolResult(
+        await callTool(server, "setup_write_profile", {
+          name: "dev", host: "127.0.0.1", port: 18080, https: false, user: "Admin", makeDefault: true,
+        }),
+      ) as any;
+      expect(res.defaultProfile).toBe("dev");
+      expect(readFileSync(envPath, "utf-8")).toContain("CCU_DEFAULT_PROFILE=dev");
+    });
+
+    it("rejects a fingerprint on a plain-HTTP target", async () => {
+      const res = callTool(server, "setup_write_profile", {
+        name: "default", host: "ccu.local", port: 80, https: false, user: "Admin",
+        tlsFingerprint: "AA:BB",
+      });
+      await expect(res).rejects.toThrow(/HTTPS/);
+    });
+  });
+
+  describe("setup_test", () => {
+    it("reports an invalid configuration as a failing finding", async () => {
+      writeFileSync(envPath, "CCU_HOST=ccu.local\n"); // flat form, no password
+      const res = parseToolResult(await callTool(server, "setup_test")) as any;
+      expect(res.ok).toBe(false);
+      expect(res.findings[0]).toMatchObject({ check: "config", ok: false });
+      expect(res.findings[0].detail).toContain("CCU_PASSWORD");
+    });
+
+    it("passes end-to-end against a mock CCU and points at reconnecting", async () => {
+      mock = await startMockCcu(adminResults());
+      writeFileSync(envPath, `CCU_HOST=127.0.0.1\nCCU_PORT=${mock.port}\nCCU_PASSWORD=hunter2\n`);
+      const raw = await callTool(server, "setup_test");
+      const res = parseToolResult(raw) as any;
+      expect(res.ok).toBe(true);
+      expect(res.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ check: "reachability", ok: true }),
+          expect.objectContaining({ check: "login", ok: true }),
+        ]),
+      );
+      expect(res.findings.find((f: any) => f.check === "login").detail).toContain("ADMIN");
+      expect(res.nextStep).toContain("reconnect");
+      expect(JSON.stringify(raw)).not.toContain("hunter2");
+    });
+
+    it("fails on an unreachable CCU without aborting other profiles", async () => {
+      mock = await startMockCcu(adminResults());
+      // Reserve a port and free it again so nothing answers there.
+      const dead = await startMockCcu();
+      const deadPort = dead.port;
+      await dead.close();
+      writeFileSync(
+        envPath,
+        [
+          "CCU_PROFILES=up,down",
+          "CCU_UP_HOST=127.0.0.1",
+          `CCU_UP_PORT=${mock.port}`,
+          "CCU_UP_PASSWORD=pw",
+          "CCU_DOWN_HOST=127.0.0.1",
+          `CCU_DOWN_PORT=${deadPort}`,
+          "CCU_DOWN_PASSWORD=pw",
+          "",
+        ].join("\n"),
+      );
+      const res = parseToolResult(await callTool(server, "setup_test")) as any;
+      expect(res.ok).toBe(false);
+      expect(res.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ profile: "up", check: "login", ok: true }),
+          expect.objectContaining({ profile: "down", check: "reachability", ok: false }),
+        ]),
+      );
+    });
+  });
+});
+
+describe("configFromEnvFile", () => {
+  let dir: string;
+  let envPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "setup-cfg-"));
+    envPath = join(dir, ".env");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.CCU_HOST;
+    delete process.env.CCU_PASSWORD;
+  });
+
+  it("evaluates the FILE, not the process environment", () => {
+    process.env.CCU_HOST = "process-sentinel";
+    process.env.CCU_PASSWORD = "process-pw";
+    writeFileSync(envPath, "CCU_HOST=file.local\nCCU_PASSWORD=file-pw\n");
+    const config = configFromEnvFile(envPath);
+    expect(config.ccu.host).toBe("file.local");
+    // …and restores the environment afterwards.
+    expect(process.env.CCU_HOST).toBe("process-sentinel");
+    expect(process.env.CCU_PASSWORD).toBe("process-pw");
+  });
+
+  it("restores the environment even when loadConfig throws", () => {
+    process.env.CCU_HOST = "process-sentinel";
+    writeFileSync(envPath, "CCU_HOST=file.local\n"); // missing password → throws
+    expect(() => configFromEnvFile(envPath)).toThrow(/CCU_PASSWORD/);
+    expect(process.env.CCU_HOST).toBe("process-sentinel");
+  });
+});
+
+describe("profilesFromVars", () => {
+  it("returns nothing for an empty map", () => {
+    expect(profilesFromVars({})).toEqual({ profiles: [] });
+  });
+
+  it("defaults port from the HTTPS flag when PORT is missing or garbage", () => {
+    const { profiles } = profilesFromVars({ CCU_HOST: "a", CCU_HTTPS: "true", CCU_PORT: "x" });
+    expect(profiles[0].port).toBe(443);
+  });
+});
+
+describe.skipIf(!HAVE_OPENSSL)("setup_test TLS pin checks", () => {
+  let dir: string;
+  let tlsDir: string;
+  let envPath: string;
+  let server: McpServer;
+  let mock: MockCcu;
+  let fingerprint: string;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "setup-tls-"));
+    tlsDir = mkdtempSync(join(tmpdir(), "setup-cert-"));
+    envPath = join(dir, ".env");
+    server = makeServer(envPath);
+    const certPath = join(tlsDir, "cert.pem");
+    const keyPath = join(tlsDir, "key.pem");
+    spawnSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath,
+      "-days", "1", "-subj", "/CN=ccu-setup",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ], { stdio: "ignore" });
+    const certPem = readFileSync(certPath, "utf-8");
+    fingerprint = new X509Certificate(certPem).fingerprint256;
+    mock = await startMockCcuTls({ cert: certPem, key: readFileSync(keyPath, "utf-8") }, adminResults());
+  });
+
+  afterEach(async () => {
+    await mock.close();
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(tlsDir, { recursive: true, force: true });
+  });
+
+  function writeEnv(pin: string): void {
+    writeFileSync(
+      envPath,
+      `CCU_HOST=127.0.0.1\nCCU_PORT=${mock.port}\nCCU_HTTPS=true\nCCU_TLS_FINGERPRINT=${pin}\nCCU_PASSWORD=pw\n`,
+    );
+  }
+
+  it("setup_probe returns the presented certificate for pinning", async () => {
+    const res = parseToolResult(
+      await callTool(server, "setup_probe", { host: "127.0.0.1", port: mock.port, https: true }),
+    ) as any;
+    expect(res.reachable).toBe(true);
+    expect(res.cert.fingerprint256.replace(/:/g, "")).toBe(fingerprint.replace(/:/g, ""));
+    expect(res.cert.subjectCN).toBe("ccu-setup");
+  });
+
+  it("setup_test passes with the right pin", async () => {
+    writeEnv(fingerprint);
+    const res = parseToolResult(await callTool(server, "setup_test")) as any;
+    expect(res.ok).toBe(true);
+    expect(res.findings).toEqual(
+      expect.arrayContaining([expect.objectContaining({ check: "tls-pin", ok: true })]),
+    );
+  });
+
+  it("setup_test flags a mismatch and skips that profile's login", async () => {
+    writeEnv("00".repeat(32));
+    const res = parseToolResult(await callTool(server, "setup_test")) as any;
+    expect(res.ok).toBe(false);
+    const pin = res.findings.find((f: any) => f.check === "tls-pin");
+    expect(pin.ok).toBe(false);
+    expect(pin.detail).toContain("does NOT match");
+    expect(res.findings.some((f: any) => f.check === "login")).toBe(false);
+  });
+});

--- a/test/unit/setup-tools.test.ts
+++ b/test/unit/setup-tools.test.ts
@@ -158,8 +158,13 @@ describe("setup-mode server", () => {
         }),
       ) as any;
       expect(res.written).toBe(true);
-      expect(res.nextStep).toContain("ccu-mcp secret");
+      expect(res.nextStep).toContain("secret");
       expect(res.nextStep).toContain(envPath);
+      // Must name the build that is printing it, not whatever `npx` would
+      // resolve to — an older global install may not have `secret` at all,
+      // and then answers with an unrelated configuration error.
+      expect(res.nextStep).toContain(process.argv[1]);
+      expect(res.nextStep).not.toContain("npx ccu-mcp secret");
       const content = readFileSync(envPath, "utf-8");
       expect(content).toContain("CCU_HOST=ccu.local");
       expect(content).not.toContain("CCU_PROFILES");

--- a/test/unit/setup-tools.test.ts
+++ b/test/unit/setup-tools.test.ts
@@ -163,7 +163,10 @@ describe("setup-mode server", () => {
       const content = readFileSync(envPath, "utf-8");
       expect(content).toContain("CCU_HOST=ccu.local");
       expect(content).not.toContain("CCU_PROFILES");
-      expect(content).toContain('CCU_PASSWORD=""');
+      // No placeholder: an absent key is what tells loadConfig the password has
+      // not been chosen yet, so the server stays in setup mode. `CCU_PASSWORD=""`
+      // would read as a deliberately empty one and start the server unconfigured.
+      expect(content).not.toContain("CCU_PASSWORD");
       expect(statSync(envPath).mode & 0o777).toBe(0o600);
     });
 
@@ -223,7 +226,20 @@ describe("setup-mode server", () => {
       });
       const content = readFileSync(envPath, "utf-8");
       expect(content).not.toContain("hunter2");
-      expect(content).toContain('CCU_PASSWORD=""');
+      expect(content).not.toContain("CCU_PASSWORD");
+    });
+
+    it("preserves a deliberately empty password across a rewrite of the same endpoint", async () => {
+      writeFileSync(envPath, 'CCU_HOST=ccu.local\nCCU_PORT=80\nCCU_PASSWORD=""\n');
+      const res = parseToolResult(
+        await callTool(server, "setup_write_profile", {
+          name: "default", host: "ccu.local", port: 80, https: false, user: "Admin",
+        }),
+      ) as any;
+      // An empty password the user chose is a decision, not a missing value:
+      // it survives the rewrite and must not send them back to `ccu-mcp secret`.
+      expect(readFileSync(envPath, "utf-8")).toContain('CCU_PASSWORD=""');
+      expect(res.nextStep).not.toContain("ccu-mcp secret");
     });
 
     it("honors makeDefault", async () => {

--- a/test/unit/tools-diagnostics.test.ts
+++ b/test/unit/tools-diagnostics.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { tryParseJson } from "../../src/tools/diagnostics.js";
 import { createTestServer, callTool, parseToolResult, cleanupDeps } from "./_helpers.js";
+import { CcuError } from "../../src/middleware/error-mapper.js";
 
 describe("tryParseJson", () => {
   it("parses valid JSON", () => {
@@ -271,6 +272,65 @@ describe("get_system_info handler", () => {
     cleanupDeps(deps);
   });
 
+  // F-005: a failed login used to come back as all-N/A + role UNKNOWN and no
+  // error — "did my setup work?" answered with a plausible yes.
+  it("fails with the login error instead of N/A when there is no session", async () => {
+    const { server, deps } = createTestServer({
+      loggedIn: false,
+      sessionCall: vi.fn().mockRejectedValue(new CcuError({
+        error: "AUTH",
+        code: 501,
+        message: "invalid credentials",
+        hint: "Verify CCU_USER/CCU_PASSWORD.",
+      })),
+    });
+
+    const result: any = await callTool(server, "get_system_info");
+    expect(result.isError).toBe(true);
+    const err = JSON.parse(result.content[0].text);
+    expect(err.error).toBe("AUTH");
+    expect(err.code).toBe(501);
+    expect(result.content[0].text).not.toContain("N/A");
+    cleanupDeps(deps);
+  });
+
+  it("propagates an unreachable CCU rather than reporting a role", async () => {
+    const { server, deps } = createTestServer({
+      loggedIn: false,
+      sessionCall: vi.fn().mockRejectedValue(new CcuError({
+        error: "UNREACHABLE",
+        code: 0,
+        message: "Cannot connect to CCU: fetch failed",
+        hint: "Check that the CCU is running.",
+      })),
+    });
+
+    const result: any = await callTool(server, "get_system_info");
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe("UNREACHABLE");
+    cleanupDeps(deps);
+  });
+
+  // The other side of the rule: a valid session that is merely denied the
+  // ADMIN-only calls must still degrade to N/A, not fail.
+  it("still degrades to N/A when the session is valid but the call is denied", async () => {
+    const { server, deps } = createTestServer({
+      loggedIn: true,
+      sessionCall: vi.fn().mockRejectedValue(new CcuError({
+        error: "AUTH",
+        code: 400,
+        message: "Access denied for CCU.getVersion: the CCU user lacks the required privilege level",
+        hint: "Use an ADMIN account.",
+      })),
+    });
+
+    const result = parseToolResult(await callTool(server, "get_system_info")) as any;
+    expect(result.role).toBe("USER");
+    expect(result.version).toBe("N/A");
+    expect(result.accessNote).toMatch(/ADMIN-only/);
+    cleanupDeps(deps);
+  });
+
   it("reports USER role with N/A fields and an accessNote when admin-only calls are denied", async () => {
     const { server, deps } = createTestServer({
       // Every ADMIN-gated CCU.* call is denied — mimics a non-admin login.
@@ -304,7 +364,6 @@ describe("error and edge paths (coverage round)", () => {
   });
 
   it("get_service_messages maps CcuError to a structured tool error", async () => {
-    const { CcuError } = await import("../../src/middleware/error-mapper.js");
     const { server, deps } = createTestServer({
       sessionCall: vi.fn().mockRejectedValue(new CcuError({ error: "CCU_ERROR", code: 501, message: "rega busy", hint: "" })),
     });


### PR DESCRIPTION
Release **v1.11.0** — the setup release: a CLI wizard (`ccu-mcp init` / `ccu-mcp doctor`) and a conversational flow (setup mode, `setup_*` tools, `ccu-mcp secret`) that share one probe → pin → test-login → write core. The password never travels through the model on either path.

Full notes: [`CHANGELOG.md` § v1.11.0](https://github.com/claymore666/ccu-mcp/blob/dev/CHANGELOG.md).

### Behavior changes

- `get_system_info` now fails with the real error (`AUTH` / `UNREACHABLE` / `TLS_ERROR`) when the CCU cannot be reached or logged into, instead of reporting `"N/A"` fields with `role: "UNKNOWN"` and no error. A denial on a *valid* session still degrades to `"N/A"`.
- An empty `CCU_PASSWORD` is accepted — presence, not non-emptiness. An absent variable is still an error.
- An unknown subcommand exits 2 instead of falling through to a normal server start.

No new required environment variables, no changed tool arguments.

### Verification

`npm run check:versions` in sync across `package.json` and both `server.json` spots · `npm publish --dry-run` ships `dist/` + README + LICENSE only · `mcp-publisher validate` green · lint clean · 597 tests passing · `npm audit --omit=dev` clean (six transitive advisories cleared in #219) · 0 open Dependabot and code-scanning alerts.

Closes #195
Closes #196
Closes #197
Closes #198
Closes #199
Closes #200
Closes #201
Closes #202
Closes #204
Closes #205
Closes #206
Closes #207
